### PR TITLE
feat(bg-remove): クライアントサイドAI背景削除ツールを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ report.json
 
 # Superpowers brainstorming
 .superpowers/
+docs/superpowers/
+
+# Wrangler local dev
+.wrangler/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,86 @@
-Please refer to AGENTS.md for all project rules and agent instructions.
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+> 詳細なプロジェクトルール・命名規約・設計方針は **AGENTS.md** を参照。本ファイルはコマンドとアーキテクチャの早期理解を目的とする。
+
+## コマンド
+
+```bash
+npm run dev          # 開発サーバー起動 (localhost:4321)
+npm run build        # 本番ビルド（astro build + generate-sw.mjs）
+npm run preview      # ビルド結果をローカルプレビュー
+npm run lint         # Biome lint チェック（src/ tests/）
+npm run lint:fix     # Biome 自動修正
+npm test             # E2E テスト全件（Playwright）
+```
+
+**単体テスト実行:**
+```bash
+npx playwright test tests/e2e/bg-remove.spec.ts          # ファイル指定
+npx playwright test --grep "モード切替"                   # テスト名で絞り込み
+npx playwright test --headed                              # ブラウザ表示あり
+```
+
+E2E テストは `npm run build` 後に `npm run preview:ci` で起動したサーバーに対して実行される。`reuseExistingServer: true` のため、既にサーバーが立ち上がっていれば再利用される。
+
+## アーキテクチャ
+
+### 新ツールの3ファイル構成
+
+すべてのツールは以下の3ファイルで完結する（Workerが必要な場合は4ファイル）:
+
+```
+src/lib/tools/[name].ts          # 純粋関数のロジック
+src/components/tools/[Name].tsx  # React Island（UIのみ、状態管理）
+src/pages/[name].astro           # ページシェル（ToolLayout + JSON-LD）
+src/workers/[name].worker.ts     # 重量級処理のみ（例: bg-remove）
+```
+
+`ToolLayout.astro` を使うと SafetyBadge・AdSlot・`<slot name="usage">` が自動挿入される。JSON-LDは `ToolLayout` 内の `ToolJsonLd` コンポーネントが `title`/`description`/`path` から自動生成するため、個別ページでの追加は不要（`bg-remove.astro` の手動追加は重複に注意）。
+
+### React Island のライフサイクル
+
+- `client:load` — ページ読み込み直後にハイドレート（デフォルト）
+- `client:only="react"` — AdSlot など SSR 不要なコンポーネント
+- `client:visible` — 遅延ハイドレート（現在未使用）
+
+### Web Worker（bg-remove）のデータフロー
+
+```
+BgRemove.tsx
+  └─ removeBackground(file, mode, onProgress)   ← lib/tools/bg-remove.ts
+       └─ ArrayBuffer (transferable) → bg-remove.worker.ts
+            └─ Transformers.js pipeline('background-removal')
+                 └─ RGBA Uint8ClampedArray → ArrayBuffer (transferable) →
+       ← Canvas.putImageData → toBlob('image/png')
+```
+
+Worker への画像送信は `File → ArrayBuffer`（transferable）。MIME タイプは `WorkerRequest.mimeType` で明示的に渡す（`image/png` ハードコード禁止）。Worker 内は `device: 'wasm'` 固定（WebGPU は不安定のため除外）。
+
+モデルは本番環境（`hostname !== 'localhost'`）では Cloudflare R2（`models.tools.codelife.cafe`）から配信。ローカルは HuggingFace CDN にフォールバック。
+
+### Service Worker とビルド
+
+`npm run build` の第2フェーズ（`scripts/generate-sw.mjs`）が `dist/` を走査して全ページ・アセット URL を収集し、`public/sw.js` のプレースホルダーを置換した `dist/sw.js` を生成する。`CACHE_NAME` のハッシュはアセット内容から自動計算され、デプロイごとに古いキャッシュが自動失効する。
+
+### E2Eテストパターン
+
+```typescript
+import { expect, test } from './fixtures/base';  // ← 必ずこのfixture経由
+
+test('...', async ({ page, createToolPage }) => {
+  const toolPage = createToolPage('tool-name');  // path（/なし）を渡す
+  await toolPage.goto();                          // networkidle まで待機
+
+  // ToolPage ヘルパーメソッド: expectSafetyBadge / expectTitle / fillInput / expectOutputContains
+});
+```
+
+`fixtures/base.ts` は広告・アナリティクスをブロックするルートを設定済み。直接 `@playwright/test` からインポートしないこと。
+
+### Cloudflare R2（モデル配信）
+
+- バケット: `codelife-models`、カスタムドメイン: `models.tools.codelife.cafe`
+- 再アップロード: `bash scripts/upload-models-to-r2.sh codelife-models`
+- CORS変更: `scripts/r2-cors.json` 編集後 `wrangler r2 bucket cors set codelife-models --file scripts/r2-cors.json`

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 🔗 **[https://tools.codelife.cafe](https://tools.codelife.cafe)**
 
-## 📦 収録ツール（17種）
+## 📦 収録ツール（18種）
 
 ### テキスト処理
 
@@ -31,6 +31,7 @@
 
 | ツール | 説明 |
 |--------|------|
+| [背景削除](/bg-remove) | AIがブラウザ内で画像の背景を自動削除。差し替えにも対応（完全ローカル実行） |
 | [QRコード生成](/qr-generator) | テキスト・URLからQRコードを生成しPNG/SVGダウンロード |
 | [Base64エンコード/デコード](/base64) | テキスト・ファイルのBase64変換、Data URI出力対応 |
 | [URLエンコード/デコード](/url-encoder) | 日本語を含むURLやクエリを安全に双方向変換。コンポーネント/フルURLモード対応 |
@@ -70,6 +71,37 @@
 | `npm run build` | 本番用に静的ビルド＋SW生成（`dist/`） |
 | `npm run preview` | ビルド結果をローカルプレビュー |
 | `npx playwright test --headed` | E2Eテストを実行（ブラウザ表示あり） |
+
+## 🚀 Cloudflare R2 モデル配信
+
+背景削除ツールの AI モデルは **`models.tools.codelife.cafe`**（Cloudflare R2）から配信されます。
+
+| バケット | `codelife-models` |
+|---|---|
+| カスタムドメイン | `https://models.tools.codelife.cafe` |
+| CORS | `tools.codelife.cafe`, `localhost:4321` |
+
+**配信済みモデル:**
+- `onnx-community/modnet-webnn/resolve/main/onnx/model.onnx` — 25.9MB (MODNet fp32)
+- `onnx-community/BEN2-ONNX/resolve/main/onnx/model_fp16.onnx` — 219MB (BEN2 fp16)
+
+ローカル開発時（`localhost`）は HuggingFace CDN に自動フォールバックします。
+
+### モデルを再アップロードする場合
+
+```bash
+bash scripts/upload-models-to-r2.sh codelife-models
+```
+
+### CORS 設定を変更する場合
+
+`scripts/r2-cors.json` を編集してから:
+
+```bash
+wrangler r2 bucket cors set codelife-models --file scripts/r2-cors.json
+```
+
+---
 
 ## 📄 ライセンス
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6718,9 +6718,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.11.0.tgz",
-      "integrity": "sha512-UOhjdztXCgdBReRcIhsvz2siIBogfv/lhJEIViCpLt924dO+GDms9T7DNoucI23s6kEPpe988m5N0D2ajnzb2g==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9142,9 +9142,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/react": "^5.0.4",
         "@astrojs/sitemap": "^3.7.2",
+        "@huggingface/transformers": "^4.2.0",
         "@radix-ui/react-checkbox": "^1.3.2",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-popover": "^1.1.14",
@@ -1294,12 +1295,39 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.9.tgz",
+      "integrity": "sha512-uWTG+l3VJRsl7EXxYizuL3P+cCPoc3cRqbWWRcQN0FhejRfbdq0RNhCmbY/YDtnTcz9icdLYuLDjsnz4d8JMuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tokenizers": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@huggingface/tokenizers/-/tokenizers-0.1.3.tgz",
+      "integrity": "sha512-8rF/RRT10u+kn7YuUbUg0OF30K8rjTc78aHpxT+qJ1uWSqxT1MHi8+9ltwYfkFYJzT/oS+qw3JVfHtNMGAdqyA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@huggingface/transformers": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@huggingface/transformers/-/transformers-4.2.0.tgz",
+      "integrity": "sha512-8BRCoBMH0XsWaEIamuR0LrJGAfftgHAfb2Vrffy0VKlSAE/MnUJ5/h/zTfEP3fDIft+nk7TqB8xXEyABGitBjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.6",
+        "@huggingface/tokenizers": "^0.1.3",
+        "onnxruntime-node": "1.24.3",
+        "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
+        "sharp": "^0.34.5"
+      }
+    },
     "node_modules/@img/colour": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
       "integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       }
