### PR TITLE
fix: ページ遷移時のテーマ消去とOS設定追従の不具合を修正

### DIFF
--- a/src/components/common/ThemeToggle.tsx
+++ b/src/components/common/ThemeToggle.tsx
@@ -5,9 +5,29 @@ export default function ThemeToggle() {
 	const [isDark, setIsDark] = useState(false);
 
 	useEffect(() => {
-		setIsDark(document.documentElement.classList.contains('dark'));
-	}, []);
+		const updateTheme = () => {
+			setIsDark(document.documentElement.classList.contains('dark'));
+		};
 
+		// Init
+		updateTheme();
+
+		// Observe html class changes
+		const observer = new MutationObserver((mutations) => {
+			for (const mutation of mutations) {
+				if (mutation.attributeName === 'class') {
+					updateTheme();
+				}
+			}
+		});
+
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['class'],
+		});
+
+		return () => observer.disconnect();
+	}, []);
 	const toggle = () => {
 		const next = !isDark;
 		setIsDark(next);

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -39,13 +39,31 @@ const adsenseId = import.meta.env.PUBLIC_ADSENSE_ID;
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <ViewTransitions />
   <script is:inline>
-    // Dark mode initialization - runs before paint to prevent flash
-    (function() {
+    const setDarkMode = () => {
       const stored = localStorage.getItem('theme');
       if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
         document.documentElement.classList.add('dark');
+      } else {
+        document.documentElement.classList.remove('dark');
       }
-    })();
+    };
+
+    // Dark mode initialization - runs before paint to prevent flash
+    setDarkMode();
+
+    // Re-apply theme after view transitions navigation
+    document.addEventListener('astro:after-swap', setDarkMode);
+
+    // Listen for OS theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        if (e.matches) {
+          document.documentElement.classList.add('dark');
+        } else {
+          document.documentElement.classList.remove('dark');
+        }
+      }
+    });
   </script>
 
   {adsenseId && (


### PR DESCRIPTION
## 概要
- ページ遷移時（`ViewTransitions` による遷移）にダークモードがリセットされてしまう不具合を修正しました。
- ユーザーがテーマを手動設定していない場合、OSのカラー設定（ダーク・ライト）の変更にWebサイト側がリアルタイムで追従する機能を追加しました。

## 修正内容

1. **`BaseLayout.astro` の修正**
   初期化時の判定だけでなく、Astro固有の `astro:after-swap` によるページ遷移後や、OSのテーマ変更イベント `matchMedia` を監視してダークモードを再適用するようにしました。

2. **`ThemeToggle.tsx` の同期処理追加**
   `MutationObserver` を利用して `document.documentElement` の `class` 属性の変更を監視し、`isDark` ステートを常にHTMLの状態と同期させるようにしました。これにより、設定による追従時にもアイコンの表示が正しく切り替わります。

## 確認事項
- [x] ダークモード時のページ遷移
- [x] ライトモード時のページ遷移
- [x] OS設定の追従
- [x] ローカルでのビルド成功