### PR TITLE
fix: CSPヘッダーの修正（インラインスクリプトとフォントの許可）

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com; font-src 'self'; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com; font-src 'self' https://fonts.gstatic.com; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
   X-Content-Type-Options: nosniff
   X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
Cloudflare Pagesデプロイ環境でReactコンポーネントが動作しない問題（Astroのインラインスクリプトがブロックされる問題）とGoogleフォントが読み込まれない問題を解消するため、CSPヘッダーを修正しました。

## 修正内容
- `script-src` に `'unsafe-inline'` を追加（Astro View TransitionsやReact hydrationのため）
- `style-src` に `https://fonts.googleapis.com` を追加
- `font-src` に `https://fonts.gstatic.com` を追加