### PR TITLE
Add validation for service worker template placeholder replacement

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -19,6 +19,7 @@ const ALL_ASSETS = [/* __ALL_ASSETS__ */];
 self.addEventListener('install', (event) => {
   event.waitUntil(
     Promise.all([
+      // 全アセットがハッシュ付きURLで管理されているため、即時アクティベートしても安全
       self.skipWaiting(),
       caches.open(CACHE_NAME).then((cache) =>
         Promise.allSettled(MIN_ASSETS.map((url) => cache.add(url)))

--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -49,6 +49,14 @@ const output = template
   .replace('[/* __ALL_PAGES__ */]', JSON.stringify(pageURLs, null, 2))
   .replace('[/* __ALL_ASSETS__ */]', JSON.stringify(assetURLs, null, 2));
 
+// プレースホルダーが残っている場合はテンプレートの構造が変わっている
+if (output.includes('__HASH__') || output.includes('__ALL_PAGES__') || output.includes('__ALL_ASSETS__')) {
+  throw new Error(
+    '[generate-sw] Template replacement failed: placeholder still present in output. ' +
+    'Verify that public/sw.js contains the expected placeholder strings.'
+  );
+}
+
 await writeFile(join(DIST, 'sw.js'), output, 'utf8');
 
 console.log(`[generate-sw] CACHE_NAME: cl-tools-${hash}`);


### PR DESCRIPTION
## Summary
This PR adds validation to the service worker generation script to ensure all template placeholders are properly replaced, and includes a clarifying comment about the safety of immediate activation.

## Key Changes
- **Template validation**: Added error checking in `scripts/generate-sw.mjs` to verify that all placeholder strings (`__HASH__`, `__ALL_PAGES__`, `__ALL_ASSETS__`) are successfully replaced in the output. If any placeholders remain, the build fails with a descriptive error message.
- **Documentation**: Added a clarifying comment in `public/sw.js` explaining that immediate activation via `skipWaiting()` is safe because all assets are managed with hash-based URLs.

## Implementation Details
The validation check compares the final output against the three expected placeholders. If any are found, it throws an error with guidance to verify the template structure, preventing silent failures where the service worker might be deployed with unreplaced placeholders.

https://claude.ai/code/session_01N4SkdRV9pgozMGKXggPfLb