### PR TITLE
feat: 日本人向けGitHub Issue Templatesの追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: "🐛 バグ報告 (Bug Report)"
+description: "動作しない機能や想定外の動作について報告します"
+title: "[BUG]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: "バグのご報告ありがとうございます！問題の把握のため、以下の項目にご記入をお願いします。"
+  - type: textarea
+    id: description
+    attributes:
+      label: "発生している問題の概要"
+      description: "何が起きましたか？期待していた動作となにが違うのか具体的に書いてください。"
+      placeholder: "例：〇〇のボタンを押しても画面が切り替わらず、コンソールにエラーが出ます。"
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: "再現手順"
+      description: "問題を再現するための手順をステップ・バイ・ステップで書いてください。"
+      placeholder: |
+        1. '...' にアクセスする
+        2. '....' をクリックする
+        3. '....' までスクロールする
+        4. エラーが発生する
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: "期待される動作"
+      description: "本来はどう動くべきだと考えていましたか？"
+      placeholder: "ボタンを押したら〇〇の画面に遷移するべき。"
+    validations:
+      required: true
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: "スクリーンショット"
+      description: "問題がわかる画像があれば、ここにドラッグ＆ドロップで貼り付けてください。"
+  - type: input
+    id: os
+    attributes:
+      label: "OS"
+      description: "お使いのOSを選んでください。"
+      placeholder: "例：Windows 11 / macOS Sonoma / iOS 17"
+  - type: input
+    id: browser
+    attributes:
+      label: "ブラウザ"
+      description: "お使いのWebブラウザとそのバージョンを教えてください。"
+      placeholder: "例：Chrome 120 / Safari 17.2 / Firefox 121"
+  - type: textarea
+    id: context
+    attributes:
+      label: "その他のコンテキスト"
+      description: "その他、問題解決に役立ちそうな情報があれば記載してください。"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,34 @@
+name: "✨ 機能追加・改善の要望 (Feature Request)"
+description: "新しい機能や既存機能の改善について提案します"
+title: "[FEATURE]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: "ご提案ありがとうございます！機能追加や改善について、以下の項目にご記入をお願いします。"
+  - type: textarea
+    id: problem
+    attributes:
+      label: "解決したい課題の概要"
+      description: "どのような問題に直面していますか？なぜその機能が必要だと感じましたか？"
+      placeholder: "例：現状、〇〇の機能がないため、手作業で〇〇をしなければならず不便です。"
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: "提案する解決策"
+      description: "どのように解決（実装）してほしいか、具体的なアイデアを教えてください。"
+      placeholder: "例：〇〇の画面に「〇〇ボタン」を追加し、クリックで〇〇できるようにしてほしい。"
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: "検討した代替案"
+      description: "他に考えられる解決策や、現在行っている回避策があれば教えてください。"
+  - type: textarea
+    id: context
+    attributes:
+      label: "その他のコンテキスト"
+      description: "参考になるリンク、スクリーンショット、またはその他の情報があれば記載してください。"

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,34 @@
+name: "❓ 質問 (Question)"
+description: "使い方、仕様、その他について質問します"
+title: "[QUESTION]: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: "ご質問ありがとうございます！わかる範囲で以下の項目にご記入をお願いします。"
+  - type: textarea
+    id: question
+    attributes:
+      label: "質問の内容"
+      description: "何について知りたいですか？具体的に教えてください。"
+      placeholder: "例：〇〇ツールの〇〇という機能は、どのように設定すれば使えますか？"
+    validations:
+      required: true
+  - type: textarea
+    id: expected-outcome
+    attributes:
+      label: "達成したいこと（目的）"
+      description: "最終的にどのような結果を得たいのか教えてください。"
+    validations:
+      required: false
+  - type: textarea
+    id: tried
+    attributes:
+      label: "試したこと"
+      description: "すでに試した設定や操作、または調べたことがあれば教えてください。"
+      placeholder: "例：〇〇の画面で〇〇を入力してみましたが、エラーになりました。"
+  - type: textarea
+    id: context
+    attributes:
+      label: "その他のコンテキスト"
+      description: "スクリーンショットや環境情報など、回答に役立つ情報があれば記載してください。"

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,33 @@
+name: "📋 タスク (Task)"
+description: "開発者向けの内部タスクやTODOを管理します"
+title: "[TASK]: "
+labels: ["task"]
+body:
+  - type: markdown
+    attributes:
+      value: "内部タスク管理用のテンプレートです。"
+  - type: textarea
+    id: task-description
+    attributes:
+      label: "タスクの概要"
+      description: "このタスクの目的と、完了条件を明確に記載してください。"
+      placeholder: "目的：〇〇\n完了条件：〇〇が実装されていること"
+    validations:
+      required: true
+  - type: textarea
+    id: checklist
+    attributes:
+      label: "チェックリスト (TODO)"
+      description: "必要な作業をMarkdownのチェックボックス形式で洗い出してください。"
+      value: |
+        - [ ] 作業項目1
+        - [ ] 作業項目2
+        - [ ] テストの追加
+        - [ ] ドキュメントの更新
+    validations:
+      required: false
+  - type: textarea
+    id: notes
+    attributes:
+      label: "備考・関連情報"
+      description: "関連するIssue、PR、参考リンク、または実装上の注意点などを記載します。"


### PR DESCRIPTION
日本人向けのIssueテンプレート（バグ報告、機能要望、質問、タスク）をYAML形式で追加しました。config.ymlにて空白Issueの作成を無効化しています。