### PR TITLE
style: 完全クライアントサイド処理のデザイン統一

### DIFF
--- a/src/components/layout/SafetyBadge.tsx
+++ b/src/components/layout/SafetyBadge.tsx
@@ -16,10 +16,6 @@ export default function SafetyBadge() {
 					className="inline-flex items-center gap-2 rounded-lg border border-safety/30 bg-safety/5 px-3 py-1.5 text-sm font-medium text-safety hover:bg-safety/10 transition-colors cursor-pointer"
 					aria-label="セキュリティ情報を表示"
 				>
-					<span className="relative flex h-2.5 w-2.5">
-						<span className="pulse-dot absolute inline-flex h-full w-full rounded-full bg-safety opacity-75"></span>
-						<span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-safety"></span>
-					</span>
 					<ShieldCheck className="h-4 w-4" />
 					<span className="hidden sm:inline">このツールはサーバーと通信しません</span>
 					<span className="sm:hidden">ローカル処理</span>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { ShieldCheck } from 'lucide-react';
 ---
 
 <BaseLayout
@@ -11,7 +12,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     <!-- Hero Section -->
     <div class="text-center mb-16 space-y-6">
       <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight mb-4 flex items-center justify-center gap-3">
-        <span class="text-primary">🔒</span>
+        <span class="text-primary"><ShieldCheck className="h-10 w-10 sm:h-12 sm:w-12" /></span>
         <span>CODE:LIFE Tools</span>
       </h1>
 
@@ -20,10 +21,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </p>
 
       <div class="mt-4 inline-flex items-center gap-2 rounded-full border border-safety/30 bg-safety/5 px-4 py-2 text-sm text-safety font-medium">
-        <span class="relative flex h-2.5 w-2.5">
-          <span class="pulse-dot absolute inline-flex h-full w-full rounded-full bg-safety opacity-75"></span>
-          <span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-safety"></span>
-        </span>
+        <ShieldCheck className="h-4 w-4" />
         完全クライアントサイド処理で機密データも安心
       </div>
     </div>
@@ -34,7 +32,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
         <!-- Feature 1 -->
         <div class="rounded-xl border border-border bg-card p-6 flex flex-col items-center text-center">
-          <div class="text-4xl mb-4">🔒</div>
+          <div class="mb-4"><ShieldCheck className="h-10 w-10" /></div>
           <h3 class="text-lg font-bold mb-3">完全クライアントサイド処理</h3>
           <ul class="text-sm text-muted-foreground space-y-2 text-left w-full list-disc pl-5">
             <li>すべてのデータ処理はブラウザ内で完結</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import ToolCard from '../components/common/ToolCard.astro';
 import AdSlot from '../components/common/AdSlot.tsx';
+import { ShieldCheck } from 'lucide-react';
 const schema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -35,11 +36,8 @@ const schema = {
         サーバーへのデータ送信は<strong class="text-foreground">一切ありません</strong>。
       </p>
       <div class="mt-6 inline-flex items-center gap-2 rounded-full border border-safety/30 bg-safety/5 px-4 py-2 text-sm text-safety font-medium">
-        <span class="relative flex h-2.5 w-2.5">
-          <span class="pulse-dot absolute inline-flex h-full w-full rounded-full bg-safety opacity-75"></span>
-          <span class="relative inline-flex h-2.5 w-2.5 rounded-full bg-safety"></span>
-        </span>
-        🔒 完全クライアントサイド処理 — データはあなたのブラウザから出ません
+        <ShieldCheck className="h-4 w-4" />
+        完全クライアントサイド処理 — 入力データはサーバーへ送信されません
       </div>
     </div>
 


### PR DESCRIPTION
- 左端のドットパルス表示を削除
- 絵文字の🔒を削除
- 盾のアイコン（ShieldCheck）のみに変更
- index.astro セクションの説明文の変更（ユーザー修正分を含む）