### PR TITLE
fix: E2Eテストのハイドレーション競合によるflaky解消

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,8 @@ export default defineConfig({
 		baseURL: 'http://localhost:4321',
 		trace: 'on-first-retry',
 		screenshot: 'only-on-failure',
+		// SW は context.route() を素通りし、並列実行時にハイドレーションを遅延させるため無効化
+		serviceWorkers: 'block',
 	},
 	projects: [
 		{ name: 'chromium', use: { ...devices['Desktop Chrome'] } },

--- a/tests/e2e/cipher.spec.ts
+++ b/tests/e2e/cipher.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test } from './fixtures/base';
 
 test.describe('Cipher Tool', () => {
 	test.beforeEach(async ({ page }) => {

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -1,4 +1,4 @@
-import { test as baseTest, expect } from '@playwright/test';
+import { test as baseTest, expect, type Page } from '@playwright/test';
 import { ToolPage } from '../helpers/tool-page';
 
 type MyFixtures = {
@@ -9,6 +9,18 @@ export const test = baseTest.extend<MyFixtures>({
 	page: async ({ page }, use) => {
 		// Block analytics to prevent test timeouts/flakiness
 		await page.route('**/*googletagmanager*', (route) => route.abort());
+		// React Island のハイドレーション完了前に fill/click すると controlled component が
+		// 空文字でリセットされ flaky になるため、goto 後に全 astro-island の ssr 属性削除
+		// （= ハイドレーション完了）を待つ
+		const originalGoto = page.goto.bind(page);
+		page.goto = async (url: string, options?: Parameters<Page['goto']>[1]) => {
+			const response = await originalGoto(url, options);
+			// 並列実行のCPU飽和時はハイドレーションに15秒以上かかることがあるため余裕を持たせる
+			await expect(page.locator('astro-island[ssr]')).toHaveCount(0, {
+				timeout: 25_000,
+			});
+			return response;
+		};
 		await use(page);
 	},
 	createToolPage: async ({ page }, use) => {

--- a/tests/e2e/fixtures/base.ts
+++ b/tests/e2e/fixtures/base.ts
@@ -5,20 +5,25 @@ type MyFixtures = {
 	createToolPage: (path: string) => ToolPage;
 };
 
+// React Island のハイドレーション完了前に fill/click すると controlled component が
+// 空文字でリセットされ flaky になるため、client:load の astro-island の ssr 属性削除
+// （= ハイドレーション完了）を待つ。client:visible 等の遅延 island は対象外。
+async function waitForClientLoadIslands(page: Page) {
+	// 並列実行の負荷ピーク時はハイドレーションが15秒を超えて停滞することがある（実測）
+	await expect(page.locator('astro-island[ssr][client="load"]')).toHaveCount(
+		0,
+		{ timeout: 25_000 },
+	);
+}
+
 export const test = baseTest.extend<MyFixtures>({
 	page: async ({ page }, use) => {
 		// Block analytics to prevent test timeouts/flakiness
 		await page.route('**/*googletagmanager*', (route) => route.abort());
-		// React Island のハイドレーション完了前に fill/click すると controlled component が
-		// 空文字でリセットされ flaky になるため、goto 後に全 astro-island の ssr 属性削除
-		// （= ハイドレーション完了）を待つ
 		const originalGoto = page.goto.bind(page);
-		page.goto = async (url: string, options?: Parameters<Page['goto']>[1]) => {
-			const response = await originalGoto(url, options);
-			// 並列実行のCPU飽和時はハイドレーションに15秒以上かかることがあるため余裕を持たせる
-			await expect(page.locator('astro-island[ssr]')).toHaveCount(0, {
-				timeout: 25_000,
-			});
+		page.goto = async (...args: Parameters<Page['goto']>) => {
+			const response = await originalGoto(...args);
+			await waitForClientLoadIslands(page);
 			return response;
 		};
 		await use(page);


### PR DESCRIPTION
## 概要

ローカル並列実行時にE2Eテストが断続的に失敗する問題（CIでは retries=2 で隠れていた）を修正します。

## 根本原因（2層）

1. **ハイドレーション競合**: React Island（client:load）のハイドレーション完了前に fill/click が実行されると、onChange ハンドラ未接続のため state が更新されず、controlled component がハイドレーション時に空文字へリセットされる。再現確認で cipher×6 + bg-remove×1 が失敗。
2. **Service Worker による帯域・IO飽和**: 本サイトはPWAで、テストごとの新規コンテキストでSWがインストールされ全リクエストがSWのfetchハンドラ経由になるため、12並列で preview サーバーとIOが飽和し、ハイドレーション自体が25秒超遅延するケースがあった。SWは Playwright の context.route() を素通りするため、bg-remove のモデルダウンロードブロックが効かない潜在問題もあった。

## 変更内容

- **tests/e2e/fixtures/base.ts**: page fixture で goto をラップし、client:load の astro-island の ssr 属性消失（Astroがハイドレーション完了時に削除）を待機。fixture を使う全 spec に透過適用。
- **tests/e2e/cipher.spec.ts**: `@playwright/test` 直 import を規約どおり `./fixtures/base` 経由に修正。
- **playwright.config.ts**: `serviceWorkers: 'block'` を追加（テストはSW機能に非依存であることを確認済み）。

## Codex (gpt-5.5) レビュー反映

- 待機対象を `astro-island[ssr][client="load"]` に絞り込み（将来 client:visible 採用時のハング防止）
- 待機処理を `waitForClientLoadIslands` ヘルパーに切り出し、goto パッチの引数型を自然化
- タイムアウト15秒への短縮提案は採用見送り: SWブロック後も並列負荷ピーク時にハイドレーションが15秒超停滞するケースを実測（25秒では3回連続グリーンの実績）

### 見送り・フォローアップ候補

- SW有効の専用 project（オフラインフォールバック等の検証用）の追加
- goto 以外のナビゲーション（reload / リンククリック）にはハイドレーション待ちが効かない点（現状の spec では問題なし）

## 検証

`npx playwright test --reporter=dot` を3回連続実行し、すべて 162 passed / 4 skipped（ローカル retries=0、各回30秒前後）。lint パス済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)