### PR TITLE
fix(ui): improve highlight visibility in dark mode

### DIFF
--- a/src/components/tools/Masking.tsx
+++ b/src/components/tools/Masking.tsx
@@ -104,7 +104,7 @@ export default function Masking() {
 			nodes.push(
 				<mark
 					key={`m-${i}`}
-					className="bg-primary/30 text-transparent rounded-[2px]"
+					className="bg-primary/30 dark:bg-primary/50 text-transparent rounded-[2px]"
 					title={range.type}
 				>
 					{text.slice(range.start, range.end)}

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -85,7 +85,7 @@ export default function RegexTester() {
 			nodes.push(
 				<mark
 					key={`m-${i}`}
-					className="bg-primary/30 text-transparent rounded-[2px]"
+					className="bg-primary/30 dark:bg-primary/50 text-transparent rounded-[2px]"
 				>
 					{match.value}
 				</mark>,


### PR DESCRIPTION
## 概要
正規表現テスターおよびマスキングツールのダークモード時において、マッチした文字列のハイライト（背景色）が暗すぎて見えづらい問題を修正しました。

## 変更内容
- ハイライト要素のCSSクラスについて、ダークモード時の背景色不透明度を調整しました（`dark:bg-primary/50` を追加）。
- 対象コンポーネント: `RegexTester.tsx`, `Masking.tsx`

## 検証
- ダークモードに切り替えた状態で、テスト文字列のハイライトが元の暗い背景色に比べて視認しやすくなったことを確認しました。