### PR TITLE
Enforce Content Security Policy and add security headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,2 +1,5 @@
 /*
-  Content-Security-Policy-Report-Only: default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com; font-src 'self'; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com; font-src 'self'; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
## Summary
This change upgrades the security posture of the application by enforcing Content Security Policy (CSP) and adding additional HTTP security headers to the deployment configuration.

## Key Changes
- **Upgraded CSP from report-only to enforced**: Changed `Content-Security-Policy-Report-Only` to `Content-Security-Policy`, which now actively blocks non-compliant content instead of just reporting violations
- **Added X-Content-Type-Options header**: Set to `nosniff` to prevent MIME type sniffing attacks
- **Added X-Frame-Options header**: Set to `SAMEORIGIN` to prevent clickjacking by restricting frame embedding to same-origin contexts
- **Added Referrer-Policy header**: Set to `strict-origin-when-cross-origin` to control referrer information leakage across origins

## Implementation Details
The CSP policy remains unchanged in its allowed sources and directives—only the enforcement mode has been switched from report-only to active enforcement. This means the application must be fully compliant with the existing CSP rules, as violations will now be blocked rather than merely logged.

https://claude.ai/code/session_019LjBin7zfrB62pUS4TLwYA