### PR TITLE
fix(csp): allow blob images and R2/Hugging Face model domains in CSP

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,5 +1,5 @@
 /*
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com; font-src 'self' https://fonts.gstatic.com; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://pagead2.googlesyndication.com https://www.googletagservices.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; img-src 'self' data: blob: https:; connect-src 'self' https://pagead2.googlesyndication.com https://cloudflareinsights.com https://models.tools.codelife.cafe https://huggingface.co https://*.huggingface.co; font-src 'self' https://fonts.gstatic.com; frame-src https://googleads.g.doubleclick.net https://tpc.googlesyndication.com
   X-Content-Type-Options: nosniff
   X-Frame-Options: SAMEORIGIN
   Referrer-Policy: strict-origin-when-cross-origin


### PR DESCRIPTION
## 概要
背景削除ツールのデプロイ後に発生していた、Content Security Policy (CSP) による画像読み込み制限およびモデル取得エラーを修正します。

## 修正内容
`public/_headers` の `Content-Security-Policy` ヘッダーを以下の通り修正しました：

1. **`img-src` に `blob:` スキームを追加**
   - 背景削除の処理に利用される Blob URL からの画像を正しくブラウザ上に描画できるようにします。
2. **`connect-src` にモデル取得関連のドメインを追加**
   - カスタムモデルサーバー `https://models.tools.codelife.cafe` への接続を許可します。
   - 開発環境およびフォールバック用の `https://huggingface.co` と `https://*.huggingface.co` への接続を許可します。

## 検証内容
- `npm run build` をローカル環境で実行し、正常にビルドとService Workerの生成が完了することを確認しました。
