### PR TITLE
改善ポイントの修正: 死んだJSON-LD・SSRエラー・不安定なdiffキー・固定著作権年

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ src/pages/[name].astro           # ページシェル（ToolLayout + JSON-LD）
 src/workers/[name].worker.ts     # 重量級処理のみ（例: bg-remove）
 ```
 
-`ToolLayout.astro` を使うと SafetyBadge・`<slot name="usage">` が自動挿入される。JSON-LDは `ToolLayout` 内の `ToolJsonLd` コンポーネントが `title`/`description`/`path` から自動生成するため、個別ページでの追加は不要（`bg-remove.astro` の手動追加は重複に注意）。
+`ToolLayout.astro` を使うと SafetyBadge・`<slot name="usage">` が自動挿入される。JSON-LDは `ToolLayout` 内の `ToolJsonLd` コンポーネントが `title`/`description`/`path` から自動生成するため、個別ページでの追加は不要（`ToolLayout` は `slot="head"` を転送しないため、ページ側で追加しても描画されない）。
 
 ### React Island のライフサイクル
 

--- a/src/components/layout/Footer.astro
+++ b/src/components/layout/Footer.astro
@@ -1,4 +1,5 @@
 ---
+const currentYear = new Date().getFullYear();
 ---
 
 <footer class="border-t border-border bg-muted/30 mt-auto">
@@ -15,7 +16,7 @@
         </a>
       </div>
       <p class="text-sm text-muted-foreground">
-        © 2026 <a href="https://codelife.cafe" class="hover:text-foreground transition-colors">CODE:LIFE</a> / marumo
+        © {currentYear} <a href="https://codelife.cafe" class="hover:text-foreground transition-colors">CODE:LIFE</a> / marumo
       </p>
     </div>
   </div>

--- a/src/components/tools/TextDiff.tsx
+++ b/src/components/tools/TextDiff.tsx
@@ -261,9 +261,9 @@ export default function TextDiff() {
 									テキストA（変更前）
 								</div>
 								<div className="w-full min-w-max">
-									{splitLines.left.map((line, i) => (
+									{splitLines.left.map((line) => (
 										<div
-											key={`l-${line.lineNum}-${i}`}
+											key={`l-${line.lineNum}`}
 											className={`flex min-w-max ${line.type === 'removed' ? 'bg-red-500/10 text-red-700 dark:text-red-300' : ''}`}
 										>
 											<span className="inline-block w-10 shrink-0 text-right pr-2 text-xs text-muted-foreground select-none border-r border-border/50 py-0.5 bg-muted/30">
@@ -287,9 +287,9 @@ export default function TextDiff() {
 									テキストB（変更後）
 								</div>
 								<div className="w-full min-w-max">
-									{splitLines.right.map((line, i) => (
+									{splitLines.right.map((line) => (
 										<div
-											key={`r-${line.lineNum}-${i}`}
+											key={`r-${line.lineNum}`}
 											className={`flex min-w-max ${line.type === 'added' ? 'bg-green-500/10 text-green-700 dark:text-green-300' : ''}`}
 										>
 											<span className="inline-block w-10 shrink-0 text-right pr-2 text-xs text-muted-foreground select-none border-r border-border/50 py-0.5 bg-muted/30">
@@ -311,9 +311,11 @@ export default function TextDiff() {
 						</div>
 					) : (
 						<div className="rounded-xl border border-border bg-card overflow-hidden font-mono-tool text-sm">
-							{unifiedLines.map((line, i) => (
+							{unifiedLines.map((line) => (
 								<div
-									key={`u-${i}`}
+									key={
+										line.lineA !== null ? `a-${line.lineA}` : `b-${line.lineB}`
+									}
 									className={`flex whitespace-pre-wrap break-all ${
 										line.type === 'added'
 											? 'bg-green-500/10 text-green-700 dark:text-green-300'

--- a/src/lib/settings/storage.ts
+++ b/src/lib/settings/storage.ts
@@ -11,6 +11,8 @@ const DEFAULT_SETTINGS: UserSettings = {
 };
 
 export function saveSettings(settings: UserSettings): void {
+	if (typeof window === 'undefined') return;
+
 	try {
 		localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
 	} catch (e) {
@@ -19,6 +21,8 @@ export function saveSettings(settings: UserSettings): void {
 }
 
 export function loadSettings(): UserSettings {
+	if (typeof window === 'undefined') return DEFAULT_SETTINGS;
+
 	try {
 		const data = localStorage.getItem(STORAGE_KEY);
 		if (!data) return DEFAULT_SETTINGS;

--- a/src/pages/bg-remove.astro
+++ b/src/pages/bg-remove.astro
@@ -1,22 +1,6 @@
 ---
 import ToolLayout from '../components/common/ToolLayout.astro';
 import BgRemoveTool from '../components/tools/BgRemove.tsx';
-
-const schema = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "AI背景削除ツール",
-  "description": "AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。背景の透過・単色・画像差し替えに対応。",
-  "url": "https://tools.codelife.cafe/bg-remove",
-  "applicationCategory": "UtilityApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "JPY"
-  },
-  "inLanguage": "ja"
-};
 ---
 
 <ToolLayout
@@ -24,10 +8,6 @@ const schema = {
   description="AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。"
   path="/bg-remove"
 >
-  <Fragment slot="head">
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
-  </Fragment>
-
   <BgRemoveTool client:load />
 
   <div slot="usage" class="mt-8">

--- a/src/pages/phone-formatter.astro
+++ b/src/pages/phone-formatter.astro
@@ -1,22 +1,6 @@
 ---
 import ToolLayout from '../components/common/ToolLayout.astro';
 import PhoneFormatterPage from '../components/phone-formatter/PhoneFormatterPage';
-
-const schema = {
-  "@context": "https://schema.org",
-  "@type": "SoftwareApplication",
-  "name": "電話番号フォーマッタ & E.164変換",
-  "description": "日本の電話番号をE.164・国際表記・国内表記にワンクリック変換。固定電話・携帯・IP電話を自動判別。CSV一括変換対応。完全クライアントサイド処理で電話番号データも安心。",
-  "url": "https://tools.codelife.cafe/phone-formatter",
-  "applicationCategory": "UtilityApplication",
-  "operatingSystem": "Any",
-  "offers": {
-    "@type": "Offer",
-    "price": "0",
-    "priceCurrency": "JPY"
-  },
-  "inLanguage": "ja"
-};
 ---
 
 <ToolLayout
@@ -24,10 +8,6 @@ const schema = {
   description="日本の電話番号をE.164・国際表記・国内表記にワンクリック変換。固定電話・携帯・IP電話を自動判別。CSV一括変換対応。完全クライアントサイド処理で電話番号データも安心。"
   path="/phone-formatter"
 >
-  <Fragment slot="head">
-    <script is:inline type="application/ld+json" set:html={JSON.stringify(schema)} />
-  </Fragment>
-
   <div class="mt-8">
     <PhoneFormatterPage client:load />
   </div>


### PR DESCRIPTION
## Summary

コードベースをスキャンして見つけた4つの改善点を修正しました。

- **死んでいた JSON-LD を削除**: `bg-remove.astro` / `phone-formatter.astro` は独自の構造化データを `<Fragment slot="head">` で渡していましたが、`ToolLayout.astro` は `slot="head"` を `BaseLayout` に転送していないため、ビルド後の HTML を確認したところこれらは一切描画されていませんでした（デッドコード）。各ページは `ToolJsonLd` が自動生成する schema のみで構成されるよう整理し、CLAUDE.md の説明も実態に合わせて更新しました。
- **`lib/settings/storage.ts` の SSR 対応**: `loadSettings`/`saveSettings` が `localStorage` に無条件アクセスしており、`npm run build`（CsvFixer のプリレンダー時）に `ReferenceError: localStorage is not defined` が発生し `console.error` でログが汚染されていました。`PhoneFormatterPage.tsx` と同じ `typeof window === 'undefined'` ガードを追加。
- **`TextDiff.tsx` の React key 安定化**: 配列インデックスを含むキーを Biome が警告（`noArrayIndexKey` x3）していたため、各行に対して一意かつ安定な行番号ベースのキーに変更しました。
- **Footer の著作権年を動的化**: ハードコードされた `© 2026` を `new Date().getFullYear()` に変更。

## Test plan

- [x] `npx biome check src/ tests/` — エラー・警告なし
- [x] `npm run build` — `localStorage is not defined` のエラーログが解消されたことを確認
- [x] ビルド後の `dist/bg-remove/index.html` / `dist/phone-formatter/index.html` を確認し、`ToolJsonLd` 由来の JSON-LD が正しく1つだけ出力されることを確認
- [ ] E2E テスト（このサンドボックス環境では Playwright ブラウザのインストールがネットワーク制限により不可）


---
_Generated by [Claude Code](https://claude.ai/code/session_012jXeJLvw6YRh6pfqNt7wEg)_