### PR TITLE
Introduce shared tool catalog and wire up UI/search to use it; bg-remove UX & worker cleanup; add `check` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
 		"preview:ci": "astro preview",
 		"lint": "biome check src/ tests/",
 		"lint:fix": "biome check --write src/ tests/",
-		"astro": "astro"
+		"astro": "astro",
+		"check": "astro check && biome check src/ tests/"
 	},
 	"dependencies": {
 		"@astrojs/react": "^5.0.7",

--- a/src/components/common/SearchModal.tsx
+++ b/src/components/common/SearchModal.tsx
@@ -2,147 +2,7 @@ import { Search } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
-type Tool = {
-	id: string;
-	name: string;
-	description: string;
-	href: string;
-	icon: string;
-	category: string;
-};
-
-const TOOLS: Tool[] = [
-	{
-		id: 'zenkaku-hankaku',
-		name: '全角↔半角変換',
-		description: 'カタカナ・英数字・記号の全角半角を一括変換',
-		href: '/zenkaku-hankaku',
-		icon: '🔄',
-		category: 'テキスト変換',
-	},
-	{
-		id: 'char-count',
-		name: '文字数カウント',
-		description: '文字数・バイト数・行数をリアルタイムカウント。Shift-JIS対応',
-		href: '/char-count',
-		icon: '🔢',
-		category: 'テキスト解析',
-	},
-	{
-		id: 'json-formatter',
-		name: 'JSON整形',
-		description: 'JSONの整形・圧縮・構文チェック',
-		href: '/json-formatter',
-		icon: '{ }',
-		category: '開発ツール',
-	},
-	{
-		id: 'text-diff',
-		name: 'テキスト差分比較',
-		description: '2つのテキストの違いをハイライト表示',
-		href: '/text-diff',
-		icon: '📝',
-		category: 'テキスト解析',
-	},
-	{
-		id: 'qr-generator',
-		name: 'QRコード生成',
-		description: 'URLやテキストからQRコードを即座に生成',
-		href: '/qr-generator',
-		icon: '📱',
-		category: '生成ツール',
-	},
-	{
-		id: 'wareki-converter',
-		name: '和暦↔西暦変換',
-		description: '明治〜令和の和暦と西暦を相互変換。干支・年齢も同時表示',
-		href: '/wareki-converter',
-		icon: '🎌',
-		category: 'ユーティリティ',
-	},
-	{
-		id: 'base64',
-		name: 'Base64変換',
-		description: 'テキスト・ファイルのBase64エンコード/デコード',
-		href: '/base64',
-		icon: '🔐',
-		category: 'ユーティリティ',
-	},
-	{
-		id: 'url-encoder',
-		name: 'URLエンコード/デコード',
-		description: '日本語を含むURLやクエリを安全に双方向変換',
-		href: '/url-encoder',
-		icon: '🔗',
-		category: 'エンコード/デコード',
-	},
-	{
-		id: 'regex-tester',
-		name: '正規表現テスター',
-		description: '正規表現のリアルタイムテスト・マッチ確認・置換',
-		href: '/regex-tester',
-		icon: '✨',
-		category: '開発ツール',
-	},
-	{
-		id: 'sql-formatter',
-		name: 'SQL整形・フォーマッター',
-		description: 'SQLの整形・圧縮。MySQL/PostgreSQL等の方言対応',
-		href: '/sql-formatter',
-		icon: '💾',
-		category: '開発ツール',
-	},
-	{
-		id: 'dummy-data',
-		name: 'ダミーデータ生成',
-		description: '日本語の氏名・電話番号等のダミーデータを一括生成',
-		href: '/dummy-data',
-		icon: '🎲',
-		category: '生成ツール',
-	},
-	{
-		id: 'masking',
-		name: '個人情報マスキング',
-		description: 'メール・電話番号・カード番号等を自動検出してマスキング',
-		href: '/masking',
-		icon: '🛡️',
-		category: 'データ処理',
-	},
-	{
-		id: 'csv-editor',
-		name: 'CSVビューア/エディタ',
-		description: 'CSV/TSVをテーブル形式で閲覧・編集・加工',
-		href: '/csv-editor',
-		icon: '📊',
-		category: 'データ処理',
-	},
-	{
-		id: 'unicode-converter',
-		name: 'ユニコード変換',
-		description: 'テキストとユニコードエスケープシーケンスを相互変換',
-		href: '/unicode-converter',
-		icon: '🔣',
-		category: 'テキスト変換',
-	},
-	{
-		id: 'csv-fixer',
-		name: 'CSV文字化け修復',
-		description:
-			'CSVのShift_JIS文字化けをブラウザで即座に修復。自動検出・BOM付与対応。',
-		href: '/csv-fixer',
-		icon: '📝',
-		category: 'データ処理',
-	},
-	{
-		id: 'phone-formatter',
-		name: '電話番号フォーマッタ',
-		description:
-			'日本の電話番号をE.164・国際表記・国内表記に即変換。CSV一括変換対応。',
-		href: '/phone-formatter',
-		icon: '📞',
-		category: 'データ処理',
-	},
-];
+import { toolCatalog } from '@/lib/tools/catalog';
 
 export default function SearchModal() {
 	const [isOpen, setIsOpen] = useState(false);
@@ -151,12 +11,17 @@ export default function SearchModal() {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const filteredTools = query
-		? TOOLS.filter((tool) =>
-				(tool.name + tool.description + tool.category)
+		? toolCatalog.filter((tool) =>
+				(
+					tool.title +
+					tool.description +
+					tool.category +
+					tool.keywords.join(' ')
+				)
 					.toLowerCase()
 					.includes(query.toLowerCase()),
 			)
-		: TOOLS;
+		: toolCatalog;
 
 	// Search trigger & Keyboard shortcuts
 	useEffect(() => {
@@ -198,6 +63,8 @@ export default function SearchModal() {
 		if (!isOpen) return;
 
 		const handleModalKeyDown = (e: KeyboardEvent) => {
+			if (filteredTools.length === 0) return;
+
 			if (e.key === 'ArrowDown') {
 				e.preventDefault();
 				setActiveIndex((prev) => (prev + 1) % filteredTools.length);
@@ -206,7 +73,7 @@ export default function SearchModal() {
 				setActiveIndex(
 					(prev) => (prev - 1 + filteredTools.length) % filteredTools.length,
 				);
-			} else if (e.key === 'Enter' && filteredTools.length > 0) {
+			} else if (e.key === 'Enter') {
 				e.preventDefault();
 				window.location.href = filteredTools[activeIndex]?.href || '/';
 			}
@@ -279,7 +146,7 @@ export default function SearchModal() {
 											<span
 												className={`font-medium ${index === activeIndex ? 'text-primary' : 'text-foreground'}`}
 											>
-												{tool.name}
+												{tool.title}
 											</span>
 											<span className="text-xs opacity-80">
 												{tool.description}

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -1,5 +1,5 @@
 ---
-import { toolCatalog } from '../../lib/tools/catalog';
+import { toolCatalog } from '@/lib/tools/catalog';
 ---
 
 <nav aria-label="ツール一覧">

--- a/src/components/layout/Navigation.astro
+++ b/src/components/layout/Navigation.astro
@@ -1,24 +1,15 @@
 ---
-// Navigation component placeholder
+import { toolCatalog } from '../../lib/tools/catalog';
 ---
 
 <nav aria-label="ツール一覧">
   <ul class="flex flex-wrap gap-2">
-    <li><a href="/zenkaku-hankaku" class="text-sm text-muted-foreground hover:text-foreground transition-colors">全角↔半角変換</a></li>
-    <li><a href="/char-count" class="text-sm text-muted-foreground hover:text-foreground transition-colors">文字数カウント</a></li>
-    <li><a href="/json-formatter" class="text-sm text-muted-foreground hover:text-foreground transition-colors">JSON整形</a></li>
-    <li><a href="/qr-generator" class="text-sm text-muted-foreground hover:text-foreground transition-colors">QRコード生成</a></li>
-    <li><a href="/text-diff" class="text-sm text-muted-foreground hover:text-foreground transition-colors">テキスト差分比較</a></li>
-    <li><a href="/wareki-converter" class="text-sm text-muted-foreground hover:text-foreground transition-colors">和暦↔西暦変換</a></li>
-    <li><a href="/base64" class="text-sm text-muted-foreground hover:text-foreground transition-colors">Base64変換</a></li>
-    <li><a href="/url-encoder" class="text-sm text-muted-foreground hover:text-foreground transition-colors">URLエンコード/デコード</a></li>
-    <li><a href="/regex-tester" class="text-sm text-muted-foreground hover:text-foreground transition-colors">正規表現チェッカー</a></li>
-    <li><a href="/sql-formatter" class="text-sm text-muted-foreground hover:text-foreground transition-colors">SQLフォーマッター</a></li>
-    <li><a href="/dummy-data" class="text-sm text-muted-foreground hover:text-foreground transition-colors">ダミーデータ生成</a></li>
-    <li><a href="/masking" class="text-sm text-muted-foreground hover:text-foreground transition-colors">個人情報マスキング</a></li>
-    <li><a href="/csv-editor" class="text-sm text-muted-foreground hover:text-foreground transition-colors">CSVエディタ</a></li>
-    <li><a href="/unicode-converter" class="text-sm text-muted-foreground hover:text-foreground transition-colors">ユニコード変換</a></li>
-    <li><a href="/csv-fixer" class="text-sm text-muted-foreground hover:text-foreground transition-colors">CSV文字化け修復</a></li>
-    <li><a href="/phone-formatter" class="text-sm text-muted-foreground hover:text-foreground transition-colors">電話番号フォーマッタ</a></li>
+    {toolCatalog.map((tool) => (
+      <li>
+        <a href={tool.href} class="text-sm text-muted-foreground hover:text-foreground transition-colors">
+          {tool.title}
+        </a>
+      </li>
+    ))}
   </ul>
 </nav>

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -18,7 +18,6 @@ import {
 	compositeBackground,
 	type ModelMode,
 	type ProgressInfo,
-	preload,
 	removeBackground,
 	terminateWorker,
 } from '@/lib/tools/bg-remove';
@@ -85,9 +84,8 @@ export default function BgRemove() {
 	const dropZoneRef = useRef<HTMLButtonElement>(null);
 	const compositeUrlRef = useRef<string | null>(null);
 
-	// --- 先行初期化 ---
+	// --- Worker クリーンアップ ---
 	useEffect(() => {
-		preload('high');
 		return () => terminateWorker();
 	}, []);
 
@@ -333,6 +331,15 @@ export default function BgRemove() {
 
 	return (
 		<div className="space-y-6">
+			<div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-4 text-sm text-muted-foreground">
+				<p className="font-medium text-foreground">
+					画像はアップロードされません
+				</p>
+				<p className="mt-1 leading-relaxed">
+					処理はブラウザ内で実行します。初回実行時のみ、選択したモードのAIモデルを取得する通信が発生します。
+				</p>
+			</div>
+
 			{/* モード切替 */}
 			<div className="flex items-center justify-between rounded-xl border border-border bg-card p-4">
 				<div className="flex items-center gap-3">

--- a/src/lib/tools/bg-remove.ts
+++ b/src/lib/tools/bg-remove.ts
@@ -31,8 +31,8 @@ function getWorker(): Worker {
 }
 
 /**
- * ページ表示時に先行初期化（lazy preload）
- * モデルを事前ダウンロードし、ドロップ即実行を可能にする
+ * 明示的な先行初期化用。
+ * 通常はファイル選択後に removeBackground 経由で必要なモデルだけ読み込む。
  */
 export function preload(mode: ModelMode = 'high'): void {
 	const w = getWorker();

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -20,7 +20,7 @@ export type ToolCatalogItem = {
 	keywords: readonly string[];
 };
 
-export const toolCatalog = [
+export const toolCatalog: readonly ToolCatalogItem[] = [
 	{
 		id: 'zenkaku-hankaku',
 		title: '全角↔半角変換',
@@ -220,12 +220,23 @@ export const toolCatalog = [
 		categoryColor: 'border-l-chart-5',
 		keywords: ['背景削除', '透過', 'AI', '画像', 'アップロード不要'],
 	},
-] as const satisfies readonly ToolCatalogItem[];
+];
+
+// カテゴリーサマリーのチップ色（categoryColor の border-l-* と対になる bg/text クラス）
+// Tailwind の静的解析に拾わせるため、クラス名は literal で保持する
+const categoryChipColor: Record<ToolCategory, string> = {
+	テキスト変換: 'bg-primary/10 text-primary',
+	テキスト解析: 'bg-accent/10 text-accent',
+	開発ツール: 'bg-chart-1/10 text-chart-1',
+	生成ツール: 'bg-chart-3/10 text-chart-3',
+	ユーティリティ: 'bg-chart-2/10 text-chart-2',
+	'エンコード/デコード': 'bg-primary/10 text-primary',
+	データ処理: 'bg-chart-4/10 text-chart-4',
+	'AI/画像': 'bg-chart-5/10 text-chart-5',
+};
 
 export const toolCategories = [
-	...new Map(
-		toolCatalog.map((tool) => [tool.category, tool.categoryColor]),
-	).entries(),
-].map(([name, color]) => ({ name, color }));
+	...new Set(toolCatalog.map((t) => t.category)),
+].map((name) => ({ name, color: categoryChipColor[name] }));
 
 export const toolSlugs = toolCatalog.map((tool) => tool.id);

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -1,0 +1,231 @@
+export type ToolCategory =
+	| 'テキスト変換'
+	| 'テキスト解析'
+	| '開発ツール'
+	| '生成ツール'
+	| 'ユーティリティ'
+	| 'エンコード/デコード'
+	| 'データ処理'
+	| 'AI/画像';
+
+export type ToolCatalogItem = {
+	id: string;
+	title: string;
+	description: string;
+	href: string;
+	icon: string;
+	category: ToolCategory;
+	categoryColor: string;
+	span?: 2;
+	keywords: readonly string[];
+};
+
+export const toolCatalog = [
+	{
+		id: 'zenkaku-hankaku',
+		title: '全角↔半角変換',
+		description:
+			'カタカナ・英数字・記号の全角半角を一括変換。カテゴリ別に細かく制御できます。',
+		href: '/zenkaku-hankaku',
+		icon: '🔄',
+		category: 'テキスト変換',
+		categoryColor: 'border-l-primary',
+		span: 2,
+		keywords: ['全角', '半角', 'カタカナ'],
+	},
+	{
+		id: 'char-count',
+		title: '文字数カウント',
+		description:
+			'文字数・バイト数・行数をリアルタイムカウント。Shift-JIS対応。',
+		href: '/char-count',
+		icon: '🔢',
+		category: 'テキスト解析',
+		categoryColor: 'border-l-accent',
+		keywords: ['文字数', 'バイト数', '行数', 'Shift-JIS'],
+	},
+	{
+		id: 'json-formatter',
+		title: 'JSON整形',
+		description: 'JSONの整形・圧縮・構文チェック。インデント幅も選べます。',
+		href: '/json-formatter',
+		icon: '{ }',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: ['JSON', 'フォーマット', 'バリデーション'],
+	},
+	{
+		id: 'text-diff',
+		title: 'テキスト差分比較',
+		description:
+			'2つのテキストの違いをハイライト表示。行単位・文字単位の切替対応。',
+		href: '/text-diff',
+		icon: '📝',
+		category: 'テキスト解析',
+		categoryColor: 'border-l-accent',
+		span: 2,
+		keywords: ['diff', '比較', '差分'],
+	},
+	{
+		id: 'qr-generator',
+		title: 'QRコード生成',
+		description:
+			'URLやテキストからQRコードを即座に生成。サイズ・色のカスタマイズ可能。',
+		href: '/qr-generator',
+		icon: '📱',
+		category: '生成ツール',
+		categoryColor: 'border-l-chart-3',
+		keywords: ['QR', 'コード'],
+	},
+	{
+		id: 'wareki-converter',
+		title: '和暦↔西暦変換',
+		description: '明治〜令和の和暦と西暦を相互変換。干支・年齢も同時表示。',
+		href: '/wareki-converter',
+		icon: '🎌',
+		category: 'ユーティリティ',
+		categoryColor: 'border-l-chart-2',
+		keywords: ['和暦', '西暦', '元号', '年齢'],
+	},
+	{
+		id: 'url-encoder',
+		title: 'URLエンコード/デコード',
+		description:
+			'日本語を含むURLやクエリを安全に双方向変換。コンポーネント/フルURLモード対応。',
+		href: '/url-encoder',
+		icon: '🔗',
+		category: 'エンコード/デコード',
+		categoryColor: 'border-l-primary',
+		keywords: ['URL', 'encodeURI', 'decodeURI', 'パーセントエンコード'],
+	},
+	{
+		id: 'base64',
+		title: 'Base64エンコード/デコード',
+		description:
+			'テキスト・ファイルのBase64エンコード/デコードをブラウザ内で実行。',
+		href: '/base64',
+		icon: '🔐',
+		category: 'ユーティリティ',
+		categoryColor: 'border-l-chart-2',
+		keywords: ['Base64', 'エンコード', 'デコード'],
+	},
+	{
+		id: 'regex-tester',
+		title: '正規表現テスター',
+		description:
+			'正規表現のリアルタイムテスト・マッチ確認・置換。よく使うパターン集付き。',
+		href: '/regex-tester',
+		icon: '✨',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: ['正規表現', 'regex', '置換'],
+	},
+	{
+		id: 'sql-formatter',
+		title: 'SQL整形・フォーマッター',
+		description:
+			'SQLの整形・圧縮をブラウザ内で実行。MySQL/PostgreSQL等の方言対応。',
+		href: '/sql-formatter',
+		icon: '💾',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: ['SQL', 'MySQL', 'PostgreSQL'],
+	},
+	{
+		id: 'dummy-data',
+		title: 'ダミーデータ生成',
+		description:
+			'日本語の氏名・住所・電話番号等のダミーデータを一括生成。JSON/CSVなど出力。',
+		href: '/dummy-data',
+		icon: '🎲',
+		category: '生成ツール',
+		categoryColor: 'border-l-chart-3',
+		keywords: ['テストデータ', 'JSON', 'CSV'],
+	},
+	{
+		id: 'masking',
+		title: '個人情報マスキング',
+		description:
+			'メール・電話番号・カード番号等の個人情報を自動検出してマスキング。',
+		href: '/masking',
+		icon: '🛡️',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		keywords: ['個人情報', 'マスキング', 'メール', '電話番号'],
+	},
+	{
+		id: 'csv-editor',
+		title: 'CSVビューア/エディタ',
+		description:
+			'ブラウザ上でCSV/TSVをテーブル形式で閲覧・編集。データの加工からエクスポートまで。',
+		href: '/csv-editor',
+		icon: '📊',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		span: 2,
+		keywords: ['CSV', 'TSV', '表', '編集'],
+	},
+	{
+		id: 'unicode-converter',
+		title: 'ユニコード変換',
+		description:
+			'テキストとユニコードエスケープシーケンス（\\uXXXX）を相互変換。',
+		href: '/unicode-converter',
+		icon: '🔣',
+		category: 'テキスト変換',
+		categoryColor: 'border-l-primary',
+		keywords: ['Unicode', 'ユニコード', '\\uXXXX'],
+	},
+	{
+		id: 'csv-fixer',
+		title: 'CSV文字化け修復',
+		description:
+			'CSVのShift_JIS文字化けをブラウザで即座に修復。自動検出・BOM付与対応。',
+		href: '/csv-fixer',
+		icon: '📝',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		keywords: ['CSV', '文字化け', 'Shift_JIS', 'BOM'],
+	},
+	{
+		id: 'phone-formatter',
+		title: '電話番号フォーマッタ',
+		description:
+			'日本の電話番号をE.164・国際表記・国内表記に即変換。CSV一括変換対応。',
+		href: '/phone-formatter',
+		icon: '📞',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		keywords: ['電話番号', 'E.164', 'CSV'],
+	},
+	{
+		id: 'cipher',
+		title: '暗号化・難読化',
+		description:
+			'シーザー暗号・ROT13・モールス信号などをブラウザ内で相互変換。',
+		href: '/cipher',
+		icon: '🔑',
+		category: 'ユーティリティ',
+		categoryColor: 'border-l-chart-2',
+		keywords: ['暗号', '難読化', 'ROT13', 'モールス信号', 'シーザー暗号'],
+	},
+	{
+		id: 'bg-remove',
+		title: '背景削除',
+		description:
+			'AIがブラウザ内で画像の背景を自動削除。画像はアップロードされません。',
+		href: '/bg-remove',
+		icon: '✂️',
+		category: 'AI/画像',
+		categoryColor: 'border-l-chart-5',
+		keywords: ['背景削除', '透過', 'AI', '画像', 'アップロード不要'],
+	},
+] as const satisfies readonly ToolCatalogItem[];
+
+export const toolCategories = [
+	...new Map(
+		toolCatalog.map((tool) => [tool.category, tool.categoryColor]),
+	).entries(),
+].map(([name, color]) => ({ name, color }));
+
+export const toolSlugs = toolCatalog.map((tool) => tool.id);

--- a/src/pages/bg-remove.astro
+++ b/src/pages/bg-remove.astro
@@ -5,7 +5,7 @@ import BgRemoveTool from '../components/tools/BgRemove.tsx';
 
 <ToolLayout
   title="背景削除"
-  description="AIがブラウザ内で画像の背景を自動削除。アップロード不要・完全ローカル処理。"
+  description="AIがブラウザ内で画像の背景を自動削除。画像はアップロードされません。"
   path="/bg-remove"
 >
   <BgRemoveTool client:load />
@@ -17,7 +17,7 @@ import BgRemoveTool from '../components/tools/BgRemove.tsx';
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
       </summary>
       <div class="mt-4 space-y-3 text-sm text-muted-foreground">
-        <p>AIモデル（Transformers.js）を使用して、画像の背景を自動で削除します。AIモデルの取得時に通信が発生する場合がありますが、画像そのものはブラウザ内で処理され、サーバーに送信されることはありません。</p>
+        <p>AIモデル（Transformers.js）を使用して、画像の背景を自動で削除します。初回実行時にAIモデルを取得する通信が発生しますが、画像そのものはブラウザ内で処理され、サーバーに送信されることはありません。</p>
         <ul class="list-disc pl-5 space-y-1">
           <li>商品写真の背景を透過にしたい</li>
           <li>プロフィール写真の背景を削除・差し替えしたい</li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import ToolCard from '../components/common/ToolCard.astro';
 import { ShieldCheck } from 'lucide-react';
+import { toolCatalog, toolCategories } from '../lib/tools/catalog';
 const schema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -42,166 +43,28 @@ const schema = {
 
     <!-- Bento Grid -->
     <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      <ToolCard
-        title="全角↔半角変換"
-        description="カタカナ・英数字・記号の全角半角を一括変換。カテゴリ別に細かく制御できます。"
-        href="/zenkaku-hankaku"
-        icon="🔄"
-        category="テキスト変換"
-        categoryColor="border-l-primary"
-        span={2}
-      />
-      <ToolCard
-        title="文字数カウント"
-        description="文字数・バイト数・行数をリアルタイムカウント。Shift-JIS対応。"
-        href="/char-count"
-        icon="🔢"
-        category="テキスト解析"
-        categoryColor="border-l-accent"
-      />
-      <ToolCard
-        title="JSON整形"
-        description="JSONの整形・圧縮・構文チェック。インデント幅も選べます。"
-        href="/json-formatter"
-        icon="{ }"
-        category="開発ツール"
-        categoryColor="border-l-chart-1"
-      />
-      <ToolCard
-        title="テキスト差分比較"
-        description="2つのテキストの違いをハイライト表示。 行単位・文字単位の切替対応。"
-        href="/text-diff"
-        icon="📝"
-        category="テキスト解析"
-        categoryColor="border-l-accent"
-        span={2}
-      />
-      <ToolCard
-        title="QRコード生成"
-        description="URLやテキストからQRコードを即座に生成。サイズ・色のカスタマイズ可能。"
-        href="/qr-generator"
-        icon="📱"
-        category="生成ツール"
-        categoryColor="border-l-chart-3"
-      />
-      <ToolCard
-        title="和暦↔西暦変換"
-        description="明治〜令和の和暦と西暦を相互変換。干支・年齢も同時表示。"
-        href="/wareki-converter"
-        icon="🎌"
-        category="ユーティリティ"
-        categoryColor="border-l-chart-2"
-      />
-      <ToolCard
-        title="URLエンコード/デコード"
-        description="日本語を含むURLやクエリを安全に双方向変換。コンポーネント/フルURLモード対応。"
-        href="/url-encoder"
-        icon="🔗"
-        category="エンコード/デコード"
-        categoryColor="border-l-primary"
-      />
-      <ToolCard
-        title="Base64エンコード/デコード"
-        description="テキスト・ファイルのBase64エンコード/デコードをブラウザ内で実行。"
-        href="/base64"
-        icon="🔐"
-        category="ユーティリティ"
-        categoryColor="border-l-chart-2"
-      />
-      <ToolCard
-        title="正規表現テスター"
-        description="正規表現のリアルタイムテスト・マッチ確認・置換。よく使うパターン集付き。"
-        href="/regex-tester"
-        icon="✨"
-        category="開発ツール"
-        categoryColor="border-l-chart-1"
-      />
-      <ToolCard
-        title="SQL整形・フォーマッター"
-        description="SQLの整形・圧縮をブラウザ内で実行。MySQL/PostgreSQL等の方言対応。"
-        href="/sql-formatter"
-        icon="💾"
-        category="開発ツール"
-        categoryColor="border-l-chart-1"
-      />
-      <ToolCard
-        title="ダミーデータ生成"
-        description="日本語の氏名・住所・電話番号等のダミーデータを一括生成。JSON/CSVなど出力。"
-        href="/dummy-data"
-        icon="🎲"
-        category="生成ツール"
-        categoryColor="border-l-chart-3"
-      />
-      <ToolCard
-        title="個人情報マスキング"
-        description="メール・電話番号・カード番号等の個人情報を自動検出してマスキング。"
-        href="/masking"
-        icon="🛡️"
-        category="データ処理"
-        categoryColor="border-l-chart-4"
-      />
-      <ToolCard
-        title="CSVビューア/エディタ"
-        description="ブラウザ上でCSV/TSVをテーブル形式で閲覧・編集。データの加工からエクスポートまで。"
-        href="/csv-editor"
-        icon="📊"
-        category="データ処理"
-        categoryColor="border-l-chart-4"
-        span={2}
-      />
-      <ToolCard
-        title="ユニコード変換"
-        description="テキストとユニコードエスケープシーケンス（\\uXXXX）を相互変換。"
-        href="/unicode-converter"
-        icon="🔣"
-        category="テキスト変換"
-        categoryColor="border-l-primary"
-      />
-      <ToolCard
-        title="CSV文字化け修復"
-        description="CSVのShift_JIS文字化けをブラウザで即座に修復。自動検出・BOM付与対応。"
-        href="/csv-fixer"
-        icon="📝"
-        category="データ処理"
-        categoryColor="border-l-chart-4"
-      />
-      <ToolCard
-        title="電話番号フォーマッタ"
-        description="日本の電話番号をE.164・国際表記・国内表記に即変換。CSV一括変換対応。"
-        href="/phone-formatter"
-        icon="📞"
-        category="データ処理"
-        categoryColor="border-l-chart-4"
-      />
-      <ToolCard
-        title="暗号化・難読化"
-        description="シーザー暗号・ROT13・モールス信号など"
-        href="/cipher"
-        icon="🔑"
-        category="ユーティリティ"
-        categoryColor="border-l-chart-2"
-      />
-      <ToolCard
-        title="背景削除"
-        description="AIがブラウザ内で画像の背景を自動削除。アップロード不要・ブラウザ内処理。"
-        href="/bg-remove"
-        icon="✂️"
-        category="AI/画像"
-        categoryColor="border-l-chart-5"
-      />
+      {toolCatalog.map((tool) => (
+        <ToolCard
+          title={tool.title}
+          description={tool.description}
+          href={tool.href}
+          icon={tool.icon}
+          category={tool.category}
+          categoryColor={tool.categoryColor}
+          span={tool.span}
+        />
+      ))}
+
       <!-- Category summary card -->
       <div class="flex flex-col justify-center items-center rounded-xl border border-border bg-card p-5 text-center">
-        <p class="text-3xl font-bold text-primary mb-1">18</p>
+        <p class="text-3xl font-bold text-primary mb-1">{toolCatalog.length}</p>
         <p class="text-sm text-muted-foreground mb-3">ツールを公開中</p>
         <div class="flex flex-wrap justify-center gap-1.5">
-          <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">テキスト変換</span>
-          <span class="text-xs rounded-full bg-accent/10 text-accent px-2 py-0.5">テキスト解析</span>
-          <span class="text-xs rounded-full bg-chart-1/10 text-chart-1 px-2 py-0.5">開発ツール</span>
-          <span class="text-xs rounded-full bg-chart-3/10 text-chart-3 px-2 py-0.5">生成ツール</span>
-          <span class="text-xs rounded-full bg-chart-2/10 text-chart-2 px-2 py-0.5">ユーティリティ</span>
-          <span class="text-xs rounded-full bg-chart-4/10 text-chart-4 px-2 py-0.5">データ処理</span>
-          <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">エンコード/デコード</span>
-          <span class="text-xs rounded-full bg-chart-5/10 text-chart-5 px-2 py-0.5">AI/画像</span>
+          {toolCategories.map((category) => (
+            <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">
+              {category.name}
+            </span>
+          ))}
         </div>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -61,7 +61,7 @@ const schema = {
         <p class="text-sm text-muted-foreground mb-3">ツールを公開中</p>
         <div class="flex flex-wrap justify-center gap-1.5">
           {toolCategories.map((category) => (
-            <span class="text-xs rounded-full bg-primary/10 text-primary px-2 py-0.5">
+            <span class={`text-xs rounded-full px-2 py-0.5 ${category.color}`}>
               {category.name}
             </span>
           ))}

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,7 +1,5 @@
-import { toolCatalog } from '../../src/lib/tools/catalog';
+import { toolSlugs } from '../../src/lib/tools/catalog';
 import { expect, test } from './fixtures/base';
-
-const toolSlugs = toolCatalog.map((tool) => tool.id);
 
 test.describe('Smoke Tests - Tools', () => {
 	for (const toolSlug of toolSlugs) {

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,15 +1,10 @@
+import { toolCatalog } from '../../src/lib/tools/catalog';
 import { expect, test } from './fixtures/base';
 
-const TOOLS = [
-	'zenkaku-hankaku',
-	'char-count',
-	'json-formatter',
-	'text-diff',
-	'qr-generator',
-];
+const toolSlugs = toolCatalog.map((tool) => tool.id);
 
 test.describe('Smoke Tests - Tools', () => {
-	for (const toolSlug of TOOLS) {
+	for (const toolSlug of toolSlugs) {
 		test(`Tool page /${toolSlug} should load and show safety badge`, async ({
 			page,
 			createToolPage,


### PR DESCRIPTION
### Motivation

- Consolidate the app's tool metadata into a single source of truth so pages, navigation and search remain consistent.
- Improve background-removal UX and lifecycle by avoiding eager model preload and ensuring worker cleanup.
- Add a convenient `check` script to run `astro check` together with `biome`.

### Description

- Add `src/lib/tools/catalog.ts` which exports a typed `toolCatalog`, `toolCategories`, and `toolSlugs` used across the app.
- Replace hard-coded tool lists with `toolCatalog` usage in the homepage (`src/pages/index.astro`), navigation (`src/components/layout/Navigation.astro`), and search modal (`src/components/common/SearchModal.tsx`).
- Enhance search to also match `keywords`, switch displayed fields from `name` to `title`, and guard keyboard navigation when no results exist; update keyboard `Enter` behavior to use the active index safely.
- Update background-removal UI (`src/components/tools/BgRemove.tsx`) to remove eager `preload` usage, add an informational banner about local processing/model download, and ensure worker termination on unmount; adjust imports accordingly.
- Clarify `preload` behavior in `src/lib/tools/bg-remove.ts` comment and keep `terminateWorker` exported for cleanup.
- Add npm script `check` to `package.json` which runs `astro check && biome check src/ tests/`.
- Update E2E smoke test (`tests/e2e/smoke.spec.ts`) to iterate `toolCatalog` slugs instead of a hard-coded list.

### Testing

- Ran Playwright smoke tests (`playwright test`) which exercise each tool page and the top page; tests were updated to use `toolCatalog` and succeeded.
- Local dev build and preview paths exercised the homepage and `bg-remove` page to verify UI changes and dynamic catalog rendering, and they loaded without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2751ef8c34832fa0228c50fa64eeb8)