@@ -1826,6 +1854,69 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -4641,6 +4732,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.17",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+      "integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -4909,6 +5009,13 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "MIT"
     },
     "node_modules/browserslist": {
       "version": "4.28.2",
@@ -5347,6 +5454,40 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/defu": {
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.7.tgz",
@@ -5376,6 +5517,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "license": "MIT"
     },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
@@ -5556,10 +5703,34 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
       "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "license": "MIT"
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -5714,6 +5885,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/flattie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/flattie/-/flattie-1.1.1.tgz",
@@ -5806,10 +5983,61 @@
       "integrity": "sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==",
       "license": "ISC"
     },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
       "license": "ISC"
     },
     "node_modules/h3": {
@@ -5827,6 +6055,18 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -6167,6 +6407,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "license": "ISC"
+    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -6446,6 +6692,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/longest-streak": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
@@ -6502,6 +6754,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/matcher/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/mdast-util-definitions": {
@@ -7433,6 +7709,15 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -7476,6 +7761,49 @@
         "regex": "^6.1.0",
         "regex-recursion": "^6.0.2"
       }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz",
+      "integrity": "sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.24.3",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz",
+      "integrity": "sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "adm-zip": "^0.5.16",
+        "global-agent": "^3.0.0",
+        "onnxruntime-common": "1.24.3"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.26.0-dev.20260416-b7804b056c",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.26.0-dev.20260416-b7804b056c.tgz",
+      "integrity": "sha512-MD6Ss4GSpQBo6zqoJzyT9LRbKYs7x/JVN23FT24EcEvlqF4VuzPOeH6X38orZPKHQDbprn7K+SBpu0/mj2CQiw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^25.1.24",
+        "guid-typescript": "^1.0.9",
+        "long": "^5.2.3",
+        "onnxruntime-common": "1.24.0-dev.20251116-b39e144322",
+        "platform": "^1.3.6",
+        "protobufjs": "^7.2.4"
+      }
+    },
+    "node_modules/onnxruntime-web/node_modules/onnxruntime-common": {
+      "version": "1.24.0-dev.20251116-b39e144322",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz",
+      "integrity": "sha512-BOoomdHYmNRL5r4iQ4bMvsl2t0/hzVQ3OM3PHD0gxeXu1PmggqBv3puZicEUVOA3AtHHYmqZtjMj9FOfGrATTw==",
+      "license": "MIT"
     },
     "node_modules/p-limit": {
       "version": "7.3.0",
@@ -7638,6 +7966,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/playwright": {
       "version": "1.59.1",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
@@ -7755,6 +8089,30 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+      "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/qrcode": {
@@ -8460,6 +8818,23 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.59.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
@@ -8531,6 +8906,27 @@
         "node": ">=10"
       }
     },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "license": "MIT"
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -8543,7 +8939,6 @@
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
         "detect-libc": "^2.1.2",
@@ -8671,6 +9066,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/sql-formatter": {
       "version": "15.7.2",
@@ -8832,6 +9233,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/typesafe-path": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.4",
     "@astrojs/sitemap": "^3.7.2",
+    "@huggingface/transformers": "^4.2.0",
     "@radix-ui/react-checkbox": "^1.3.2",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-popover": "^1.1.14",

--- a/scripts/r2-cors.json
+++ b/scripts/r2-cors.json
@@ -1,0 +1,16 @@
+{
+  "rules": [
+    {
+      "allowed": {
+        "origins": [
+          "https://tools.codelife.cafe",
+          "http://localhost:4321"
+        ],
+        "methods": ["GET", "HEAD"],
+        "headers": ["*"]
+      },
+      "exposeHeaders": ["Content-Length", "Content-Type"],
+      "maxAgeSeconds": 3000
+    }
+  ]
+}

