### PR TITLE
fix(bg-remove): 透明背景に戻すと画像が消えるバグを修正

### DIFF
--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -93,15 +93,21 @@ export default function BgRemove() {
 
 	// --- URL クリーンアップ ---
 	useEffect(() => {
-		return () => { if (sourceUrl) URL.revokeObjectURL(sourceUrl); };
+		return () => {
+			if (sourceUrl) URL.revokeObjectURL(sourceUrl);
+		};
 	}, [sourceUrl]);
 
 	useEffect(() => {
-		return () => { if (resultUrl) URL.revokeObjectURL(resultUrl); };
+		return () => {
+			if (resultUrl) URL.revokeObjectURL(resultUrl);
+		};
 	}, [resultUrl]);
 
 	useEffect(() => {
-		return () => { if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current); };
+		return () => {
+			if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
+		};
 	}, []);
 
 	// --- ファイル検証 ---

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -83,6 +83,7 @@ export default function BgRemove() {
 	const [isDragOver, setIsDragOver] = useState(false);
 	const fileInputRef = useRef<HTMLInputElement>(null);
 	const dropZoneRef = useRef<HTMLButtonElement>(null);
+	const compositeUrlRef = useRef<string | null>(null);
 
 	// --- 先行初期化 ---
 	useEffect(() => {
@@ -92,12 +93,16 @@ export default function BgRemove() {
 
 	// --- URL クリーンアップ ---
 	useEffect(() => {
-		return () => {
-			if (sourceUrl) URL.revokeObjectURL(sourceUrl);
-			if (resultUrl) URL.revokeObjectURL(resultUrl);
-			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
-		};
-	}, [sourceUrl, resultUrl, compositeUrl]);
+		return () => { if (sourceUrl) URL.revokeObjectURL(sourceUrl); };
+	}, [sourceUrl]);
+
+	useEffect(() => {
+		return () => { if (resultUrl) URL.revokeObjectURL(resultUrl); };
+	}, [resultUrl]);
+
+	useEffect(() => {
+		return () => { if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current); };
+	}, []);
 
 	// --- ファイル検証 ---
 	const validateFile = useCallback((file: File): string | null => {
@@ -119,7 +124,8 @@ export default function BgRemove() {
 
 			// 既存の結果をクリア
 			if (resultUrl) URL.revokeObjectURL(resultUrl);
-			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+			if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
+			compositeUrlRef.current = null;
 			setResultBlob(null);
 			setResultUrl(null);
 			setCompositeUrl(null);
@@ -146,7 +152,7 @@ export default function BgRemove() {
 				setStatus('error');
 			}
 		},
-		[resultUrl, compositeUrl],
+		[resultUrl],
 	);
 
 	// --- ファイル処理 ---
@@ -246,7 +252,8 @@ export default function BgRemove() {
 	// --- 背景差し替え ---
 	useEffect(() => {
 		if (!resultBlob || bgOption.type === 'transparent') {
-			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+			if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
+			compositeUrlRef.current = null;
 			setCompositeUrl(null);
 			return;
 		}
@@ -254,14 +261,16 @@ export default function BgRemove() {
 		let cancelled = false;
 		compositeBackground(resultBlob, bgOption).then((blob) => {
 			if (cancelled) return;
-			if (compositeUrl) URL.revokeObjectURL(compositeUrl);
-			setCompositeUrl(URL.createObjectURL(blob));
+			if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
+			const newUrl = URL.createObjectURL(blob);
+			compositeUrlRef.current = newUrl;
+			setCompositeUrl(newUrl);
 		});
 
 		return () => {
 			cancelled = true;
 		};
-	}, [resultBlob, bgOption, compositeUrl]);
+	}, [resultBlob, bgOption]);
 
 	// --- ダウンロード ---
 	const handleDownload = useCallback(() => {
@@ -282,7 +291,8 @@ export default function BgRemove() {
 	const handleReset = useCallback(() => {
 		if (sourceUrl) URL.revokeObjectURL(sourceUrl);
 		if (resultUrl) URL.revokeObjectURL(resultUrl);
-		if (compositeUrl) URL.revokeObjectURL(compositeUrl);
+		if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
+		compositeUrlRef.current = null;
 
 		setSourceFile(null);
 		setSourceUrl(null);
@@ -293,7 +303,7 @@ export default function BgRemove() {
 		setProgress(null);
 		setError(null);
 		setBgOption({ type: 'transparent' });
-	}, [sourceUrl, resultUrl, compositeUrl]);
+	}, [sourceUrl, resultUrl]);
 
 	// --- 背景画像アップロード ---
 	const bgImageInputRef = useRef<HTMLInputElement>(null);


### PR DESCRIPTION
## Summary

- URLクリーンアップ `useEffect` が `[sourceUrl, resultUrl, compositeUrl]` を1つのeffectでまとめて依存配列に持っていたため、`compositeUrl` が変わるたびに `resultUrl` も revoke されていた
- 透明→色選択時に `compositeUrl` が更新→effectのクリーンアップで `resultUrl` が失効→透明に戻すと `resultUrl` が無効で画像が表示されなくなっていた
- 合わせて、`compositeUrl` が合成effectの依存配列に入っていたことで、合成完了→`setCompositeUrl`→effect再実行という無限ループも発生していた

**修正内容:**
- URLクリーンアップeffectを `sourceUrl`・`resultUrl` それぞれ独立したeffectに分離
- `compositeUrl` の管理を `compositeUrlRef`（useRef）で行うことで、合成effectの依存配列から除去し不要な再実行を防止
- `processImage`・`handleReset` でも ref 経由で compositeUrl を revoke するよう更新

## Test plan

- [ ] 背景削除を実行する
- [ ] 「背景を変更」で任意の色（例: 白）を選択 → 合成画像が表示される
- [ ] 透明（市松模様）ボタンをクリック → 背景削除後の透過PNG画像が表示される（消えない）
- [ ] 再度色を選択→透明を繰り返しても問題ないことを確認

https://claude.ai/code/session_01NAtgo8jEdLfjRg31T623Jq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAtgo8jEdLfjRg31T623Jq)_