### PR TITLE
Update cipher tool page title and icon

### DIFF
--- a/src/pages/cipher.astro
+++ b/src/pages/cipher.astro
@@ -4,7 +4,7 @@ import { CipherPage } from '../components/tools/cipher/CipherPage';
 ---
 
 <ToolLayout
-  title="暗号化・難読化ツール | CODE:LIFE Tools"
+  title="暗号化・難読化ツール"
   description="シーザー暗号・ROT13・文字列反転・モールス信号をブラウザ内で変換。ひらがな・カタカナ対応のシーザー暗号、ブルートフォース解析付き。完全クライアントサイド処理でデータも安心。"
   path="/cipher"
 >

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -178,7 +178,7 @@ const schema = {
         title="暗号化・難読化"
         description="シーザー暗号・ROT13・モールス信号など"
         href="/cipher"
-        icon="Lock"
+        icon="🔑"
         category="ユーティリティ"
         categoryColor="border-l-chart-2"
       />


### PR DESCRIPTION
## Summary
Minor updates to the cipher tool page metadata and home page card display.

## Changes
- Removed "| CODE:LIFE Tools" suffix from the cipher page title for a cleaner, more concise title
- Updated the cipher tool card icon on the home page from "Lock" to "🔑" (key emoji) for better visual representation

## Details
These changes improve the page title consistency and enhance the visual presentation of the cipher tool card on the home page by using a more intuitive emoji icon instead of an icon component reference.

https://claude.ai/code/session_01E9DixyBrxa9zTxYMD9hpT7