--- a/scripts/upload-models-to-r2.sh
+++ b/scripts/upload-models-to-r2.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# HuggingFace からモデルをダウンロードし Cloudflare R2 にアップロードする
+# 使い方: bash scripts/upload-models-to-r2.sh <BUCKET_NAME>
+# 例:     bash scripts/upload-models-to-r2.sh codelife-models
+
+set -euo pipefail
+
+BUCKET="${1:?Usage: $0 <BUCKET_NAME>}"
+HF_BASE="https://huggingface.co"
+TMP_DIR="$(mktemp -d)"
+
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+download() {
+  local model="$1" file="$2"
+  local url="${HF_BASE}/${model}/resolve/main/${file}"
+  local dest="${TMP_DIR}/${model}/resolve/main/${file}"
+  mkdir -p "$(dirname "$dest")"
+  echo "  Downloading ${model}/${file} ..."
+  curl -fL --retry 3 --retry-delay 2 -o "$dest" "$url"
+}
+
+upload() {
+  local model="$1" file="$2"
+  local local_path="${TMP_DIR}/${model}/resolve/main/${file}"
+  local r2_key="${model}/resolve/main/${file}"
+  echo "  Uploading → r2://${BUCKET}/${r2_key}"
+  wrangler r2 object put "${BUCKET}/${r2_key}" \
+    --file="${local_path}" \
+    --content-type="$(content_type "$file")" \
+    --remote
+}
+
+content_type() {
+  case "$1" in
+    *.json) echo "application/json" ;;
+    *.onnx) echo "application/octet-stream" ;;
+    *)      echo "application/octet-stream" ;;
+  esac
+}
+
+process_model() {
+  local model="$1"
+  shift
+  local files=("$@")
+
+  echo ""
+  echo "=== ${model} ==="
+  for f in "${files[@]}"; do
+    download "$model" "$f"
+    upload   "$model" "$f"
+  done
+}
+
+echo "Bucket: ${BUCKET}"
+echo "Temp dir: ${TMP_DIR}"
+
+# --- MODNet (高速・人物特化, fp32) ---
+process_model "onnx-community/modnet-webnn" \
+  "config.json" \
+  "preprocessor_config.json" \
+  "quantize_config.json" \
+  "onnx/model.onnx"
+
+# --- BEN2 (高精度, fp16) ---
+process_model "onnx-community/BEN2-ONNX" \
+  "config.json" \
+  "preprocessor_config.json" \
+  "onnx/model_fp16.onnx"
+
+echo ""
+echo "✅ 完了: すべてのモデルを r2://${BUCKET} にアップロードしました"

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -1,0 +1,657 @@
+import {
+	Download,
+	ImageIcon,
+	Loader2,
+	RefreshCw,
+	Scissors,
+	Upload,
+	Wand2,
+	X,
+	Zap,
+} from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+	compositeBackground,
+	type ModelMode,
+	type ProgressInfo,
+	preload,
+	removeBackground,
+	terminateWorker,
+} from '@/lib/tools/bg-remove';
+
+// --- 定数 ---
+const ACCEPTED_TYPES = ['image/png', 'image/jpeg', 'image/webp'];
+const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
+
+type Status = 'idle' | 'loading' | 'processing' | 'done' | 'error';
+
+type BackgroundOption =
+	| { type: 'transparent' }
+	| { type: 'color'; value: string }
+	| { type: 'image'; value: Blob };
+
+// --- 市松模様 CSS ---
+const checkerboardStyle: React.CSSProperties = {
+	backgroundImage: `
+		linear-gradient(45deg, var(--muted) 25%, transparent 25%),
+		linear-gradient(-45deg, var(--muted) 25%, transparent 25%),
+		linear-gradient(45deg, transparent 75%, var(--muted) 75%),
+		linear-gradient(-45deg, transparent 75%, var(--muted) 75%)
+	`,
+	backgroundSize: '20px 20px',
+	backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+};
+
+// --- プリセット背景色 ---
+const PRESET_COLORS = [
+	'#ffffff',
+	'#000000',
+	'#ef4444',
+	'#3b82f6',
+	'#22c55e',
+	'#f59e0b',
+	'#8b5cf6',
+	'#ec4899',
+];
+
+export default function BgRemove() {
+	// --- 状態管理 ---
+	const [status, setStatus] = useState<Status>('idle');
+	const [mode, setMode] = useState<ModelMode>('high');
+	const [progress, setProgress] = useState<ProgressInfo | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	// 入力画像
+	const [sourceFile, setSourceFile] = useState<File | null>(null);
+	const [sourceUrl, setSourceUrl] = useState<string | null>(null);
+
+	// 結果
+	const [resultBlob, setResultBlob] = useState<Blob | null>(null);
+	const [resultUrl, setResultUrl] = useState<string | null>(null);
+
+	// 背景差し替え
+	const [bgOption, setBgOption] = useState<BackgroundOption>({
+		type: 'transparent',
+	});
+	const [compositeUrl, setCompositeUrl] = useState<string | null>(null);
+
+	// D&D
+	const [isDragOver, setIsDragOver] = useState(false);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+	const dropZoneRef = useRef<HTMLDivElement>(null);
+
+	// --- 先行初期化 ---
+	useEffect(() => {
+		preload('high');
+		return () => terminateWorker();
+	}, []);
+
+	// --- URL クリーンアップ ---
+	useEffect(() => {
+		return () => {
+			if (sourceUrl) URL.revokeObjectURL(sourceUrl);
+			if (resultUrl) URL.revokeObjectURL(resultUrl);
+			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+		};
+	}, [sourceUrl, resultUrl, compositeUrl]);
+
+	// --- ファイル検証 ---
+	const validateFile = useCallback((file: File): string | null => {
+		if (!ACCEPTED_TYPES.includes(file.type)) {
+			return '対応形式: PNG、JPG、WEBP のみ';
+		}
+		if (file.size > MAX_FILE_SIZE) {
+			return 'ファイルサイズは20MB以下にしてください';
+		}
+		return null;
+	}, []);
+
+	// --- 背景削除実行 ---
+	const processImage = useCallback(
+		async (file: File, selectedMode: ModelMode) => {
+			setStatus('loading');
+			setProgress(null);
+			setError(null);
+
+			// 既存の結果をクリア
+			if (resultUrl) URL.revokeObjectURL(resultUrl);
+			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+			setResultBlob(null);
+			setResultUrl(null);
+			setCompositeUrl(null);
+			setBgOption({ type: 'transparent' });
+
+			try {
+				const blob = await removeBackground(file, selectedMode, (info) => {
+					setProgress(info);
+					if (info.status === 'progress') {
+						setStatus('loading');
+					} else if (info.status === 'done' || info.status === 'ready') {
+						setStatus('processing');
+					}
+				});
+
+				const url = URL.createObjectURL(blob);
+				setResultBlob(blob);
+				setResultUrl(url);
+				setStatus('done');
+			} catch (err) {
+				const message =
+					err instanceof Error ? err.message : '背景削除に失敗しました';
+				setError(message);
+				setStatus('error');
+			}
+		},
+		[resultUrl, compositeUrl],
+	);
+
+	// --- ファイル処理 ---
+	const handleFile = useCallback(
+		(file: File) => {
+			const validationError = validateFile(file);
+			if (validationError) {
+				setError(validationError);
+				setStatus('error');
+				return;
+			}
+
+			// 既存のソース URL をクリア
+			if (sourceUrl) URL.revokeObjectURL(sourceUrl);
+
+			setSourceFile(file);
+			setSourceUrl(URL.createObjectURL(file));
+			setError(null);
+
+			processImage(file, mode);
+		},
+		[validateFile, mode, processImage, sourceUrl],
+	);
+
+	// --- D&D ハンドラ ---
+	const handleDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragOver(true);
+	}, []);
+
+	const handleDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragOver(false);
+	}, []);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			setIsDragOver(false);
+
+			const file = e.dataTransfer.files[0];
+			if (file) handleFile(file);
+		},
+		[handleFile],
+	);
+
+	// --- クリップボード貼付 ---
+	useEffect(() => {
+		const handler = (e: ClipboardEvent) => {
+			const items = e.clipboardData?.items;
+			if (!items) return;
+
+			for (const item of items) {
+				if (item.type.startsWith('image/')) {
+					const file = item.getAsFile();
+					if (file) {
+						e.preventDefault();
+						handleFile(file);
+						return;
+					}
+				}
+			}
+		};
+
+		document.addEventListener('paste', handler);
+		return () => document.removeEventListener('paste', handler);
+	}, [handleFile]);
+
+	// --- ファイル選択 ---
+	const handleFileSelect = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (file) handleFile(file);
+			// input をリセット（同じファイルの再選択を可能にする）
+			e.target.value = '';
+		},
+		[handleFile],
+	);
+
+	// --- モード切替 ---
+	const handleModeChange = useCallback(
+		(checked: boolean) => {
+			const newMode: ModelMode = checked ? 'high' : 'fast';
+			setMode(newMode);
+
+			// 結果がある場合は再処理
+			if (sourceFile && status === 'done') {
+				processImage(sourceFile, newMode);
+			}
+		},
+		[sourceFile, status, processImage],
+	);
+
+	// --- 背景差し替え ---
+	useEffect(() => {
+		if (!resultBlob || bgOption.type === 'transparent') {
+			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+			setCompositeUrl(null);
+			return;
+		}
+
+		let cancelled = false;
+		compositeBackground(resultBlob, bgOption).then((blob) => {
+			if (cancelled) return;
+			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+			setCompositeUrl(URL.createObjectURL(blob));
+		});
+
+		return () => {
+			cancelled = true;
+		};
+	}, [resultBlob, bgOption, compositeUrl]);
+
+	// --- ダウンロード ---
+	const handleDownload = useCallback(() => {
+		const url = compositeUrl ?? resultUrl;
+		if (!url) return;
+
+		const a = document.createElement('a');
+		a.href = url;
+		const baseName = sourceFile?.name?.replace(/\.[^.]+$/, '') ?? 'image';
+		const suffix = bgOption.type === 'transparent' ? '_transparent' : '_bg';
+		a.download = `${baseName}${suffix}.png`;
+		document.body.appendChild(a);
+		a.click();
+		document.body.removeChild(a);
+	}, [compositeUrl, resultUrl, sourceFile, bgOption]);
+
+	// --- リセット ---
+	const handleReset = useCallback(() => {
+		if (sourceUrl) URL.revokeObjectURL(sourceUrl);
+		if (resultUrl) URL.revokeObjectURL(resultUrl);
+		if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+
+		setSourceFile(null);
+		setSourceUrl(null);
+		setResultBlob(null);
+		setResultUrl(null);
+		setCompositeUrl(null);
+		setStatus('idle');
+		setProgress(null);
+		setError(null);
+		setBgOption({ type: 'transparent' });
+	}, [sourceUrl, resultUrl, compositeUrl]);
+
+	// --- 背景画像アップロード ---
+	const bgImageInputRef = useRef<HTMLInputElement>(null);
+	const handleBgImageSelect = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (file) {
+				setBgOption({ type: 'image', value: file });
+			}
+			e.target.value = '';
+		},
+		[],
+	);
+
+	// --- 進捗率の計算 ---
+	const progressPercent =
+		progress?.progress != null ? Math.round(progress.progress) : 0;
+
+	// --- 表示する画像 URL ---
+	const displayUrl = compositeUrl ?? resultUrl;
+
+	return (
+		<div className="space-y-6">
+			{/* モード切替 */}
+			<div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
+				<div className="flex items-center gap-3">
+					<div className="flex items-center gap-2">
+						<Zap className="h-4 w-4 text-amber-500" />
+						<Label
+							htmlFor="mode-switch"
+							className="text-sm font-medium cursor-pointer"
+						>
+							{mode === 'fast' ? '⚡ 高速モード' : '✨ 高精度モード'}
+						</Label>
+					</div>
+					<Switch
+						id="mode-switch"
+						checked={mode === 'high'}
+						onCheckedChange={handleModeChange}
+						disabled={status === 'loading' || status === 'processing'}
+					/>
+				</div>
+				<div className="text-xs text-muted-foreground">
+					{mode === 'fast' ? (
+						<span>MODNet（人物特化・高速）≈ 25.9MB</span>
+					) : (
+						<span>BEN2（極めて高精度・アニメ対応）≈ 209MB</span>
+					)}
+				</div>
+			</div>
+
+			{/* エラー表示 */}
+			{error && (
+				<div className="flex items-center gap-2 rounded-xl border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive">
+					<X className="h-4 w-4 shrink-0" />
+					<span>{error}</span>
+					<Button
+						variant="ghost"
+						size="sm"
+						className="ml-auto"
+						onClick={() => setError(null)}
+					>
+						閉じる
+					</Button>
+				</div>
+			)}
+
+			{/* ドロップゾーン / プレビュー */}
+			{status === 'idle' && !sourceUrl ? (
+				<div
+					ref={dropZoneRef}
+					onDragOver={handleDragOver}
+					onDragLeave={handleDragLeave}
+					onDrop={handleDrop}
+					onClick={() => fileInputRef.current?.click()}
+					onKeyDown={(e) => {
+						if (e.key === 'Enter' || e.key === ' ')
+							fileInputRef.current?.click();
+					}}
+					role="button"
+					tabIndex={0}
+					className={`
+						relative flex flex-col items-center justify-center gap-4
+						rounded-xl border-2 border-dashed p-12 cursor-pointer
+						transition-all duration-200
+						${
+							isDragOver
+								? 'border-primary bg-primary/5 scale-[1.01]'
+								: 'border-border hover:border-primary/50 hover:bg-muted/30'
+						}
+					`}
+				>
+					<div className="rounded-full bg-primary/10 p-4">
+						<Upload className="h-8 w-8 text-primary" />
+					</div>
+					<div className="text-center">
+						<p className="text-lg font-medium">画像をドラッグ＆ドロップ</p>
+						<p className="mt-1 text-sm text-muted-foreground">
+							またはクリックしてファイルを選択（PNG・JPG・WEBP、20MB以下）
+						</p>
+						<p className="mt-2 text-xs text-muted-foreground">
+							Ctrl+V でクリップボードから貼り付けも可能
+						</p>
+					</div>
+					<input
+						ref={fileInputRef}
+						type="file"
+						accept={ACCEPTED_TYPES.join(',')}
+						onChange={handleFileSelect}
+						className="hidden"
+					/>
+				</div>
+			) : (
+				<div className="space-y-4">
+					{/* 進捗バー */}
+					{(status === 'loading' || status === 'processing') && (
+						<div className="rounded-xl border border-border bg-card p-5 space-y-4 shadow-sm animate-in fade-in-50 duration-200">
+							<div className="flex items-center gap-3 text-sm">
+								<Loader2 className="h-5 w-5 animate-spin text-primary shrink-0" />
+								<div className="flex-1 min-w-0">
+									<p className="font-semibold text-card-foreground">
+										{status === 'loading'
+											? 'AIモデルをロード中（初回のみダウンロード）...'
+											: 'AI背景削除を実行中（ブラウザ内完全ローカル処理）...'}
+									</p>
+									<p className="text-xs text-muted-foreground mt-0.5">
+										{status === 'loading'
+											? `AIモデル（${mode === 'high' ? '高精度: 約209MB' : '人物特化高速: 約25.9MB'}）を準備しています。これには数十秒かかる場合があります。`
+											: 'ダウンロードが完了しました。画像から背景を自動で切り抜いています。これには2〜5秒程度かかります。'}
+									</p>
+								</div>
+								{status === 'loading' && progressPercent > 0 && (
+									<span className="text-sm font-semibold text-primary shrink-0">
+										{progressPercent}%
+									</span>
+								)}
+							</div>
+
+							{/* プログレスバー本体 */}
+							<div className="h-2 w-full rounded-full bg-muted overflow-hidden relative">
+								{status === 'loading' ? (
+									<div
+										className="h-full rounded-full bg-primary transition-all duration-300 ease-out"
+										style={{
+											width: `${progressPercent}%`,
+										}}
+									/>
+								) : (
+									<div className="h-full rounded-full bg-primary animate-pulse w-full" />
+								)}
+							</div>
+
+							{/* 詳細な進捗テキスト */}
+							{progress && (
+								<div className="flex flex-col gap-1 text-xs text-muted-foreground">
+									{progress.loaded != null && progress.total != null && (
+										<div className="flex justify-between font-mono">
+											<span>進捗状況:</span>
+											<span>
+												{(progress.loaded / (1024 * 1024)).toFixed(1)} MB /{' '}
+												{(progress.total / (1024 * 1024)).toFixed(1)} MB
+											</span>
+										</div>
+									)}
+									{progress.file && (
+										<p className="truncate">
+											読み込み中:{' '}
+											<span className="font-mono">{progress.file}</span>
+										</p>
+									)}
+								</div>
+							)}
+						</div>
+					)}
+
+					{/* プレビュー */}
+					<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+						{/* 元画像 */}
+						{sourceUrl && (
+							<div className="space-y-2">
+								<div className="flex items-center gap-2 text-sm font-medium">
+									<ImageIcon className="h-4 w-4 text-muted-foreground" />
+									<span>元の画像</span>
+								</div>
+								<div className="rounded-xl border border-border overflow-hidden bg-muted/30">
+									<img
+										src={sourceUrl}
+										alt="元の画像"
+										className="w-full h-auto max-h-[400px] object-contain"
+									/>
+								</div>
+							</div>
+						)}
+
+						{/* 結果画像 */}
+						{(displayUrl ||
+							status === 'loading' ||
+							status === 'processing') && (
+							<div className="space-y-2">
+								<div className="flex items-center gap-2 text-sm font-medium">
+									<Scissors className="h-4 w-4 text-primary" />
+									<span>背景削除後</span>
+									{status === 'done' && (
+										<Badge variant="outline" className="text-xs">
+											完了
+										</Badge>
+									)}
+								</div>
+								<div
+									className="rounded-xl border border-border overflow-hidden"
+									style={
+										bgOption.type === 'transparent'
+											? checkerboardStyle
+											: undefined
+									}
+								>
+									{displayUrl ? (
+										<img
+											src={displayUrl}
+											alt="背景削除後の画像"
+											className="w-full h-auto max-h-[400px] object-contain"
+										/>
+									) : (
+										<div className="flex items-center justify-center h-[200px]">
+											<Loader2 className="h-8 w-8 animate-spin text-primary" />
+										</div>
+									)}
+								</div>
+							</div>
+						)}
+					</div>
+
+					{/* 背景差し替えオプション（結果がある時のみ） */}
+					{status === 'done' && resultBlob && (
+						<div className="rounded-xl border border-border bg-card p-4 space-y-3">
+							<p className="text-sm font-medium">背景を変更</p>
+							<div className="flex flex-wrap items-center gap-2">
+								{/* 透過 */}
+								<button
+									type="button"
+									onClick={() => setBgOption({ type: 'transparent' })}
+									className={`
+										h-8 w-8 rounded-lg border-2 transition-all
+										${bgOption.type === 'transparent' ? 'border-primary ring-2 ring-primary/30' : 'border-border'}
+									`}
+									style={checkerboardStyle}
+									title="透過"
+								/>
+								{/* プリセット色 */}
+								{PRESET_COLORS.map((color) => (
+									<button
+										key={color}
+										type="button"
+										onClick={() =>
+											setBgOption({
+												type: 'color',
+												value: color,
+											})
+										}
+										className={`
+											h-8 w-8 rounded-lg border-2 transition-all
+											${bgOption.type === 'color' && bgOption.value === color ? 'border-primary ring-2 ring-primary/30' : 'border-border'}
+										`}
+										style={{ backgroundColor: color }}
+										title={color}
+									/>
+								))}
+								{/* カスタム色 */}
+								<label
+									className="relative h-8 w-8 rounded-lg border-2 border-border overflow-hidden cursor-pointer hover:border-primary/50 transition-colors"
+									title="カスタム色"
+								>
+									<input
+										type="color"
+										className="absolute inset-0 opacity-0 cursor-pointer"
+										onChange={(e) =>
+											setBgOption({
+												type: 'color',
+												value: e.target.value,
+											})
+										}
+									/>
+									<div className="w-full h-full bg-gradient-to-br from-red-500 via-green-500 to-blue-500" />
+								</label>
+								{/* 画像背景 */}
+								<Button
+									variant="outline"
+									size="sm"
+									className="h-8 text-xs"
+									onClick={() => bgImageInputRef.current?.click()}
+								>
+									<ImageIcon className="h-3 w-3 mr-1" />
+									画像
+								</Button>
+								<input
+									ref={bgImageInputRef}
+									type="file"
+									accept="image/*"
+									onChange={handleBgImageSelect}
+									className="hidden"
+								/>
+							</div>
+						</div>
+					)}
+
+					{/* アクションボタン */}
+					{status === 'done' && (
+						<div className="flex flex-wrap gap-3">
+							<Button onClick={handleDownload} className="gap-2">
+								<Download className="h-4 w-4" />
+								PNGをダウンロード
+							</Button>
+							<Button variant="outline" onClick={handleReset} className="gap-2">
+								<RefreshCw className="h-4 w-4" />
+								別の画像を処理
+							</Button>
+						</div>
+					)}
+
+					{/* エラー時のリトライ */}
+					{status === 'error' && (
+						<div className="flex gap-3">
+							{sourceFile && (
+								<Button
+									variant="outline"
+									onClick={() => processImage(sourceFile, mode)}
+									className="gap-2"
+								>
+									<RefreshCw className="h-4 w-4" />
+									リトライ
+								</Button>
+							)}
+							<Button variant="outline" onClick={handleReset} className="gap-2">
+								<X className="h-4 w-4" />
+								リセット
+							</Button>
+						</div>
+					)}
+				</div>
+			)}
+
+			{/* 注意事項 */}
+			<div className="rounded-xl border border-border bg-card p-4 space-y-2">
+				<div className="flex items-start gap-2 text-xs text-muted-foreground">
+					<Wand2 className="h-4 w-4 mt-0.5 shrink-0 text-primary" />
+					<div className="space-y-1">
+						<p>
+							<strong>AI による背景削除</strong> — Transformers.js
+							を使用してブラウザ内で完全に処理されます。
+						</p>
+						<p>
+							初回はモデルのダウンロードが必要です（高精度モード:
+							約209MB、高速モード〈人物特化〉: 約25.9MB）。
+							2回目以降はキャッシュされ即座に処理できます。
+						</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -82,7 +82,7 @@ export default function BgRemove() {
 	// D&D
 	const [isDragOver, setIsDragOver] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
-	const dropZoneRef = useRef<HTMLDivElement>(null);
+	const dropZoneRef = useRef<HTMLButtonElement>(null);
 
 	// --- 先行初期化 ---
 	useEffect(() => {

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -363,22 +363,17 @@ export default function BgRemove() {
 
 			{/* ドロップゾーン / プレビュー */}
 			{status === 'idle' && !sourceUrl ? (
-				<div
+				<button
+					type="button"
 					ref={dropZoneRef}
 					onDragOver={handleDragOver}
 					onDragLeave={handleDragLeave}
 					onDrop={handleDrop}
 					onClick={() => fileInputRef.current?.click()}
-					onKeyDown={(e) => {
-						if (e.key === 'Enter' || e.key === ' ')
-							fileInputRef.current?.click();
-					}}
-					role="button"
-					tabIndex={0}
 					className={`
-						relative flex flex-col items-center justify-center gap-4
+						w-full relative flex flex-col items-center justify-center gap-4
 						rounded-xl border-2 border-dashed p-12 cursor-pointer
-						transition-all duration-200
+						transition-all duration-200 bg-transparent
 						${
 							isDragOver
 								? 'border-primary bg-primary/5 scale-[1.01]'
@@ -405,7 +400,7 @@ export default function BgRemove() {
 						onChange={handleFileSelect}
 						className="hidden"
 					/>
-				</div>
+				</button>
 			) : (
 				<div className="space-y-4">
 					{/* 進捗バー */}

--- a/src/lib/tools/bg-remove.ts
+++ b/src/lib/tools/bg-remove.ts
@@ -1,0 +1,180 @@
+// bg-remove.ts — Worker ラッパ + Canvas 後処理
+// UIから推論詳細を隠蔽し、Blob入力 → PNG Blob出力 のシンプルなAPIを提供
+
+import type {
+	ModelMode,
+	WorkerRequest,
+	WorkerResponse,
+} from '@/workers/bg-remove.worker';
+
+export type { ModelMode };
+
+export type ProgressInfo = {
+	status: string;
+	progress: number;
+	loaded?: number;
+	total?: number;
+	file?: string;
+};
+
+// --- Worker シングルトン ---
+let worker: Worker | null = null;
+
+function getWorker(): Worker {
+	if (!worker) {
+		worker = new Worker(
+			new URL('../../workers/bg-remove.worker.ts', import.meta.url),
+			{ type: 'module' },
+		);
+	}
+	return worker;
+}
+
+/**
+ * ページ表示時に先行初期化（lazy preload）
+ * モデルを事前ダウンロードし、ドロップ即実行を可能にする
+ */
+export function preload(mode: ModelMode = 'high'): void {
+	const w = getWorker();
+	w.postMessage({
+		id: 'preload',
+		mode,
+		preloadOnly: true,
+	} satisfies WorkerRequest);
+}
+
+/**
+ * Worker を終了してリソースを解放
+ */
+export function terminateWorker(): void {
+	if (worker) {
+		worker.terminate();
+		worker = null;
+	}
+}
+
+/**
+ * 画像ファイルから背景を削除し、透過 PNG の Blob を返す
+ */
+export function removeBackground(
+	file: Blob,
+	mode: ModelMode,
+	onProgress?: (info: ProgressInfo) => void,
+): Promise<Blob> {
+	return new Promise((resolve, reject) => {
+		const w = getWorker();
+		const id = crypto.randomUUID();
+
+		const handler = (e: MessageEvent<WorkerResponse>) => {
+			const msg = e.data;
+
+			// progress は id に関係なく全て通知
+			if (msg.type === 'progress') {
+				onProgress?.({
+					status: msg.payload.status,
+					progress: msg.payload.progress ?? 0,
+					loaded: msg.payload.loaded,
+					total: msg.payload.total,
+					file: msg.payload.file,
+				});
+				return;
+			}
+
+			// id が一致するメッセージのみ処理
+			if (!('id' in msg) || msg.id !== id) return;
+
+			if (msg.type === 'result') {
+				w.removeEventListener('message', handler);
+
+				// RGBA ピクセルデータを Canvas 経由で PNG Blob に変換
+				const rgba = new Uint8ClampedArray(msg.data);
+				const imageData = new ImageData(rgba, msg.width, msg.height);
+
+				const canvas = document.createElement('canvas');
+				canvas.width = msg.width;
+				canvas.height = msg.height;
+				const ctx = canvas.getContext('2d');
+
+				if (!ctx) {
+					reject(new Error('Canvas 2D コンテキストの取得に失敗しました'));
+					return;
+				}
+
+				ctx.putImageData(imageData, 0, 0);
+
+				canvas.toBlob((blob) => {
+					if (blob) {
+						resolve(blob);
+					} else {
+						reject(new Error('PNG Blob の生成に失敗しました'));
+					}
+				}, 'image/png');
+			}
+
+			if (msg.type === 'error') {
+				w.removeEventListener('message', handler);
+				reject(new Error(msg.message));
+			}
+		};
+
+		w.addEventListener('message', handler);
+
+		// File/Blob → ArrayBuffer → Worker へ transferable 送信
+		file
+			.arrayBuffer()
+			.then((buffer) => {
+				w.postMessage(
+					{
+						id,
+						mode,
+						imageData: buffer,
+						mimeType: file.type || 'application/octet-stream',
+					} satisfies WorkerRequest,
+					[buffer],
+				);
+			})
+			.catch(reject);
+	});
+}
+
+/**
+ * 透過画像に背景色/画像を合成して新しい PNG Blob を返す
+ */
+export async function compositeBackground(
+	foregroundBlob: Blob,
+	background: { type: 'color'; value: string } | { type: 'image'; value: Blob },
+): Promise<Blob> {
+	const img = await createImageBitmap(foregroundBlob);
+	const canvas = document.createElement('canvas');
+	canvas.width = img.width;
+	canvas.height = img.height;
+	const ctx = canvas.getContext('2d');
+
+	if (!ctx) {
+		throw new Error('Canvas 2D コンテキストの取得に失敗しました');
+	}
+
+	// 背景を描画
+	if (background.type === 'color') {
+		ctx.fillStyle = background.value;
+		ctx.fillRect(0, 0, canvas.width, canvas.height);
+	} else {
+		const bgImg = await createImageBitmap(background.value);
+		ctx.drawImage(bgImg, 0, 0, canvas.width, canvas.height);
+		bgImg.close();
+	}
+
+	// 前景（透過済み）を重ねる
+	ctx.drawImage(img, 0, 0);
+	img.close();
+
+	return new Promise((resolve, reject) => {
+		canvas.toBlob((blob) => {
+			if (blob) {
+				resolve(blob);
+			} else {
+				reject(new Error('合成画像の生成に失敗しました'));
+			}
+		}, 'image/png');
+	});
+}

--- a/src/pages/bg-remove.astro
+++ b/src/pages/bg-remove.astro
@@ -1,0 +1,61 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import BgRemoveTool from '../components/tools/BgRemove.tsx';
+
+const schema = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "AI背景削除ツール",
+  "description": "AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。背景の透過・単色・画像差し替えに対応。",
+  "url": "https://tools.codelife.cafe/bg-remove",
+  "applicationCategory": "UtilityApplication",
+  "operatingSystem": "Any",
+  "offers": {
+    "@type": "Offer",
+    "price": "0",
+    "priceCurrency": "JPY"
+  },
+  "inLanguage": "ja"
+};
+---
+
+<ToolLayout
+  title="背景削除"
+  description="AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。"
+  path="/bg-remove"
+>
+  <Fragment slot="head">
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
+  </Fragment>
+
+  <BgRemoveTool client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4">
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>AIモデル（Transformers.js）を使用して、画像の背景を自動で削除します。すべての処理はブラウザ内で完結し、画像がサーバーに送信されることはありません。</p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>商品写真の背景を透過にしたい</li>
+          <li>プロフィール写真の背景を削除・差し替えしたい</li>
+          <li>プレゼン資料に使う画像の背景を除去したい</li>
+          <li>SNS用に人物だけを切り抜きたい</li>
+        </ul>
+        <div class="mt-4 space-y-2">
+          <h4 class="font-semibold text-foreground">2つのモードを搭載</h4>
+          <ul class="list-disc pl-5 space-y-1">
+            <li><strong>✨ 高精度モード（既定）</strong> — BEN2（約209MB）。アニメキャラや毛髪、複雑なエッジを高精度に処理するモデル。</li>
+            <li><strong>⚡ 高速モード</strong> — MODNet（約25.9MB）。人物・ポートレート特化モデル。人物写真を高速に処理。背景が複雑な場合やアニメ・商品写真には高精度モードを推奨。</li>
+          </ul>
+        </div>
+        <div class="mt-4 space-y-2">
+          <h4 class="font-semibold text-foreground">背景差し替え</h4>
+          <p>背景を透過以外にも、単色やカスタム画像に差し替えることができます。</p>
+        </div>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -182,9 +182,17 @@ const schema = {
         category="ユーティリティ"
         categoryColor="border-l-chart-2"
       />
+      <ToolCard
+        title="背景削除"
+        description="AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。"
+        href="/bg-remove"
+        icon="✂️"
+        category="AI/画像"
+        categoryColor="border-l-chart-5"
+      />
       <!-- Category summary card -->
       <div class="flex flex-col justify-center items-center rounded-xl border border-border bg-card p-5 text-center">
-        <p class="text-3xl font-bold text-primary mb-1">17</p>
+        <p class="text-3xl font-bold text-primary mb-1">18</p>
         <p class="text-sm text-muted-foreground mb-3">ツールを公開中</p>
         <div class="flex flex-wrap justify-center gap-1.5">
           <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">テキスト変換</span>
@@ -194,6 +202,7 @@ const schema = {
           <span class="text-xs rounded-full bg-chart-2/10 text-chart-2 px-2 py-0.5">ユーティリティ</span>
           <span class="text-xs rounded-full bg-chart-4/10 text-chart-4 px-2 py-0.5">データ処理</span>
           <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">エンコード/デコード</span>
+          <span class="text-xs rounded-full bg-chart-5/10 text-chart-5 px-2 py-0.5">AI/画像</span>
         </div>
       </div>
     </div>

--- a/src/pages/phone-formatter.astro
+++ b/src/pages/phone-formatter.astro
@@ -25,7 +25,7 @@ const schema = {
   path="/phone-formatter"
 >
   <Fragment slot="head">
-    <script type="application/ld+json" set:html={JSON.stringify(schema)} />
+    <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
   </Fragment>
 
   <div class="mt-8">

--- a/src/workers/bg-remove.worker.ts
+++ b/src/workers/bg-remove.worker.ts
@@ -133,7 +133,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
 			const { width, height, data } = output;
 
 			// ArrayBuffer として transferable 送信
-			const buffer = (data as Uint8ClampedArray).buffer.slice(0);
+			const buffer = (data as Uint8ClampedArray).buffer.slice(0) as ArrayBuffer;
 
 			self.postMessage(
 				{
@@ -143,7 +143,7 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
 					height,
 					data: buffer,
 				} satisfies WorkerResultMessage,
-				[buffer],
+				{ transfer: [buffer] },
 			);
 		} finally {
 			URL.revokeObjectURL(url);

--- a/src/workers/bg-remove.worker.ts
+++ b/src/workers/bg-remove.worker.ts
@@ -11,6 +11,11 @@ if (typeof location !== 'undefined' && location.hostname !== 'localhost') {
 env.allowLocalModels = false;
 env.useBrowserCache = true;
 
+// フェッチが中断された場合などのWorker内未処理拒否をサイレントに抑制
+self.addEventListener('unhandledrejection', (event) => {
+	event.preventDefault();
+});
+
 // --- モデルレジストリ ---
 const MODELS = {
 	fast: {

--- a/src/workers/bg-remove.worker.ts
+++ b/src/workers/bg-remove.worker.ts
@@ -1,0 +1,159 @@
+// bg-remove.worker.ts — 背景削除推論を Web Worker に隔離
+// Transformers.js v4 の background-removal パイプラインを使用
+import { env, pipeline } from '@huggingface/transformers';
+
+// --- モデル配信設定 ---
+// Cloudflare R2 (models.tools.codelife.cafe) からモデルを配信。
+// ローカル開発時は HuggingFace CDN にフォールバック。
+if (typeof location !== 'undefined' && location.hostname !== 'localhost') {
+	env.remoteHost = 'https://models.tools.codelife.cafe';
+}
+env.allowLocalModels = false;
+env.useBrowserCache = true;
+
+// --- モデルレジストリ ---
+const MODELS = {
+	fast: {
+		id: 'onnx-community/modnet-webnn',
+		dtype: 'fp32' as const, // float32: ~25.9MB（高精度化）
+	},
+	high: {
+		id: 'onnx-community/BEN2-ONNX',
+		dtype: 'fp16' as const, // fp16: ~209MB
+	},
+} as const;
+
+export type ModelMode = 'fast' | 'high';
+
+// --- メッセージ型定義 ---
+export interface WorkerRequest {
+	id: string;
+	mode: ModelMode;
+	imageData?: ArrayBuffer;
+	mimeType?: string;
+	preloadOnly?: boolean;
+}
+
+export interface WorkerProgressMessage {
+	type: 'progress';
+	payload: {
+		status: string;
+		progress?: number;
+		loaded?: number;
+		total?: number;
+		file?: string;
+	};
+}
+
+export interface WorkerResultMessage {
+	type: 'result';
+	id: string;
+	width: number;
+	height: number;
+	data: ArrayBuffer; // RGBA Uint8ClampedArray as transferable
+}
+
+export interface WorkerErrorMessage {
+	type: 'error';
+	id: string;
+	message: string;
+}
+
+export interface WorkerReadyMessage {
+	type: 'ready';
+	id: string;
+}
+
+export type WorkerResponse =
+	| WorkerProgressMessage
+	| WorkerResultMessage
+	| WorkerErrorMessage
+	| WorkerReadyMessage;
+
+// --- パイプライン管理 ---
+// biome-ignore lint/suspicious/noExplicitAny: Transformers.js pipeline type is complex
+let remover: any = null;
+let currentMode: ModelMode | null = null;
+
+async function ensurePipeline(mode: ModelMode) {
+	if (remover && currentMode === mode) return remover;
+
+	const model = MODELS[mode];
+
+	// Worker 内は WebGPU 不安定を避け wasm 固定
+	remover = await pipeline('background-removal', model.id, {
+		device: 'wasm',
+		dtype: model.dtype,
+		progress_callback: (p: {
+			status: string;
+			progress?: number;
+			loaded?: number;
+			total?: number;
+			file?: string;
+		}) => {
+			self.postMessage({
+				type: 'progress',
+				payload: p,
+			} satisfies WorkerProgressMessage);
+		},
+	});
+
+	currentMode = mode;
+	return remover;
+}
+
+// --- メッセージハンドラ ---
+self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
+	const { id, mode, imageData, mimeType, preloadOnly } = e.data;
+
+	try {
+		const pipe = await ensurePipeline(mode);
+
+		// preload のみ: パイプライン初期化だけして終了
+		if (preloadOnly) {
+			self.postMessage({ type: 'ready', id } satisfies WorkerReadyMessage);
+			return;
+		}
+
+		if (!imageData) {
+			throw new Error('画像データが指定されていません');
+		}
+
+		// Blob → URL → pipeline に渡す
+		const blob = new Blob([imageData], {
+			type: mimeType ?? 'application/octet-stream',
+		});
+		const url = URL.createObjectURL(blob);
+
+		try {
+			// background-removal パイプラインは RawImage (RGBA) を返す
+			const output = await pipe(url);
+
+			// RawImage から RGBA ピクセルデータを取得
+			const { width, height, data } = output;
+
+			// ArrayBuffer として transferable 送信
+			const buffer = (data as Uint8ClampedArray).buffer.slice(0);
+
+			self.postMessage(
+				{
+					type: 'result',
+					id,
+					width,
+					height,
+					data: buffer,
+				} satisfies WorkerResultMessage,
+				[buffer],
+			);
+		} finally {
+			URL.revokeObjectURL(url);
+		}
+	} catch (err: unknown) {
+		const message = err instanceof Error ? err.message : String(err);
+		self.postMessage({
+			type: 'error',
+			id,
+			message,
+		} satisfies WorkerErrorMessage);
+	}
+};

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from './fixtures/base';
 
 test.describe('背景削除ツール', () => {
-	test('ページが正常に読み込まれ、ドロップゾーンが表示される', async ({ page, createToolPage }) => {
+	test('ページが正常に読み込まれ、ドロップゾーンが表示される', async ({
+		page,
+		createToolPage,
+	}) => {
 		const toolPage = createToolPage('bg-remove');
 		await toolPage.goto();
 
@@ -12,7 +15,10 @@ test.describe('背景削除ツール', () => {
 		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible();
 	});
 
-	test('モード切替UIが表示され、デフォルトで高精度モードになっている', async ({ page, createToolPage }) => {
+	test('モード切替UIが表示され、デフォルトで高精度モードになっている', async ({
+		page,
+		createToolPage,
+	}) => {
 		const toolPage = createToolPage('bg-remove');
 		await toolPage.goto();
 
@@ -24,12 +30,16 @@ test.describe('背景削除ツール', () => {
 		// デフォルトで高精度モードの表示
 		const modeLabel = page.locator('label[for="mode-switch"]');
 		await expect(modeLabel).toContainText('✨ 高精度モード');
-		await expect(page.getByText('BEN2（極めて高精度・アニメ対応）≈ 209MB')).toBeVisible();
+		await expect(
+			page.getByText('BEN2（極めて高精度・アニメ対応）≈ 209MB'),
+		).toBeVisible();
 
 		// スイッチをOFFにして高速モードに切り替え
 		await modeSwitch.click();
 		await expect(modeLabel).toContainText('⚡ 高速モード');
-		await expect(page.getByText('MODNet（高速・バランス型）≈ 25.9MB')).toBeVisible();
+		await expect(
+			page.getByText('MODNet（人物特化・高速）≈ 25.9MB'),
+		).toBeVisible();
 	});
 
 	test('セキュリティバッジが表示される', async ({ page, createToolPage }) => {

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -1,0 +1,56 @@
+import { expect, test } from './fixtures/base';
+
+test.describe('背景削除ツール', () => {
+	test('ページが正常に読み込まれ、ドロップゾーンが表示される', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('bg-remove');
+		await toolPage.goto();
+
+		// h1 タイトル確認
+		await expect(page.locator('h1').first()).toContainText('背景削除');
+
+		// ドロップゾーンが表示される
+		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible();
+	});
+
+	test('モード切替UIが表示され、デフォルトで高精度モードになっている', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('bg-remove');
+		await toolPage.goto();
+
+		// モード切替スイッチが存在する
+		const modeSwitch = page.getByRole('switch');
+		await expect(modeSwitch).toBeVisible();
+		await expect(modeSwitch).toBeChecked(); // デフォルトで高精度モード (checked = true)
+
+		// デフォルトで高精度モードの表示
+		const modeLabel = page.locator('label[for="mode-switch"]');
+		await expect(modeLabel).toContainText('✨ 高精度モード');
+		await expect(page.getByText('BEN2（極めて高精度・アニメ対応）≈ 209MB')).toBeVisible();
+
+		// スイッチをOFFにして高速モードに切り替え
+		await modeSwitch.click();
+		await expect(modeLabel).toContainText('⚡ 高速モード');
+		await expect(page.getByText('MODNet（高速・バランス型）≈ 25.9MB')).toBeVisible();
+	});
+
+	test('セキュリティバッジが表示される', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('bg-remove');
+		await toolPage.goto();
+
+		// SafetyBadge の確認
+		await expect(
+			page.getByRole('button', { name: /セキュリティ情報を表示/ }),
+		).toBeVisible();
+	});
+
+	test('使い方セクションが開閉できる', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('bg-remove');
+		await toolPage.goto();
+
+		const usageDetails = page.getByText('使い方・ユースケース');
+		await expect(usageDetails).toBeVisible();
+
+		// details を開く
+		await usageDetails.click();
+		await expect(page.getByText('商品写真の背景を透過にしたい')).toBeVisible();
+	});
+});

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -2,39 +2,33 @@ import { expect, test } from './fixtures/base';
 
 test.describe('背景削除ツール', () => {
 	test.beforeEach(async ({ page }) => {
-		// AIモデルのダウンロードをブロックして networkidle を確保
+		// AIモデルのダウンロードリクエストをブロック（Worker含む）
 		await page.route('**/*.onnx*', (route) => route.abort());
 		await page.route('**/*huggingface*', (route) => route.abort());
+		await page.route('**/*hf.co*', (route) => route.abort());
 		await page.route('**/*models.tools.codelife*', (route) => route.abort());
+		// React Island のハイドレーション完了後にアサートできるよう domcontentloaded で待機
+		await page.goto('/bg-remove', { waitUntil: 'domcontentloaded' });
+		// ドロップゾーンが表示されるまで待つ（Reactハイドレーション完了の目印）
+		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible({
+			timeout: 10000,
+		});
 	});
 
 	test('ページが正常に読み込まれ、ドロップゾーンが表示される', async ({
 		page,
-		createToolPage,
 	}) => {
-		const toolPage = createToolPage('bg-remove');
-		await toolPage.goto();
-
-		// h1 タイトル確認
 		await expect(page.locator('h1').first()).toContainText('背景削除');
-
-		// ドロップゾーンが表示される
 		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible();
 	});
 
 	test('モード切替UIが表示され、デフォルトで高精度モードになっている', async ({
 		page,
-		createToolPage,
 	}) => {
-		const toolPage = createToolPage('bg-remove');
-		await toolPage.goto();
-
-		// モード切替スイッチが存在する
 		const modeSwitch = page.getByRole('switch');
 		await expect(modeSwitch).toBeVisible();
 		await expect(modeSwitch).toBeChecked(); // デフォルトで高精度モード (checked = true)
 
-		// デフォルトで高精度モードの表示
 		const modeLabel = page.locator('label[for="mode-switch"]');
 		await expect(modeLabel).toContainText('✨ 高精度モード');
 		await expect(
@@ -49,24 +43,16 @@ test.describe('背景削除ツール', () => {
 		).toBeVisible();
 	});
 
-	test('セキュリティバッジが表示される', async ({ page, createToolPage }) => {
-		const toolPage = createToolPage('bg-remove');
-		await toolPage.goto();
-
-		// SafetyBadge の確認
+	test('セキュリティバッジが表示される', async ({ page }) => {
 		await expect(
 			page.getByRole('button', { name: /セキュリティ情報を表示/ }),
 		).toBeVisible();
 	});
 
-	test('使い方セクションが開閉できる', async ({ page, createToolPage }) => {
-		const toolPage = createToolPage('bg-remove');
-		await toolPage.goto();
-
+	test('使い方セクションが開閉できる', async ({ page }) => {
 		const usageDetails = page.getByText('使い方・ユースケース');
 		await expect(usageDetails).toBeVisible();
 
-		// details を開く
 		await usageDetails.click();
 		await expect(page.getByText('商品写真の背景を透過にしたい')).toBeVisible();
 	});

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -1,6 +1,13 @@
 import { expect, test } from './fixtures/base';
 
 test.describe('背景削除ツール', () => {
+	test.beforeEach(async ({ page }) => {
+		// AIモデルのダウンロードをブロックして networkidle を確保
+		await page.route('**/*.onnx*', (route) => route.abort());
+		await page.route('**/*huggingface*', (route) => route.abort());
+		await page.route('**/*models.tools.codelife*', (route) => route.abort());
+	});
+
 	test('ページが正常に読み込まれ、ドロップゾーンが表示される', async ({
 		page,
 		createToolPage,

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -2,11 +2,12 @@ import { expect, test } from './fixtures/base';
 
 test.describe('背景削除ツール', () => {
 	test.beforeEach(async ({ page }) => {
-		// AIモデルのダウンロードリクエストをブロック（Worker含む）
-		await page.route('**/*.onnx*', (route) => route.abort());
-		await page.route('**/*huggingface*', (route) => route.abort());
-		await page.route('**/*hf.co*', (route) => route.abort());
-		await page.route('**/*models.tools.codelife*', (route) => route.abort());
+		// AIモデルのダウンロードリクエストをブロック（Worker含む: context.route でWorkerリクエストも捕捉）
+		const context = page.context();
+		await context.route('**/*.onnx*', (route) => route.abort());
+		await context.route('**/*huggingface*', (route) => route.abort());
+		await context.route('**/*hf.co*', (route) => route.abort());
+		await context.route('**/*models.tools.codelife*', (route) => route.abort());
 		// React Island のハイドレーション完了後にアサートできるよう domcontentloaded で待機
 		await page.goto('/bg-remove', { waitUntil: 'domcontentloaded' });
 		// ドロップゾーンが表示されるまで待つ（Reactハイドレーション完了の目印）


### PR DESCRIPTION
## Summary

- Transformers.js v4 の `background-removal` パイプラインを Web Worker に隔離し、完全ローカルで画像背景を削除するツールを実装
- MODNet（人物特化・高速 ~25.9MB）/ BEN2（高精度 ~219MB）の2モードを UI で切替可能
- Cloudflare R2（`models.tools.codelife.cafe`）からモデル配信、localhost は HuggingFace CDN フォールバック

## 主な変更

| ファイル | 内容 |
|---|---|
| `src/workers/bg-remove.worker.ts` | 推論 Worker。R2 remoteHost 設定、MIME タイプ動的処理 |
| `src/lib/tools/bg-remove.ts` | Worker ラッパー。ArrayBuffer transferable で送信 |
| `src/components/tools/BgRemove.tsx` | React Island UI。MODNet を「人物特化」と明記 |
| `src/pages/bg-remove.astro` | ページシェル（ToolLayout + JSON-LD） |
| `scripts/upload-models-to-r2.sh` | HuggingFace → R2 アップロードスクリプト |
| `scripts/r2-cors.json` | R2 CORS 設定（Cloudflare 形式） |
| `tests/e2e/bg-remove.spec.ts` | Playwright E2E テスト |
| `.gitignore` | `.wrangler/`・`docs/superpowers/` を除外追加 |
| `CLAUDE.md` / `README.md` | アーキテクチャ・R2 運用手順を更新 |

## Test plan

- [ ] `npm run dev` でローカル起動、`/bg-remove` にアクセスして UI を確認
- [ ] 画像をドロップし、高速モード（MODNet）で背景削除が動作することを確認
- [ ] 高精度モード（BEN2）に切り替えて処理が完了することを確認
- [ ] 本番デプロイ後、`models.tools.codelife.cafe` からモデルが取得されることを Cloudflare Dashboard で確認
- [ ] `npx playwright test tests/e2e/bg-remove.spec.ts` でE2Eテストがパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)