### PR TITLE
fix: モバイル表示時にQRコード画像が縦長に引き伸ばされる問題の修正

### DIFF
--- a/src/components/tools/QrGenerator.tsx
+++ b/src/components/tools/QrGenerator.tsx
@@ -80,8 +80,8 @@ export default function QrGenerator() {
 						<img
 							src={qrDataUrl}
 							alt="QRコード"
-							className="max-w-full rounded-lg shimmer"
-							style={{ width: options.size, height: options.size }}
+							className="max-w-full rounded-lg shimmer aspect-square"
+							style={{ width: options.size, height: 'auto' }}
 						/>
 					) : (
 						<div className="flex flex-col items-center justify-center text-muted-foreground py-12">


### PR DESCRIPTION
Closes #3 

## 対応内容
- `QrGenerator.tsx` のプレビュー用の `img` タグのアスペクト比スタイルを修正しました。
- 画面幅縮小時（モバイル表示時）にQRコード画像が縦長に引き伸ばされる問題を確認したため、`className`に`aspect-square`を追加し、`style`の`height`を`auto`に変更しました。

## 確認事項
- E2Eテスト（Playwright）が正常にパスすることを確認済みです。