### PR TITLE
Move regex testing to Web Worker with timeout protection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3789,12 +3789,6 @@
         "tailwindcss": "4.2.2"
       }
     },
-    "node_modules/@tailwindcss/node/node_modules/tailwindcss": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
-      "integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
-      "license": "MIT"
-    },
     "node_modules/@tailwindcss/oxide": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.2.tgz",
@@ -4094,12 +4088,6 @@
       "peerDependencies": {
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
-    },
-    "node_modules/@tailwindcss/vite/node_modules/tailwindcss": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.0.tgz",
-      "integrity": "sha512-yYzTZ4++b7fNYxFfpnberEEKu43w44aqDMNM9MHMmcKuCH7lL8jJ4yJ7LGHv7rSwiqM0nkiobF9I6cLlpS2P7Q==",
-      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -1,5 +1,5 @@
 import { Trash2, XCircle } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import CopyButton from '@/components/common/CopyButton';
 import {
 	Accordion,
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import type { RegexResult } from '@/lib/tools/regex-tester';
 import { COMMON_PATTERNS, testRegex } from '@/lib/tools/regex-tester';
 
 export default function RegexTester() {
@@ -39,13 +40,18 @@ export default function RegexTester() {
 		);
 	};
 
-	const result = useMemo(() => {
-		return testRegex(
-			pattern,
-			flags,
-			text,
-			showReplace ? replacement : undefined,
+	const [result, setResult] = useState<RegexResult>({ matches: [] });
+
+	useEffect(() => {
+		let cancelled = false;
+		testRegex(pattern, flags, text, showReplace ? replacement : undefined).then(
+			(r) => {
+				if (!cancelled) setResult(r);
+			},
 		);
+		return () => {
+			cancelled = true;
+		};
 	}, [pattern, flags, text, showReplace, replacement]);
 
 	// Handle synchronized scrolling for highlight overlay

--- a/src/lib/tools/regex-tester.ts
+++ b/src/lib/tools/regex-tester.ts
@@ -30,53 +30,38 @@ export const COMMON_PATTERNS = [
 	},
 ];
 
-export function testRegex(
+const TIMEOUT_MS = 500;
+
+export async function testRegex(
 	pattern: string,
 	flags: string,
 	text: string,
 	replacement?: string,
-): RegexResult {
+): Promise<RegexResult> {
 	if (!pattern) return { matches: [] };
 
-	try {
-		const regex = new RegExp(pattern, flags);
-		const matches: RegexMatch[] = [];
+	return new Promise((resolve) => {
+		const worker = new Worker(new URL('./regex-worker.ts', import.meta.url), {
+			type: 'module',
+		});
 
-		if (regex.global) {
-			let match: RegExpExecArray | null = regex.exec(text);
-			while (match !== null) {
-				matches.push({
-					value: match[0],
-					index: match.index,
-					groups: match.slice(1),
-				});
-				// Avoid infinite loops with zero-length matches
-				if (match.index === regex.lastIndex) {
-					regex.lastIndex++;
-				}
-				match = regex.exec(text);
-			}
-		} else {
-			const match = regex.exec(text);
-			if (match) {
-				matches.push({
-					value: match[0],
-					index: match.index,
-					groups: match.slice(1),
-				});
-			}
-		}
+		const timeoutId = setTimeout(() => {
+			worker.terminate();
+			resolve({ matches: [], error: 'タイムアウト：正規表現が複雑すぎます' });
+		}, TIMEOUT_MS);
 
-		let replacedText: string | undefined;
-		if (replacement !== undefined) {
-			replacedText = text.replace(regex, replacement);
-		}
-
-		return { matches, replacedText };
-	} catch (err: unknown) {
-		return {
-			matches: [],
-			error: err instanceof Error ? err.message : String(err),
+		worker.onmessage = (event: MessageEvent<RegexResult>) => {
+			clearTimeout(timeoutId);
+			worker.terminate();
+			resolve(event.data);
 		};
-	}
+
+		worker.onerror = (event: ErrorEvent) => {
+			clearTimeout(timeoutId);
+			worker.terminate();
+			resolve({ matches: [], error: event.message });
+		};
+
+		worker.postMessage({ pattern, flags, text, replacement });
+	});
 }

--- a/src/lib/tools/regex-worker.ts
+++ b/src/lib/tools/regex-worker.ts
@@ -1,0 +1,55 @@
+import type { RegexMatch, RegexResult } from './regex-tester';
+
+type WorkerInput = {
+	pattern: string;
+	flags: string;
+	text: string;
+	replacement?: string;
+};
+
+self.onmessage = (event: MessageEvent<WorkerInput>) => {
+	const { pattern, flags, text, replacement } = event.data;
+
+	try {
+		const regex = new RegExp(pattern, flags);
+		const matches: RegexMatch[] = [];
+
+		if (regex.global) {
+			let match: RegExpExecArray | null = regex.exec(text);
+			while (match !== null) {
+				matches.push({
+					value: match[0],
+					index: match.index,
+					groups: match.slice(1),
+				});
+				if (match.index === regex.lastIndex) {
+					regex.lastIndex++;
+				}
+				match = regex.exec(text);
+			}
+		} else {
+			const match = regex.exec(text);
+			if (match) {
+				matches.push({
+					value: match[0],
+					index: match.index,
+					groups: match.slice(1),
+				});
+			}
+		}
+
+		let replacedText: string | undefined;
+		if (replacement !== undefined) {
+			replacedText = text.replace(regex, replacement);
+		}
+
+		const result: RegexResult = { matches, replacedText };
+		self.postMessage(result);
+	} catch (err: unknown) {
+		const result: RegexResult = {
+			matches: [],
+			error: err instanceof Error ? err.message : String(err),
+		};
+		self.postMessage(result);
+	}
+};


### PR DESCRIPTION
## Summary
Refactored the regex testing functionality to execute in a Web Worker to prevent blocking the main thread during complex regex operations. Added a 500ms timeout to handle cases where regex patterns cause excessive computation.

## Key Changes
- **Moved regex logic to Web Worker**: Created new `regex-worker.ts` that handles all regex matching and replacement operations in a separate thread
- **Made `testRegex` async**: Changed the function signature from synchronous to async, returning a `Promise<RegexResult>`
- **Added timeout protection**: Implemented a 500ms timeout (`TIMEOUT_MS`) that terminates the worker if regex processing takes too long, preventing UI freezes
- **Updated component to use async result**: Modified `RegexTester.tsx` to use `useEffect` hook instead of `useMemo` to handle the async nature of regex testing, with proper cleanup to avoid state updates on unmounted components

## Implementation Details
- The main thread communicates with the worker via `postMessage` and listens for results via `onmessage`
- Error handling is preserved in the worker, with errors sent back to the main thread
- The component includes a cancellation flag to prevent setting state after unmounting
- Worker is properly terminated after receiving results or on timeout

https://claude.ai/code/session_01H27JFmsdJevfbmEynZxeG8