### PR TITLE
Improve PWA caching strategy and manifest configuration

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -13,13 +13,25 @@
       "src": "/icon-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
-      "purpose": "maskable any"
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/icon-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
-      "purpose": "maskable any"
+      "purpose": "maskable"
+    },
+    {
+      "src": "/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
     },
     {
       "src": "/favicon.svg",

--- a/public/sw.js
+++ b/public/sw.js
@@ -40,13 +40,17 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-// PWA インストール時に全ページ・全アセットをプリキャッシュ
+// PWA インストール時に全ページ・全アセットをプリキャッシュ（未キャッシュURLのみ取得）
 self.addEventListener('message', (event) => {
   if (event.data?.type !== 'PRECACHE_ALL') return;
   event.waitUntil(
-    caches.open(CACHE_NAME).then((cache) =>
-      Promise.allSettled([...ALL_PAGES, ...ALL_ASSETS].map((url) => cache.add(url)))
-    )
+    caches.open(CACHE_NAME).then(async (cache) => {
+      const urls = [...ALL_PAGES, ...ALL_ASSETS];
+      const uncached = (
+        await Promise.all(urls.map(async (url) => ((await cache.match(url)) ? null : url)))
+      ).filter(Boolean);
+      return Promise.allSettled(uncached.map((url) => cache.add(url)));
+    })
   );
 });
 
@@ -66,7 +70,9 @@ self.addEventListener('fetch', (event) => {
         const cached = await cache.match(reqUrl, { ignoreVary: true });
         if (cached) return cached;
         const response = await fetch(event.request);
-        cache.put(reqUrl, response.clone());
+        if (response.ok) {
+          cache.put(reqUrl, response.clone());
+        }
         return response;
       })
     );

--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -15,12 +15,30 @@ const pageURLs = [
 ];
 
 // dist/_astro/ 配下の全ファイルを収集
-const assetFiles = await readdir(join(DIST, '_astro'));
+let assetFiles = [];
+try {
+  assetFiles = await readdir(join(DIST, '_astro'));
+} catch {
+  // _astro/ が存在しない場合は空配列のまま続行
+}
 const assetURLs = assetFiles.map((f) => `/_astro/${f}`);
 
-// アセット内容に基づくキャッシュバージョンハッシュ（変更があると自動失効）
+// ページHTML内容 + アセットURLからキャッシュバージョンハッシュを計算（内容変更時に自動失効）
+const pageContents = await Promise.all(
+  pageURLs.map(async (url) => {
+    const filePath =
+      url === '/'
+        ? join(DIST, 'index.html')
+        : join(DIST, url.replace(/^\//, '').replace(/\/$/, ''), 'index.html');
+    try {
+      return await readFile(filePath, 'utf8');
+    } catch {
+      return url;
+    }
+  })
+);
 const hash = createHash('md5')
-  .update([...pageURLs, ...assetURLs].sort().join('\n'))
+  .update([...pageContents, ...assetURLs].sort().join('\n'))
   .digest('hex')
   .slice(0, 8);
 


### PR DESCRIPTION
## Summary
This PR enhances the PWA implementation by improving the service worker caching logic, refining the cache versioning mechanism, and updating the web app manifest for better icon handling.

## Key Changes

- **Service Worker Cache Versioning**: Changed cache hash calculation from URL-based to content-based by reading actual page HTML files. This ensures the cache automatically invalidates when page content changes, not just when URLs change.

- **Precache Optimization**: Modified the precache installation to only fetch URLs that aren't already cached, reducing unnecessary network requests during PWA installation.

- **Error Handling**: Added try-catch blocks in the build script to gracefully handle missing `_astro/` directory and missing page files.

- **Response Validation**: Added a check to only cache successful HTTP responses (response.ok), preventing cached error responses.

- **Web App Manifest Icons**: Split the combined "maskable any" purpose into separate icon entries with individual purposes ("maskable" and "any") for better compatibility and clearer intent. Added explicit entries for both 192x192 and 512x512 icons with both purpose types.

## Implementation Details

- The cache hash now includes actual page HTML content instead of just URLs, making it more reliable for detecting meaningful changes
- Precache filtering uses `cache.match()` to check existing entries before attempting to fetch, improving efficiency
- The manifest now follows the recommended pattern of separate icon entries per purpose rather than combining them

https://claude.ai/code/session_0135uzdqonvRmTp5XjeQYstk