### PR TITLE
Phase 3c1: ハッシュ値計算 / JSON-CSV相互変換ツールを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 | ツール | 説明 |
 |--------|------|
 | [JSON整形](/json-formatter) | JSONの整形・圧縮・バリデーション |
+| [JSON ↔ CSV 変換](/json-csv) | JSONとCSVの相互変換。ネスト展開・型推論・BOM付きUTF-8出力（Excel文字化け対策） |
 | [CSVビューア/エディタ](/csv-editor) | CSVをテーブル形式で閲覧・編集・エクスポート |
 | [CSV文字化け修復](/csv-fixer) | CSVの文字コード自動判定・変換（Shift_JIS/UTF-8/EUC-JP等） |
 | [電話番号フォーマッタ](/phone-formatter) | 日本語の電話番号をE.164・国際表記・国内表記に即変換。CSV一括変換対応。 |
@@ -44,6 +45,7 @@
 | ツール | 説明 |
 |--------|------|
 | [正規表現チェッカー](/regex-tester) | リアルタイムマッチング・置換・キャプチャグループ表示 |
+| [ハッシュ値計算](/hash) | MD5・SHA-1・SHA-256・SHA-512・CRC32の計算と期待値照合（ファイルの改ざんチェック） |
 | [SQLフォーマッター](/sql-formatter) | SQL文の整形（MySQL, PostgreSQL等の方言対応） |
 | [個人情報マスキング](/masking) | メール・電話番号・カード番号等を自動検出してマスキング |
 | [暗号変換](/cipher) | シーザー暗号・ROT13・モールス信号・逆順等のテキスト変換 |
@@ -73,6 +75,7 @@
 | `npm run build` | 本番用に静的ビルド＋SW生成（`dist/`） |
 | `npm run preview` | ビルド結果をローカルプレビュー |
 | `npx playwright test --headed` | E2Eテストを実行（ブラウザ表示あり） |
+| `npm run test:unit` | コアロジックの単体テストを実行（Node 22 の `node --test`、runner追加なし） |
 
 ## 🚀 Cloudflare R2 モデル配信
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
 		"dev": "astro dev",
 		"build": "astro build && node scripts/generate-sw.mjs",
 		"test": "playwright test",
+		"test:unit": "node --test \"tests/unit/*.test.ts\"",
 		"preview": "astro preview --host",
 		"preview:ci": "astro preview",
 		"lint": "biome check src/ tests/",

--- a/scripts/generate-fixtures.ts
+++ b/scripts/generate-fixtures.ts
@@ -143,4 +143,11 @@ fs.writeFileSync(
 	),
 );
 
+// 7. ハッシュツール用の固定内容テキスト（期待ハッシュ値が決定的になる）
+// 内容を変更すると tests/e2e/hash.spec.ts の期待値も更新が必要
+fs.writeFileSync(
+	path.join(fixturesDir, 'hash-sample.txt'),
+	Buffer.from('CODE:LIFE hash fixture v1\n', 'utf8'),
+);
+
 console.log('Fixtures generated successfully.');

--- a/src/components/common/FileDropzone.tsx
+++ b/src/components/common/FileDropzone.tsx
@@ -29,6 +29,23 @@ export interface FileDropzoneProps {
 	'data-testid'?: string;
 }
 
+function matchesAccept(file: File, accept?: string): boolean {
+	if (!accept) return true;
+	const fileName = file.name.toLowerCase();
+	const fileType = file.type.toLowerCase();
+	return accept
+		.split(',')
+		.map((token) => token.trim().toLowerCase())
+		.filter(Boolean)
+		.some((token) => {
+			if (token.startsWith('.')) return fileName.endsWith(token);
+			if (token.endsWith('/*')) {
+				return fileType.startsWith(token.slice(0, -1));
+			}
+			return fileType === token;
+		});
+}
+
 export function FileDropzone({
 	onFileSelect,
 	onValidationError,
@@ -51,6 +68,10 @@ export function FileDropzone({
 
 	const handleFile = useCallback(
 		(file: File) => {
+			if (!matchesAccept(file, accept)) {
+				onValidationError?.('対応していないファイル形式です。');
+				return;
+			}
 			if (maxSizeBytes != null && file.size > maxSizeBytes) {
 				onValidationError?.(validationMessage);
 				return;
@@ -63,6 +84,7 @@ export function FileDropzone({
 			onFileSelect(file);
 		},
 		[
+			accept,
 			maxSizeBytes,
 			validationMessage,
 			validate,

--- a/src/components/common/FileDropzone.tsx
+++ b/src/components/common/FileDropzone.tsx
@@ -1,0 +1,166 @@
+import { Upload, X } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+export interface FileDropzoneProps {
+	/** 検証を通過したファイルのみ通知される */
+	onFileSelect: (file: File) => void;
+	/** 検証失敗時のエラーメッセージ通知（表示は呼び出し側で行う） */
+	onValidationError?: (message: string) => void;
+	/** input の accept 属性（例: '.json,.csv,.txt'）。未指定は任意ファイル */
+	accept?: string;
+	/** ファイルサイズ上限（バイト）。超過時は validationMessage を通知 */
+	maxSizeBytes?: number;
+	/** maxSizeBytes 超過時のメッセージ */
+	validationMessage?: string;
+	/** 追加の検証フック。エラーメッセージを返すと選択を拒否（null = OK） */
+	validate?: (file: File) => string | null;
+	label?: string;
+	description?: string;
+	privacyNote?: string;
+	/** 選択中ファイル名の表示（controlled） */
+	selectedFileName?: string | null;
+	/** 指定時のみクリアボタンを表示 */
+	onClear?: () => void;
+	disabled?: boolean;
+	inputAriaLabel?: string;
+	className?: string;
+	'data-testid'?: string;
+}
+
+export function FileDropzone({
+	onFileSelect,
+	onValidationError,
+	accept,
+	maxSizeBytes,
+	validationMessage = 'ファイルサイズが上限を超えています。',
+	validate,
+	label = 'ファイルをドラッグ＆ドロップ',
+	description = 'またはクリックしてファイルを選択',
+	privacyNote = '🔒 ファイルはサーバーに送信されません。すべてブラウザ内で処理されます。',
+	selectedFileName,
+	onClear,
+	disabled = false,
+	inputAriaLabel = 'ファイルを選択',
+	className,
+	'data-testid': dataTestId,
+}: FileDropzoneProps) {
+	const [isDragOver, setIsDragOver] = useState(false);
+	const fileInputRef = useRef<HTMLInputElement>(null);
+
+	const handleFile = useCallback(
+		(file: File) => {
+			if (maxSizeBytes != null && file.size > maxSizeBytes) {
+				onValidationError?.(validationMessage);
+				return;
+			}
+			const customError = validate?.(file);
+			if (customError) {
+				onValidationError?.(customError);
+				return;
+			}
+			onFileSelect(file);
+		},
+		[
+			maxSizeBytes,
+			validationMessage,
+			validate,
+			onFileSelect,
+			onValidationError,
+		],
+	);
+
+	const handleDragOver = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			if (!disabled) setIsDragOver(true);
+		},
+		[disabled],
+	);
+
+	const handleDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault();
+		e.stopPropagation();
+		setIsDragOver(false);
+	}, []);
+
+	const handleDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault();
+			e.stopPropagation();
+			setIsDragOver(false);
+			if (disabled) return;
+			const file = e.dataTransfer.files[0];
+			if (file) handleFile(file);
+		},
+		[disabled, handleFile],
+	);
+
+	const handleInputChange = useCallback(
+		(e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (file) handleFile(file);
+			// 同じファイルの再選択を可能にする
+			e.target.value = '';
+		},
+		[handleFile],
+	);
+
+	return (
+		<div className={className}>
+			<button
+				type="button"
+				disabled={disabled}
+				onDragOver={handleDragOver}
+				onDragLeave={handleDragLeave}
+				onDrop={handleDrop}
+				onClick={() => fileInputRef.current?.click()}
+				className={cn(
+					'w-full relative flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed p-8 cursor-pointer transition-all duration-200 bg-transparent',
+					isDragOver
+						? 'border-primary bg-primary/5 scale-[1.01]'
+						: 'border-border hover:border-primary/50 hover:bg-muted/30',
+					disabled && 'opacity-50 cursor-not-allowed',
+				)}
+			>
+				<div className="rounded-full bg-primary/10 p-3">
+					<Upload className="h-6 w-6 text-primary" />
+				</div>
+				<div className="text-center">
+					<p className="text-sm font-medium">{label}</p>
+					<p className="mt-1 text-xs text-muted-foreground">{description}</p>
+					<p className="mt-2 text-xs text-muted-foreground">{privacyNote}</p>
+				</div>
+				<input
+					ref={fileInputRef}
+					type="file"
+					accept={accept}
+					aria-label={inputAriaLabel}
+					data-testid={dataTestId}
+					onChange={handleInputChange}
+					className="hidden"
+				/>
+			</button>
+			{selectedFileName && (
+				<div className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm">
+					<span className="truncate font-mono" title={selectedFileName}>
+						{selectedFileName}
+					</span>
+					{onClear && (
+						<Button
+							variant="ghost"
+							size="icon"
+							className="ml-auto h-6 w-6 shrink-0"
+							onClick={onClear}
+							aria-label="選択をクリア"
+						>
+							<X className="h-4 w-4" />
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/tools/hash-generator/HashPage.tsx
+++ b/src/components/tools/hash-generator/HashPage.tsx
@@ -1,0 +1,316 @@
+import { AlertTriangle, Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FileDropzone } from '@/components/common/FileDropzone';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+	Dialog,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import {
+	HASH_ALGORITHM_LABELS,
+	HASH_ALGORITHMS,
+	type HashAlgorithm,
+	type HashResults,
+	hashFile,
+	hashText,
+	isShaAlgorithm,
+	MAX_FILE_SIZE,
+	validateHashFile,
+} from '@/lib/tools/hash';
+import { HashResultTable } from './HashResultTable';
+import { HashVerifier } from './HashVerifier';
+
+type InputMode = 'text' | 'file';
+
+const MB = 1024 * 1024;
+const FILE_TOO_LARGE_MESSAGE = `ファイルサイズが上限（${MAX_FILE_SIZE / MB}MB）を超えています。`;
+
+export function HashPage() {
+	const [inputMode, setInputMode] = useState<InputMode>('text');
+	const [text, setText] = useState('');
+	const [file, setFile] = useState<File | null>(null);
+	const [algorithms, setAlgorithms] = useState<HashAlgorithm[]>([
+		'md5',
+		'sha1',
+		'sha256',
+	]);
+	const [results, setResults] = useState<HashResults>({});
+	const [computing, setComputing] = useState(false);
+	const [progress, setProgress] = useState(0);
+	const [error, setError] = useState<string | null>(null);
+	const [uppercase, setUppercase] = useState(false);
+	const [confirmHugeFile, setConfirmHugeFile] = useState<File | null>(null);
+	const runIdRef = useRef(0);
+
+	// --- テキスト入力の自動計算（300ms debounce + 古い結果の破棄） ---
+	useEffect(() => {
+		if (inputMode !== 'text') return;
+		const runId = ++runIdRef.current;
+		const timer = setTimeout(async () => {
+			if (algorithms.length === 0 || text === '') {
+				setResults({});
+				return;
+			}
+			setComputing(true);
+			try {
+				const computed = await hashText(text, algorithms);
+				if (runIdRef.current === runId) {
+					setResults(computed);
+					setError(null);
+				}
+			} catch (err) {
+				if (runIdRef.current === runId) {
+					setError(
+						err instanceof Error
+							? err.message
+							: 'ハッシュの計算に失敗しました。',
+					);
+				}
+			} finally {
+				if (runIdRef.current === runId) setComputing(false);
+			}
+		}, 300);
+		return () => clearTimeout(timer);
+	}, [inputMode, text, algorithms]);
+
+	// --- ファイル計算 ---
+	const runFileHash = useCallback(
+		async (target: File, selected: readonly HashAlgorithm[]) => {
+			const runId = ++runIdRef.current;
+			setComputing(true);
+			setProgress(0);
+			setError(null);
+			try {
+				const computed = await hashFile(target, selected, (percent) => {
+					if (runIdRef.current === runId) setProgress(percent);
+				});
+				if (runIdRef.current === runId) setResults(computed);
+			} catch (err) {
+				if (runIdRef.current === runId) {
+					setError(
+						err instanceof Error
+							? err.message
+							: 'ハッシュの計算に失敗しました。ファイルが大きすぎる可能性があります。',
+					);
+					setResults({});
+				}
+			} finally {
+				if (runIdRef.current === runId) setComputing(false);
+			}
+		},
+		[],
+	);
+
+	// warnLevel は validateHashFile を単一のソースとして使用する
+	const startFileHash = useCallback(
+		(target: File, selected: readonly HashAlgorithm[]) => {
+			const validation = validateHashFile(target);
+			if (!validation.ok) {
+				setError(FILE_TOO_LARGE_MESSAGE);
+				return;
+			}
+			if (validation.warnLevel === 'huge' && selected.some(isShaAlgorithm)) {
+				setConfirmHugeFile(target);
+				return;
+			}
+			runFileHash(target, selected);
+		},
+		[runFileHash],
+	);
+
+	const handleFileSelect = useCallback(
+		(selected: File) => {
+			// ファイル差し替え時は前回結果をクリア
+			setResults({});
+			setError(null);
+			setFile(selected);
+			if (algorithms.length > 0) startFileHash(selected, algorithms);
+		},
+		[algorithms, startFileHash],
+	);
+
+	const handleAlgorithmToggle = useCallback(
+		(algorithm: HashAlgorithm, checked: boolean) => {
+			const next = checked
+				? [...algorithms, algorithm]
+				: algorithms.filter((a) => a !== algorithm);
+			setAlgorithms(next);
+			if (inputMode === 'file' && file) {
+				setResults({});
+				if (next.length > 0) startFileHash(file, next);
+			}
+		},
+		[algorithms, inputMode, file, startFileHash],
+	);
+
+	const handleClearFile = useCallback(() => {
+		runIdRef.current++;
+		setFile(null);
+		setResults({});
+		setError(null);
+		setComputing(false);
+	}, []);
+
+	const handleModeChange = useCallback((mode: string) => {
+		runIdRef.current++;
+		setInputMode(mode as InputMode);
+		setResults({});
+		setError(null);
+		setComputing(false);
+	}, []);
+
+	const fileWarnLevel =
+		file && inputMode === 'file'
+			? (() => {
+					const v = validateHashFile(file);
+					return v.ok ? v.warnLevel : null;
+				})()
+			: null;
+
+	return (
+		<div className="space-y-6">
+			{/* 入力切替 */}
+			<Tabs value={inputMode} onValueChange={handleModeChange}>
+				<TabsList className="w-full grid grid-cols-2">
+					<TabsTrigger value="text">テキスト</TabsTrigger>
+					<TabsTrigger value="file">ファイル</TabsTrigger>
+				</TabsList>
+				<TabsContent value="text" className="mt-3">
+					<Textarea
+						value={text}
+						onChange={(e) => setText(e.target.value)}
+						placeholder="ハッシュ値を計算するテキストを入力（入力すると自動で計算されます）"
+						className="min-h-32 font-mono"
+						aria-label="ハッシュ計算するテキスト"
+					/>
+				</TabsContent>
+				<TabsContent value="file" className="mt-3">
+					<FileDropzone
+						onFileSelect={handleFileSelect}
+						onValidationError={setError}
+						maxSizeBytes={MAX_FILE_SIZE}
+						validationMessage={FILE_TOO_LARGE_MESSAGE}
+						description={`任意のファイルに対応（最大${MAX_FILE_SIZE / MB}MB）`}
+						selectedFileName={file?.name ?? null}
+						onClear={handleClearFile}
+						inputAriaLabel="ハッシュ計算するファイルを選択"
+						data-testid="hash-file-input"
+					/>
+					{fileWarnLevel === 'large' && (
+						<p className="mt-2 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500">
+							<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+							100MBを超えるファイルのため、処理に時間がかかる場合があります。
+						</p>
+					)}
+				</TabsContent>
+			</Tabs>
+
+			{/* アルゴリズム選択 */}
+			<div className="rounded-lg border border-border p-4">
+				<p className="text-sm font-semibold mb-3">計算するアルゴリズム</p>
+				<div className="flex flex-wrap gap-x-6 gap-y-3">
+					{HASH_ALGORITHMS.map((algorithm) => (
+						<div key={algorithm} className="flex items-center gap-2">
+							<Checkbox
+								id={`algo-${algorithm}`}
+								checked={algorithms.includes(algorithm)}
+								onCheckedChange={(checked) =>
+									handleAlgorithmToggle(algorithm, checked === true)
+								}
+							/>
+							<Label
+								htmlFor={`algo-${algorithm}`}
+								className="text-sm cursor-pointer"
+							>
+								{HASH_ALGORITHM_LABELS[algorithm]}
+							</Label>
+						</div>
+					))}
+				</div>
+			</div>
+
+			{/* エラー表示 */}
+			{error && (
+				<div
+					className="rounded-lg border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
+					role="alert"
+				>
+					{error}
+				</div>
+			)}
+
+			{/* ファイル計算の進捗バー */}
+			{computing && inputMode === 'file' && (
+				<div className="space-y-2">
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin text-primary" />
+						<span>計算中… {Math.round(progress)}%</span>
+					</div>
+					<div
+						className="h-2 w-full rounded-full bg-muted overflow-hidden"
+						role="progressbar"
+						aria-valuenow={Math.round(progress)}
+						aria-valuemin={0}
+						aria-valuemax={100}
+					>
+						<div
+							className="h-full rounded-full bg-primary transition-all duration-200"
+							style={{ width: `${progress}%` }}
+						/>
+					</div>
+				</div>
+			)}
+
+			{/* 結果 */}
+			<HashResultTable
+				selectedAlgorithms={algorithms}
+				results={results}
+				computing={computing}
+				uppercase={uppercase}
+				onUppercaseChange={setUppercase}
+			/>
+
+			{/* 期待値照合 */}
+			<HashVerifier results={results} selectedAlgorithms={algorithms} />
+
+			{/* 200MB超 + SHA系選択時の確認モーダル */}
+			<Dialog
+				open={confirmHugeFile != null}
+				onOpenChange={(open) => {
+					if (!open) setConfirmHugeFile(null);
+				}}
+			>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>大容量ファイルの確認</DialogTitle>
+						<DialogDescription>
+							200MBを超えるファイルでSHA系アルゴリズムを計算するには、ファイル全体をメモリに読み込む必要があります。環境によっては処理に失敗したり、時間がかかる場合があります。続行しますか？
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<Button variant="outline" onClick={() => setConfirmHugeFile(null)}>
+							キャンセル
+						</Button>
+						<Button
+							onClick={() => {
+								const target = confirmHugeFile;
+								setConfirmHugeFile(null);
+								if (target) runFileHash(target, algorithms);
+							}}
+						>
+							計算する
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+}

--- a/src/components/tools/hash-generator/HashResultTable.tsx
+++ b/src/components/tools/hash-generator/HashResultTable.tsx
@@ -1,0 +1,89 @@
+import CopyButton from '@/components/common/CopyButton';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import {
+	HASH_ALGORITHM_LABELS,
+	HASH_ALGORITHMS,
+	type HashAlgorithm,
+	type HashResults,
+} from '@/lib/tools/hash';
+
+interface HashResultTableProps {
+	selectedAlgorithms: readonly HashAlgorithm[];
+	results: HashResults;
+	computing: boolean;
+	uppercase: boolean;
+	onUppercaseChange: (value: boolean) => void;
+}
+
+export function HashResultTable({
+	selectedAlgorithms,
+	results,
+	computing,
+	uppercase,
+	onUppercaseChange,
+}: HashResultTableProps) {
+	// 表示順は定義順（md5 → sha1 → sha256 → sha512 → crc32）に固定する
+	const rows = HASH_ALGORITHMS.filter((a) => selectedAlgorithms.includes(a));
+
+	if (rows.length === 0) {
+		return (
+			<p className="text-sm text-muted-foreground">
+				計算するアルゴリズムを選択してください。
+			</p>
+		);
+	}
+
+	return (
+		<div className="space-y-3">
+			<div className="flex items-center justify-between">
+				<h2 className="text-sm font-semibold">計算結果</h2>
+				<div className="flex items-center gap-2">
+					<Switch
+						id="uppercase-toggle"
+						checked={uppercase}
+						onCheckedChange={onUppercaseChange}
+					/>
+					<Label
+						htmlFor="uppercase-toggle"
+						className="text-sm cursor-pointer text-muted-foreground"
+					>
+						大文字で表示
+					</Label>
+				</div>
+			</div>
+			<div className="space-y-2">
+				{rows.map((algorithm) => {
+					const raw = results[algorithm];
+					// Preview = Export: コピーする値は表示と同一にする
+					const displayValue =
+						raw != null ? (uppercase ? raw.toUpperCase() : raw) : null;
+					return (
+						<div
+							key={algorithm}
+							className="rounded-lg border border-border p-3"
+							data-testid={`hash-result-${algorithm}`}
+						>
+							<div className="flex items-center justify-between gap-2">
+								<span className="text-xs font-semibold text-muted-foreground">
+									{HASH_ALGORITHM_LABELS[algorithm]}
+								</span>
+								{displayValue != null && (
+									<CopyButton text={displayValue} size="sm" variant="ghost" />
+								)}
+							</div>
+							<p className="mt-1 font-mono text-sm break-all min-h-5">
+								{displayValue ??
+									(computing ? (
+										<span className="text-muted-foreground">計算中…</span>
+									) : (
+										<span className="text-muted-foreground">—</span>
+									))}
+							</p>
+						</div>
+					);
+				})}
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/hash-generator/HashVerifier.tsx
+++ b/src/components/tools/hash-generator/HashVerifier.tsx
@@ -1,0 +1,95 @@
+import { CheckCircle2, HelpCircle, XCircle } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+	compareHash,
+	detectAlgorithmByLength,
+	HASH_ALGORITHM_LABELS,
+	type HashAlgorithm,
+	type HashResults,
+	normalizeHash,
+} from '@/lib/tools/hash';
+
+type VerifyVerdict =
+	| { kind: 'empty' }
+	| { kind: 'unknown-length' }
+	| { kind: 'not-selected'; algorithm: HashAlgorithm }
+	| { kind: 'pending'; algorithm: HashAlgorithm }
+	| { kind: 'match'; algorithm: HashAlgorithm }
+	| { kind: 'mismatch'; algorithm: HashAlgorithm };
+
+interface HashVerifierProps {
+	results: HashResults;
+	selectedAlgorithms: readonly HashAlgorithm[];
+}
+
+export function HashVerifier({
+	results,
+	selectedAlgorithms,
+}: HashVerifierProps) {
+	const [expected, setExpected] = useState('');
+
+	const verdict = useMemo<VerifyVerdict>(() => {
+		const normalized = normalizeHash(expected);
+		if (!normalized) return { kind: 'empty' };
+		const algorithm = detectAlgorithmByLength(normalized);
+		if (!algorithm) return { kind: 'unknown-length' };
+		// 検出されたアルゴリズムが未選択でも自動で計算対象には追加しない（仕様）
+		if (!selectedAlgorithms.includes(algorithm)) {
+			return { kind: 'not-selected', algorithm };
+		}
+		const computed = results[algorithm];
+		if (computed == null) return { kind: 'pending', algorithm };
+		return compareHash(computed, expected)
+			? { kind: 'match', algorithm }
+			: { kind: 'mismatch', algorithm };
+	}, [expected, results, selectedAlgorithms]);
+
+	return (
+		<div className="rounded-lg border border-border p-4 space-y-3">
+			<Label htmlFor="expected-hash" className="text-sm font-semibold">
+				期待値との照合（ファイルの改ざん・破損チェック）
+			</Label>
+			<Input
+				id="expected-hash"
+				value={expected}
+				onChange={(e) => setExpected(e.target.value)}
+				placeholder="配布元のハッシュ値を貼り付けると自動で照合します"
+				className="font-mono"
+			/>
+			<div data-testid="hash-verify-result" className="min-h-6 text-sm">
+				{verdict.kind === 'unknown-length' && (
+					<span className="inline-flex items-center gap-1.5 text-muted-foreground">
+						<HelpCircle className="h-4 w-4 shrink-0" />
+						ハッシュ値の長さからアルゴリズムを判定できません
+					</span>
+				)}
+				{verdict.kind === 'not-selected' && (
+					<span className="inline-flex items-center gap-1.5 text-amber-600 dark:text-amber-500">
+						<HelpCircle className="h-4 w-4 shrink-0" />
+						対象アルゴリズムを選択してください（検出:{' '}
+						{HASH_ALGORITHM_LABELS[verdict.algorithm]}）
+					</span>
+				)}
+				{verdict.kind === 'pending' && (
+					<span className="text-muted-foreground">
+						{HASH_ALGORITHM_LABELS[verdict.algorithm]} の計算結果を待っています…
+					</span>
+				)}
+				{verdict.kind === 'match' && (
+					<span className="inline-flex items-center gap-1.5 rounded-full bg-green-500/10 px-3 py-1 font-medium text-green-600 dark:text-green-500">
+						<CheckCircle2 className="h-4 w-4 shrink-0" />✅ 一致（
+						{HASH_ALGORITHM_LABELS[verdict.algorithm]}）
+					</span>
+				)}
+				{verdict.kind === 'mismatch' && (
+					<span className="inline-flex items-center gap-1.5 rounded-full bg-destructive/10 px-3 py-1 font-medium text-destructive">
+						<XCircle className="h-4 w-4 shrink-0" />❌ 不一致（
+						{HASH_ALGORITHM_LABELS[verdict.algorithm]}）
+					</span>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/json-csv/ConvertOptionsPanel.tsx
+++ b/src/components/tools/json-csv/ConvertOptionsPanel.tsx
@@ -88,7 +88,10 @@ export function ConvertOptionsPanel({
 									})
 								}
 							>
-								<SelectTrigger className="w-[130px] h-8 rounded-lg bg-background">
+								<SelectTrigger
+									aria-label="区切り文字"
+									className="w-[130px] h-8 rounded-lg bg-background"
+								>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -111,7 +114,10 @@ export function ConvertOptionsPanel({
 									})
 								}
 							>
-								<SelectTrigger className="w-[150px] h-8 rounded-lg bg-background">
+								<SelectTrigger
+									aria-label="改行コード"
+									className="w-[150px] h-8 rounded-lg bg-background"
+								>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>
@@ -158,7 +164,10 @@ export function ConvertOptionsPanel({
 									})
 								}
 							>
-								<SelectTrigger className="w-[130px] h-8 rounded-lg bg-background">
+								<SelectTrigger
+									aria-label="区切り文字"
+									className="w-[130px] h-8 rounded-lg bg-background"
+								>
 									<SelectValue />
 								</SelectTrigger>
 								<SelectContent>

--- a/src/components/tools/json-csv/ConvertOptionsPanel.tsx
+++ b/src/components/tools/json-csv/ConvertOptionsPanel.tsx
@@ -1,0 +1,201 @@
+import { Label } from '@/components/ui/label';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import type {
+	CsvDelimiter,
+	CsvToJsonOptions,
+	JsonToCsvOptions,
+} from '@/lib/tools/json-csv';
+
+export type Direction = 'json-to-csv' | 'csv-to-json';
+
+interface ConvertOptionsPanelProps {
+	direction: Direction;
+	jsonOpts: JsonToCsvOptions;
+	csvOpts: CsvToJsonOptions;
+	withBom: boolean;
+	onJsonOptsChange: (options: JsonToCsvOptions) => void;
+	onCsvOptsChange: (options: CsvToJsonOptions) => void;
+	onWithBomChange: (value: boolean) => void;
+}
+
+const DELIMITER_VALUES: Record<string, CsvDelimiter> = {
+	comma: ',',
+	tab: '\t',
+	semicolon: ';',
+};
+
+function delimiterToKey(delimiter: CsvDelimiter | 'auto'): string {
+	if (delimiter === 'auto') return 'auto';
+	return (
+		Object.entries(DELIMITER_VALUES).find(([, v]) => v === delimiter)?.[0] ??
+		'comma'
+	);
+}
+
+function OptionSwitch({
+	id,
+	label,
+	checked,
+	onCheckedChange,
+}: {
+	id: string;
+	label: string;
+	checked: boolean;
+	onCheckedChange: (value: boolean) => void;
+}) {
+	return (
+		<div className="flex items-center gap-2">
+			<Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
+			<Label htmlFor={id} className="text-sm cursor-pointer">
+				{label}
+			</Label>
+		</div>
+	);
+}
+
+export function ConvertOptionsPanel({
+	direction,
+	jsonOpts,
+	csvOpts,
+	withBom,
+	onJsonOptsChange,
+	onCsvOptsChange,
+	onWithBomChange,
+}: ConvertOptionsPanelProps) {
+	return (
+		<div className="rounded-lg border border-border p-4">
+			<p className="text-sm font-semibold mb-3">変換オプション</p>
+			<div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+				{direction === 'json-to-csv' ? (
+					<>
+						<div className="flex items-center gap-2">
+							<Label className="text-sm text-muted-foreground">
+								区切り文字
+							</Label>
+							<Select
+								value={delimiterToKey(jsonOpts.delimiter)}
+								onValueChange={(key) =>
+									onJsonOptsChange({
+										...jsonOpts,
+										delimiter: DELIMITER_VALUES[key],
+									})
+								}
+							>
+								<SelectTrigger className="w-[130px] h-8 rounded-lg bg-background">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="comma">カンマ（,）</SelectItem>
+									<SelectItem value="tab">タブ</SelectItem>
+									<SelectItem value="semicolon">セミコロン（;）</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<div className="flex items-center gap-2">
+							<Label className="text-sm text-muted-foreground">
+								改行コード
+							</Label>
+							<Select
+								value={jsonOpts.newline === '\r\n' ? 'crlf' : 'lf'}
+								onValueChange={(key) =>
+									onJsonOptsChange({
+										...jsonOpts,
+										newline: key === 'crlf' ? '\r\n' : '\n',
+									})
+								}
+							>
+								<SelectTrigger className="w-[150px] h-8 rounded-lg bg-background">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="crlf">CRLF（Windows）</SelectItem>
+									<SelectItem value="lf">LF（Unix）</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<OptionSwitch
+							id="opt-include-header"
+							label="ヘッダー行を含める"
+							checked={jsonOpts.includeHeader}
+							onCheckedChange={(v) =>
+								onJsonOptsChange({ ...jsonOpts, includeHeader: v })
+							}
+						/>
+						<OptionSwitch
+							id="opt-flatten"
+							label="ネストを展開（ドット記法）"
+							checked={jsonOpts.flattenNested}
+							onCheckedChange={(v) =>
+								onJsonOptsChange({ ...jsonOpts, flattenNested: v })
+							}
+						/>
+						<OptionSwitch
+							id="opt-bom"
+							label="BOM付きUTF-8（Excel文字化け対策）"
+							checked={withBom}
+							onCheckedChange={onWithBomChange}
+						/>
+					</>
+				) : (
+					<>
+						<div className="flex items-center gap-2">
+							<Label className="text-sm text-muted-foreground">
+								区切り文字
+							</Label>
+							<Select
+								value={delimiterToKey(csvOpts.delimiter)}
+								onValueChange={(key) =>
+									onCsvOptsChange({
+										...csvOpts,
+										delimiter: key === 'auto' ? 'auto' : DELIMITER_VALUES[key],
+									})
+								}
+							>
+								<SelectTrigger className="w-[130px] h-8 rounded-lg bg-background">
+									<SelectValue />
+								</SelectTrigger>
+								<SelectContent>
+									<SelectItem value="auto">自動判定</SelectItem>
+									<SelectItem value="comma">カンマ（,）</SelectItem>
+									<SelectItem value="tab">タブ</SelectItem>
+									<SelectItem value="semicolon">セミコロン（;）</SelectItem>
+								</SelectContent>
+							</Select>
+						</div>
+						<OptionSwitch
+							id="opt-has-header"
+							label="1行目をヘッダーとして扱う"
+							checked={csvOpts.hasHeader}
+							onCheckedChange={(v) =>
+								onCsvOptsChange({ ...csvOpts, hasHeader: v })
+							}
+						/>
+						<OptionSwitch
+							id="opt-infer-types"
+							label="型推論（数値・真偽値・null）"
+							checked={csvOpts.inferTypes}
+							onCheckedChange={(v) =>
+								onCsvOptsChange({ ...csvOpts, inferTypes: v })
+							}
+						/>
+						<OptionSwitch
+							id="opt-unflatten"
+							label="ドット記法キーをネスト復元"
+							checked={csvOpts.unflattenDotKeys}
+							onCheckedChange={(v) =>
+								onCsvOptsChange({ ...csvOpts, unflattenDotKeys: v })
+							}
+						/>
+					</>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/json-csv/JsonCsvPage.tsx
+++ b/src/components/tools/json-csv/JsonCsvPage.tsx
@@ -1,0 +1,253 @@
+import { Download, FileJson, Sparkles, Zap } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import CopyButton from '@/components/common/CopyButton';
+import { FileDropzone } from '@/components/common/FileDropzone';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import { downloadBlob } from '@/lib/download';
+import {
+	buildCsvBlob,
+	type ConvertResult,
+	type CsvToJsonOptions,
+	csvToJson,
+	type JsonToCsvOptions,
+	jsonToCsv,
+} from '@/lib/tools/json-csv';
+import { ConvertOptionsPanel, type Direction } from './ConvertOptionsPanel';
+
+// 1MB以上の入力は自動変換を停止し、手動の「変換」ボタンに切り替える
+const MANUAL_MODE_THRESHOLD = 1024 * 1024;
+const MAX_INPUT_FILE_SIZE = 10 * 1024 * 1024;
+
+const SAMPLE_JSON = JSON.stringify(
+	[
+		{
+			name: '山田太郎',
+			age: 30,
+			contact: { email: 'taro@example.com', tel: '03-1234-5678' },
+			tags: ['営業', 'リーダー'],
+		},
+		{
+			name: '鈴木花子',
+			age: 25,
+			contact: { email: 'hanako@example.com', tel: '06-9876-5432' },
+			tags: ['開発'],
+		},
+	],
+	null,
+	2,
+);
+
+const SAMPLE_CSV = [
+	'name,age,department,active',
+	'山田太郎,30,営業部,true',
+	'鈴木花子,25,開発部,false',
+	'佐藤次郎,41,人事部,true',
+].join('\r\n');
+
+export function JsonCsvPage() {
+	const [direction, setDirection] = useState<Direction>('json-to-csv');
+	const [input, setInput] = useState('');
+	const [result, setResult] = useState<ConvertResult | null>(null);
+	const [jsonOpts, setJsonOpts] = useState<JsonToCsvOptions>({
+		delimiter: ',',
+		includeHeader: true,
+		flattenNested: true,
+		newline: '\r\n',
+	});
+	const [csvOpts, setCsvOpts] = useState<CsvToJsonOptions>({
+		delimiter: 'auto',
+		hasHeader: true,
+		inferTypes: true,
+		unflattenDotKeys: false,
+	});
+	const [withBom, setWithBom] = useState(true);
+
+	const isManualMode = input.length >= MANUAL_MODE_THRESHOLD;
+
+	const convert = useCallback(() => {
+		if (!input.trim()) {
+			setResult(null);
+			return;
+		}
+		setResult(
+			direction === 'json-to-csv'
+				? jsonToCsv(input, jsonOpts)
+				: csvToJson(input, csvOpts),
+		);
+	}, [input, direction, jsonOpts, csvOpts]);
+
+	// 自動変換（300ms debounce）。1MB以上は手動実行に切り替え
+	useEffect(() => {
+		if (isManualMode) return;
+		const timer = setTimeout(convert, 300);
+		return () => clearTimeout(timer);
+	}, [convert, isManualMode]);
+
+	const handleDirectionChange = useCallback((value: string) => {
+		setDirection(value as Direction);
+		setResult(null);
+	}, []);
+
+	const handleFileSelect = useCallback(async (file: File) => {
+		try {
+			setInput(await file.text());
+		} catch (_error) {
+			setResult({ ok: false, error: 'ファイルの読み込みに失敗しました。' });
+		}
+	}, []);
+
+	const handleSample = useCallback(() => {
+		setInput(direction === 'json-to-csv' ? SAMPLE_JSON : SAMPLE_CSV);
+	}, [direction]);
+
+	const handleDownload = useCallback(() => {
+		if (!result?.ok || !result.output) return;
+		if (direction === 'json-to-csv') {
+			// Preview = Export: 画面表示と同じ output からBlobを生成する
+			downloadBlob(buildCsvBlob(result.output, withBom), 'converted.csv');
+		} else {
+			downloadBlob(
+				new Blob([result.output], { type: 'application/json;charset=utf-8' }),
+				'converted.json',
+			);
+		}
+	}, [result, direction, withBom]);
+
+	const output = result?.ok ? result.output : '';
+	const inputLabel = direction === 'json-to-csv' ? 'JSON' : 'CSV';
+	const outputLabel = direction === 'json-to-csv' ? 'CSV' : 'JSON';
+
+	return (
+		<div className="space-y-4">
+			{/* 変換方向トグル */}
+			<Tabs value={direction} onValueChange={handleDirectionChange}>
+				<TabsList className="w-full grid grid-cols-2">
+					<TabsTrigger value="json-to-csv">JSON → CSV</TabsTrigger>
+					<TabsTrigger value="csv-to-json">CSV → JSON</TabsTrigger>
+				</TabsList>
+			</Tabs>
+
+			{/* オプション */}
+			<ConvertOptionsPanel
+				direction={direction}
+				jsonOpts={jsonOpts}
+				csvOpts={csvOpts}
+				withBom={withBom}
+				onJsonOptsChange={setJsonOpts}
+				onCsvOptsChange={setCsvOpts}
+				onWithBomChange={setWithBom}
+			/>
+
+			{/* 入力 / 出力 2ペイン（モバイルは縦積み） */}
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+				{/* 入力ペイン */}
+				<div className="space-y-2">
+					<div className="flex items-center justify-between min-h-8">
+						<span className="text-sm font-semibold">{inputLabel} 入力</span>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={handleSample}
+							className="gap-1.5"
+						>
+							<Sparkles className="h-3.5 w-3.5" />
+							サンプルデータ
+						</Button>
+					</div>
+					<Textarea
+						value={input}
+						onChange={(e) => setInput(e.target.value)}
+						placeholder={
+							direction === 'json-to-csv'
+								? '[{"name":"山田太郎","age":30}] のようなJSON配列を入力'
+								: 'name,age\n山田太郎,30 のようなCSVを入力'
+						}
+						className="min-h-64 font-mono text-sm"
+						aria-label={`${inputLabel}入力`}
+					/>
+					<FileDropzone
+						onFileSelect={handleFileSelect}
+						onValidationError={(message) =>
+							setResult({ ok: false, error: message })
+						}
+						accept=".json,.csv,.txt"
+						maxSizeBytes={MAX_INPUT_FILE_SIZE}
+						validationMessage="ファイルサイズは10MB以下にしてください。"
+						label="ファイルから読み込み"
+						description="JSON / CSV / テキストファイル（.json .csv .txt）"
+						inputAriaLabel="変換するファイルを選択"
+						data-testid="json-csv-file-input"
+					/>
+					{isManualMode && (
+						<div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm">
+							<Zap className="h-4 w-4 shrink-0 text-amber-500" />
+							<span className="text-muted-foreground">
+								1MB以上の入力のため自動変換を停止しています。
+							</span>
+							<Button size="sm" className="ml-auto shrink-0" onClick={convert}>
+								変換
+							</Button>
+						</div>
+					)}
+				</div>
+
+				{/* 出力ペイン */}
+				<div className="space-y-2">
+					<div className="flex items-center justify-between min-h-8 gap-2">
+						<span className="text-sm font-semibold">{outputLabel} 出力</span>
+						<div className="flex items-center gap-2">
+							{result?.ok && result.output && (
+								<>
+									<Badge variant="outline" className="text-xs">
+										{result.rowCount}行を変換しました
+									</Badge>
+									<CopyButton text={output} size="sm" />
+									<Button
+										variant="outline"
+										size="sm"
+										onClick={handleDownload}
+										className="gap-1.5"
+									>
+										<Download className="h-3.5 w-3.5" />
+										ダウンロード
+									</Button>
+								</>
+							)}
+						</div>
+					</div>
+					{result && !result.ok ? (
+						<div
+							className="rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive min-h-64"
+							role="alert"
+							data-testid="json-csv-error"
+						>
+							<p className="font-medium">変換エラー</p>
+							<p className="mt-1">{result.error}</p>
+						</div>
+					) : (
+						<Textarea
+							value={output}
+							readOnly
+							placeholder={`変換結果（${outputLabel}）がここに表示されます`}
+							className="min-h-64 font-mono text-sm bg-muted/30"
+							aria-label={`${outputLabel}出力`}
+						/>
+					)}
+					{direction === 'json-to-csv' && result?.ok && result.output && (
+						<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+							<FileJson className="h-3.5 w-3.5 shrink-0" />
+							ダウンロード時は
+							{withBom
+								? 'BOM付きUTF-8で保存されます（Excelで文字化けしません）'
+								: 'BOMなしUTF-8で保存されます'}
+							。
+						</p>
+					)}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/json-csv/JsonCsvPage.tsx
+++ b/src/components/tools/json-csv/JsonCsvPage.tsx
@@ -4,7 +4,7 @@ import CopyButton from '@/components/common/CopyButton';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { downloadBlob } from '@/lib/download';
 import {
@@ -121,133 +121,141 @@ export function JsonCsvPage() {
 	const outputLabel = direction === 'json-to-csv' ? 'CSV' : 'JSON';
 
 	return (
-		<div className="space-y-4">
+		<Tabs
+			value={direction}
+			onValueChange={handleDirectionChange}
+			className="gap-4"
+		>
 			{/* 変換方向トグル */}
-			<Tabs value={direction} onValueChange={handleDirectionChange}>
-				<TabsList className="w-full grid grid-cols-2">
-					<TabsTrigger value="json-to-csv">JSON → CSV</TabsTrigger>
-					<TabsTrigger value="csv-to-json">CSV → JSON</TabsTrigger>
-				</TabsList>
-			</Tabs>
+			<TabsList className="w-full grid grid-cols-2">
+				<TabsTrigger value="json-to-csv">JSON → CSV</TabsTrigger>
+				<TabsTrigger value="csv-to-json">CSV → JSON</TabsTrigger>
+			</TabsList>
 
-			{/* オプション */}
-			<ConvertOptionsPanel
-				direction={direction}
-				jsonOpts={jsonOpts}
-				csvOpts={csvOpts}
-				withBom={withBom}
-				onJsonOptsChange={setJsonOpts}
-				onCsvOptsChange={setCsvOpts}
-				onWithBomChange={setWithBom}
-			/>
+			<TabsContent value={direction} className="space-y-4">
+				{/* オプション */}
+				<ConvertOptionsPanel
+					direction={direction}
+					jsonOpts={jsonOpts}
+					csvOpts={csvOpts}
+					withBom={withBom}
+					onJsonOptsChange={setJsonOpts}
+					onCsvOptsChange={setCsvOpts}
+					onWithBomChange={setWithBom}
+				/>
 
-			{/* 入力 / 出力 2ペイン（モバイルは縦積み） */}
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-				{/* 入力ペイン */}
-				<div className="space-y-2">
-					<div className="flex items-center justify-between min-h-8">
-						<span className="text-sm font-semibold">{inputLabel} 入力</span>
-						<Button
-							variant="outline"
-							size="sm"
-							onClick={handleSample}
-							className="gap-1.5"
-						>
-							<Sparkles className="h-3.5 w-3.5" />
-							サンプルデータ
-						</Button>
-					</div>
-					<Textarea
-						value={input}
-						onChange={(e) => setInput(e.target.value)}
-						placeholder={
-							direction === 'json-to-csv'
-								? '[{"name":"山田太郎","age":30}] のようなJSON配列を入力'
-								: 'name,age\n山田太郎,30 のようなCSVを入力'
-						}
-						className="min-h-64 font-mono text-sm"
-						aria-label={`${inputLabel}入力`}
-					/>
-					<FileDropzone
-						onFileSelect={handleFileSelect}
-						onValidationError={(message) =>
-							setResult({ ok: false, error: message })
-						}
-						accept=".json,.csv,.txt"
-						maxSizeBytes={MAX_INPUT_FILE_SIZE}
-						validationMessage="ファイルサイズは10MB以下にしてください。"
-						label="ファイルから読み込み"
-						description="JSON / CSV / テキストファイル（.json .csv .txt）"
-						inputAriaLabel="変換するファイルを選択"
-						data-testid="json-csv-file-input"
-					/>
-					{isManualMode && (
-						<div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm">
-							<Zap className="h-4 w-4 shrink-0 text-amber-500" />
-							<span className="text-muted-foreground">
-								1MB以上の入力のため自動変換を停止しています。
-							</span>
-							<Button size="sm" className="ml-auto shrink-0" onClick={convert}>
-								変換
+				{/* 入力 / 出力 2ペイン（モバイルは縦積み） */}
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					{/* 入力ペイン */}
+					<div className="space-y-2">
+						<div className="flex items-center justify-between min-h-8">
+							<span className="text-sm font-semibold">{inputLabel} 入力</span>
+							<Button
+								variant="outline"
+								size="sm"
+								onClick={handleSample}
+								className="gap-1.5"
+							>
+								<Sparkles className="h-3.5 w-3.5" />
+								サンプルデータ
 							</Button>
 						</div>
-					)}
-				</div>
-
-				{/* 出力ペイン */}
-				<div className="space-y-2">
-					<div className="flex items-center justify-between min-h-8 gap-2">
-						<span className="text-sm font-semibold">{outputLabel} 出力</span>
-						<div className="flex items-center gap-2">
-							{result?.ok && result.output && (
-								<>
-									<Badge variant="outline" className="text-xs">
-										{result.rowCount}行を変換しました
-									</Badge>
-									<CopyButton text={output} size="sm" />
-									<Button
-										variant="outline"
-										size="sm"
-										onClick={handleDownload}
-										className="gap-1.5"
-									>
-										<Download className="h-3.5 w-3.5" />
-										ダウンロード
-									</Button>
-								</>
-							)}
-						</div>
-					</div>
-					{result && !result.ok ? (
-						<div
-							className="rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive min-h-64"
-							role="alert"
-							data-testid="json-csv-error"
-						>
-							<p className="font-medium">変換エラー</p>
-							<p className="mt-1">{result.error}</p>
-						</div>
-					) : (
 						<Textarea
-							value={output}
-							readOnly
-							placeholder={`変換結果（${outputLabel}）がここに表示されます`}
-							className="min-h-64 font-mono text-sm bg-muted/30"
-							aria-label={`${outputLabel}出力`}
+							value={input}
+							onChange={(e) => setInput(e.target.value)}
+							placeholder={
+								direction === 'json-to-csv'
+									? '[{"name":"山田太郎","age":30}] のようなJSON配列を入力'
+									: 'name,age\n山田太郎,30 のようなCSVを入力'
+							}
+							className="min-h-64 font-mono text-sm"
+							aria-label={`${inputLabel}入力`}
 						/>
-					)}
-					{direction === 'json-to-csv' && result?.ok && result.output && (
-						<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
-							<FileJson className="h-3.5 w-3.5 shrink-0" />
-							ダウンロード時は
-							{withBom
-								? 'BOM付きUTF-8で保存されます（Excelで文字化けしません）'
-								: 'BOMなしUTF-8で保存されます'}
-							。
-						</p>
-					)}
+						<FileDropzone
+							onFileSelect={handleFileSelect}
+							onValidationError={(message) =>
+								setResult({ ok: false, error: message })
+							}
+							accept=".json,.csv,.txt"
+							maxSizeBytes={MAX_INPUT_FILE_SIZE}
+							validationMessage="ファイルサイズは10MB以下にしてください。"
+							label="ファイルから読み込み"
+							description="JSON / CSV / テキストファイル（.json .csv .txt）"
+							inputAriaLabel="変換するファイルを選択"
+							data-testid="json-csv-file-input"
+						/>
+						{isManualMode && (
+							<div className="flex items-center gap-2 rounded-lg border border-amber-500/30 bg-amber-500/5 p-3 text-sm">
+								<Zap className="h-4 w-4 shrink-0 text-amber-500" />
+								<span className="text-muted-foreground">
+									1MB以上の入力のため自動変換を停止しています。
+								</span>
+								<Button
+									size="sm"
+									className="ml-auto shrink-0"
+									onClick={convert}
+								>
+									変換
+								</Button>
+							</div>
+						)}
+					</div>
+
+					{/* 出力ペイン */}
+					<div className="space-y-2">
+						<div className="flex items-center justify-between min-h-8 gap-2">
+							<span className="text-sm font-semibold">{outputLabel} 出力</span>
+							<div className="flex items-center gap-2">
+								{result?.ok && result.output && (
+									<>
+										<Badge variant="outline" className="text-xs">
+											{result.rowCount}行を変換しました
+										</Badge>
+										<CopyButton text={output} size="sm" />
+										<Button
+											variant="outline"
+											size="sm"
+											onClick={handleDownload}
+											className="gap-1.5"
+										>
+											<Download className="h-3.5 w-3.5" />
+											ダウンロード
+										</Button>
+									</>
+								)}
+							</div>
+						</div>
+						{result && !result.ok ? (
+							<div
+								className="rounded-lg border border-destructive/50 bg-destructive/5 p-4 text-sm text-destructive min-h-64"
+								role="alert"
+								data-testid="json-csv-error"
+							>
+								<p className="font-medium">変換エラー</p>
+								<p className="mt-1">{result.error}</p>
+							</div>
+						) : (
+							<Textarea
+								value={output}
+								readOnly
+								placeholder={`変換結果（${outputLabel}）がここに表示されます`}
+								className="min-h-64 font-mono text-sm bg-muted/30"
+								aria-label={`${outputLabel}出力`}
+							/>
+						)}
+						{direction === 'json-to-csv' && result?.ok && result.output && (
+							<p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+								<FileJson className="h-3.5 w-3.5 shrink-0" />
+								ダウンロード時は
+								{withBom
+									? 'BOM付きUTF-8で保存されます（Excelで文字化けしません）'
+									: 'BOMなしUTF-8で保存されます'}
+								。
+							</p>
+						)}
+					</div>
 				</div>
-			</div>
-		</div>
+			</TabsContent>
+		</Tabs>
 	);
 }

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { XIcon } from 'lucide-react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
+import type * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+function Dialog({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+	return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+	return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+	return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+	return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+	return (
+		<DialogPrimitive.Overlay
+			data-slot="dialog-overlay"
+			className={cn(
+				'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogContent({
+	className,
+	children,
+	showCloseButton = true,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+	showCloseButton?: boolean;
+}) {
+	return (
+		<DialogPortal data-slot="dialog-portal">
+			<DialogOverlay />
+			<DialogPrimitive.Content
+				data-slot="dialog-content"
+				className={cn(
+					'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+					className,
+				)}
+				{...props}
+			>
+				{children}
+				{showCloseButton && (
+					<DialogPrimitive.Close
+						data-slot="dialog-close"
+						className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
+					>
+						<XIcon />
+						<span className="sr-only">閉じる</span>
+					</DialogPrimitive.Close>
+				)}
+			</DialogPrimitive.Content>
+		</DialogPortal>
+	);
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="dialog-header"
+			className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogFooter({ className, ...props }: React.ComponentProps<'div'>) {
+	return (
+		<div
+			data-slot="dialog-footer"
+			className={cn(
+				'flex flex-col-reverse gap-2 sm:flex-row sm:justify-end',
+				className,
+			)}
+			{...props}
+		/>
+	);
+}
+
+function DialogTitle({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+	return (
+		<DialogPrimitive.Title
+			data-slot="dialog-title"
+			className={cn('text-lg leading-none font-semibold', className)}
+			{...props}
+		/>
+	);
+}
+
+function DialogDescription({
+	className,
+	...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+	return (
+		<DialogPrimitive.Description
+			data-slot="dialog-description"
+			className={cn('text-muted-foreground text-sm', className)}
+			{...props}
+		/>
+	);
+}
+
+export {
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogOverlay,
+	DialogPortal,
+	DialogTitle,
+	DialogTrigger,
+};

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,0 +1,14 @@
+/**
+ * Blob をファイルとしてダウンロードする共通 helper。
+ * click 後に object URL を必ず revoke してメモリを解放する。
+ */
+export function downloadBlob(blob: Blob, filename: string): void {
+	const url = URL.createObjectURL(blob);
+	const a = document.createElement('a');
+	a.href = url;
+	a.download = filename;
+	document.body.appendChild(a);
+	a.click();
+	document.body.removeChild(a);
+	setTimeout(() => URL.revokeObjectURL(url), 1000);
+}

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -210,6 +210,17 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		keywords: ['暗号', '難読化', 'ROT13', 'モールス信号', 'シーザー暗号'],
 	},
 	{
+		id: 'hash',
+		title: 'ハッシュ値計算',
+		description:
+			'MD5・SHA-256等のハッシュ値をテキスト・ファイルから計算。ファイルの改ざん・破損チェックに。',
+		href: '/hash',
+		icon: '🔏',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: ['ハッシュ', 'MD5', 'SHA-256', 'チェックサム', 'CRC32', '改ざん'],
+	},
+	{
 		id: 'bg-remove',
 		title: '背景削除',
 		description:

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -210,6 +210,17 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		keywords: ['暗号', '難読化', 'ROT13', 'モールス信号', 'シーザー暗号'],
 	},
 	{
+		id: 'json-csv',
+		title: 'JSON ↔ CSV 変換',
+		description:
+			'JSONとCSVを相互変換。ネスト展開・型推論・Excel文字化け対策のBOM付きUTF-8出力に対応。',
+		href: '/json-csv',
+		icon: '🔁',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		keywords: ['JSON', 'CSV', '変換', 'BOM', 'Excel', 'フラット化'],
+	},
+	{
 		id: 'hash',
 		title: 'ハッシュ値計算',
 		description:

--- a/src/lib/tools/hash.ts
+++ b/src/lib/tools/hash.ts
@@ -1,0 +1,368 @@
+export type HashAlgorithm = 'md5' | 'sha1' | 'sha256' | 'sha512' | 'crc32';
+
+export type HashResults = Partial<Record<HashAlgorithm, string>>;
+
+export type HashInputValidation =
+	| { ok: true; warnLevel: 'none' | 'large' | 'huge' }
+	| { ok: false; reason: 'too-large-file' };
+
+export const MAX_FILE_SIZE = 256 * 1024 * 1024;
+export const LARGE_FILE_THRESHOLD = 100 * 1024 * 1024;
+export const HUGE_FILE_THRESHOLD = 200 * 1024 * 1024;
+const CHUNK_SIZE = 8 * 1024 * 1024;
+
+export const HASH_ALGORITHMS: readonly HashAlgorithm[] = [
+	'md5',
+	'sha1',
+	'sha256',
+	'sha512',
+	'crc32',
+];
+
+export const HASH_ALGORITHM_LABELS: Record<HashAlgorithm, string> = {
+	md5: 'MD5',
+	sha1: 'SHA-1',
+	sha256: 'SHA-256',
+	sha512: 'SHA-512',
+	crc32: 'CRC32',
+};
+
+const SUBTLE_NAMES = {
+	sha1: 'SHA-1',
+	sha256: 'SHA-256',
+	sha512: 'SHA-512',
+} as const;
+
+type ShaAlgorithm = keyof typeof SUBTLE_NAMES;
+
+export function isShaAlgorithm(
+	algorithm: HashAlgorithm,
+): algorithm is ShaAlgorithm {
+	return (
+		algorithm === 'sha1' || algorithm === 'sha256' || algorithm === 'sha512'
+	);
+}
+
+interface IncrementalHasher {
+	update(chunk: Uint8Array): void;
+	digest(): string;
+}
+
+// ---------------------------------------------------------------------------
+// MD5（RFC 1321 準拠・ゼロ依存純TS実装。update/digest のインクリメンタル方式）
+// ---------------------------------------------------------------------------
+
+const MD5_K = new Int32Array(64);
+for (let i = 0; i < 64; i++) {
+	MD5_K[i] = Math.floor(Math.abs(Math.sin(i + 1)) * 2 ** 32) | 0;
+}
+
+// biome-ignore format: 4ラウンド×16のシフト量テーブル
+const MD5_S = [
+	7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22, 7, 12, 17, 22,
+	5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20, 5, 9, 14, 20,
+	4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23, 4, 11, 16, 23,
+	6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21, 6, 10, 15, 21,
+];
+
+export function createMd5(): IncrementalHasher {
+	let a = 0x67452301;
+	let b = 0xefcdab89 | 0;
+	let c = 0x98badcfe | 0;
+	let d = 0x10325476;
+	const buffer = new Uint8Array(64);
+	let bufferLen = 0;
+	let totalBytes = 0;
+	const m = new Int32Array(16);
+
+	function processBlock(bytes: Uint8Array, offset: number): void {
+		for (let i = 0; i < 16; i++) {
+			const o = offset + i * 4;
+			m[i] =
+				bytes[o] |
+				(bytes[o + 1] << 8) |
+				(bytes[o + 2] << 16) |
+				(bytes[o + 3] << 24);
+		}
+		let x = a;
+		let y = b;
+		let z = c;
+		let w = d;
+		for (let i = 0; i < 64; i++) {
+			let f: number;
+			let g: number;
+			if (i < 16) {
+				f = (y & z) | (~y & w);
+				g = i;
+			} else if (i < 32) {
+				f = (w & y) | (~w & z);
+				g = (5 * i + 1) % 16;
+			} else if (i < 48) {
+				f = y ^ z ^ w;
+				g = (3 * i + 5) % 16;
+			} else {
+				f = z ^ (y | ~w);
+				g = (7 * i) % 16;
+			}
+			const tmp = w;
+			w = z;
+			z = y;
+			const sum = (x + f + MD5_K[i] + m[g]) | 0;
+			const s = MD5_S[i];
+			y = (y + ((sum << s) | (sum >>> (32 - s)))) | 0;
+			x = tmp;
+		}
+		a = (a + x) | 0;
+		b = (b + y) | 0;
+		c = (c + z) | 0;
+		d = (d + w) | 0;
+	}
+
+	function update(chunk: Uint8Array): void {
+		totalBytes += chunk.length;
+		let offset = 0;
+		if (bufferLen > 0) {
+			const need = 64 - bufferLen;
+			const take = Math.min(need, chunk.length);
+			buffer.set(chunk.subarray(0, take), bufferLen);
+			bufferLen += take;
+			offset = take;
+			if (bufferLen < 64) return;
+			processBlock(buffer, 0);
+			bufferLen = 0;
+		}
+		while (offset + 64 <= chunk.length) {
+			processBlock(chunk, offset);
+			offset += 64;
+		}
+		if (offset < chunk.length) {
+			buffer.set(chunk.subarray(offset), 0);
+			bufferLen = chunk.length - offset;
+		}
+	}
+
+	function digest(): string {
+		const bitLen = totalBytes * 8;
+		update(new Uint8Array([0x80]));
+		// update() が totalBytes を進めるためビット長は事前に確定しておく
+		while (bufferLen !== 56) {
+			update(new Uint8Array(1));
+		}
+		const lenBytes = new Uint8Array(8);
+		const lo = bitLen >>> 0;
+		const hi = Math.floor(bitLen / 0x100000000);
+		lenBytes[0] = lo & 0xff;
+		lenBytes[1] = (lo >>> 8) & 0xff;
+		lenBytes[2] = (lo >>> 16) & 0xff;
+		lenBytes[3] = (lo >>> 24) & 0xff;
+		lenBytes[4] = hi & 0xff;
+		lenBytes[5] = (hi >>> 8) & 0xff;
+		lenBytes[6] = (hi >>> 16) & 0xff;
+		lenBytes[7] = (hi >>> 24) & 0xff;
+		update(lenBytes);
+		const out = new Uint8Array(16);
+		const words = [a, b, c, d];
+		for (let i = 0; i < 4; i++) {
+			out[i * 4] = words[i] & 0xff;
+			out[i * 4 + 1] = (words[i] >>> 8) & 0xff;
+			out[i * 4 + 2] = (words[i] >>> 16) & 0xff;
+			out[i * 4 + 3] = (words[i] >>> 24) & 0xff;
+		}
+		return toHex(out);
+	}
+
+	return { update, digest };
+}
+
+// ---------------------------------------------------------------------------
+// CRC32（テーブル方式・多項式 0xEDB88320）
+// ---------------------------------------------------------------------------
+
+let crc32Table: Uint32Array | null = null;
+
+function getCrc32Table(): Uint32Array {
+	if (crc32Table) return crc32Table;
+	const table = new Uint32Array(256);
+	for (let n = 0; n < 256; n++) {
+		let c = n;
+		for (let k = 0; k < 8; k++) {
+			c = c & 1 ? 0xedb88320 ^ (c >>> 1) : c >>> 1;
+		}
+		table[n] = c >>> 0;
+	}
+	crc32Table = table;
+	return table;
+}
+
+export function createCrc32(): IncrementalHasher {
+	const table = getCrc32Table();
+	let crc = 0xffffffff;
+
+	return {
+		update(chunk: Uint8Array): void {
+			for (let i = 0; i < chunk.length; i++) {
+				crc = table[(crc ^ chunk[i]) & 0xff] ^ (crc >>> 8);
+			}
+		},
+		digest(): string {
+			// unsigned 32bit に正規化し、常にゼロ埋め8桁の小文字hexで返す
+			return ((crc ^ 0xffffffff) >>> 0).toString(16).padStart(8, '0');
+		},
+	};
+}
+
+// ---------------------------------------------------------------------------
+// 公開API
+// ---------------------------------------------------------------------------
+
+function toHex(bytes: Uint8Array): string {
+	let hex = '';
+	for (let i = 0; i < bytes.length; i++) {
+		hex += bytes[i].toString(16).padStart(2, '0');
+	}
+	return hex;
+}
+
+function createIncrementalHasher(
+	algorithm: 'md5' | 'crc32',
+): IncrementalHasher {
+	return algorithm === 'md5' ? createMd5() : createCrc32();
+}
+
+async function digestSha(
+	algorithm: ShaAlgorithm,
+	bytes: Uint8Array,
+): Promise<string> {
+	const buf = await crypto.subtle.digest(
+		SUBTLE_NAMES[algorithm],
+		bytes as BufferSource,
+	);
+	return toHex(new Uint8Array(buf));
+}
+
+export async function hashText(
+	text: string,
+	algorithms: readonly HashAlgorithm[],
+): Promise<HashResults> {
+	const bytes = new TextEncoder().encode(text);
+	const results: HashResults = {};
+	for (const algorithm of algorithms) {
+		if (isShaAlgorithm(algorithm)) {
+			results[algorithm] = await digestSha(algorithm, bytes);
+		} else {
+			const hasher = createIncrementalHasher(algorithm);
+			hasher.update(bytes);
+			results[algorithm] = hasher.digest();
+		}
+	}
+	return results;
+}
+
+export async function hashFile(
+	file: File,
+	algorithms: readonly HashAlgorithm[],
+	onProgress?: (percent: number) => void,
+	chunkSize: number = CHUNK_SIZE,
+): Promise<HashResults> {
+	const shaAlgorithms = algorithms.filter(isShaAlgorithm);
+	const incrementalAlgorithms = algorithms.filter(
+		(a): a is 'md5' | 'crc32' => a === 'md5' || a === 'crc32',
+	);
+
+	// SHA系は Web Crypto の制約上フルバッファが必要。未選択ならチャンク分のみ確保する
+	let fullBuffer: Uint8Array | null = null;
+	if (shaAlgorithms.length > 0 && file.size > 0) {
+		try {
+			fullBuffer = new Uint8Array(file.size);
+		} catch (_error) {
+			throw new Error(
+				'メモリ不足のためハッシュを計算できませんでした。ファイルサイズを小さくするか、SHA系以外のアルゴリズムをお試しください。',
+			);
+		}
+	}
+
+	const hashers = incrementalAlgorithms.map((a) => ({
+		algorithm: a,
+		hasher: createIncrementalHasher(a),
+	}));
+
+	// 進捗の作業量モデル: 読み取り = file.size、SHA 1アルゴリズムごとに + file.size
+	const totalUnits = file.size * (1 + shaAlgorithms.length);
+	let doneUnits = 0;
+	const reportProgress = () => {
+		if (!onProgress) return;
+		onProgress(
+			totalUnits === 0 ? 100 : Math.min(100, (doneUnits / totalUnits) * 100),
+		);
+	};
+
+	for (let offset = 0; offset < file.size; offset += chunkSize) {
+		const slice = file.slice(offset, Math.min(offset + chunkSize, file.size));
+		const chunk = new Uint8Array(await slice.arrayBuffer());
+		for (const { hasher } of hashers) {
+			hasher.update(chunk);
+		}
+		fullBuffer?.set(chunk, offset);
+		doneUnits += chunk.length;
+		reportProgress();
+	}
+
+	const results: HashResults = {};
+	for (const { algorithm, hasher } of hashers) {
+		results[algorithm] = hasher.digest();
+	}
+	for (const algorithm of shaAlgorithms) {
+		results[algorithm] = await digestSha(
+			algorithm,
+			fullBuffer ?? new Uint8Array(0),
+		);
+		doneUnits += file.size;
+		reportProgress();
+	}
+
+	fullBuffer = null;
+	onProgress?.(100);
+	return results;
+}
+
+export function validateHashFile(
+	file: Pick<File, 'size'>,
+): HashInputValidation {
+	if (file.size > MAX_FILE_SIZE) {
+		return { ok: false, reason: 'too-large-file' };
+	}
+	if (file.size > HUGE_FILE_THRESHOLD) {
+		return { ok: true, warnLevel: 'huge' };
+	}
+	if (file.size > LARGE_FILE_THRESHOLD) {
+		return { ok: true, warnLevel: 'large' };
+	}
+	return { ok: true, warnLevel: 'none' };
+}
+
+export function normalizeHash(value: string): string {
+	return value.trim().replace(/[\s-]/g, '').toLowerCase();
+}
+
+export function compareHash(computed: string, expected: string): boolean {
+	return normalizeHash(computed) === normalizeHash(expected);
+}
+
+export function detectAlgorithmByLength(hex: string): HashAlgorithm | null {
+	const normalized = normalizeHash(hex);
+	if (!/^[0-9a-f]+$/.test(normalized)) return null;
+	switch (normalized.length) {
+		case 8:
+			return 'crc32';
+		case 32:
+			return 'md5';
+		case 40:
+			return 'sha1';
+		case 64:
+			return 'sha256';
+		case 128:
+			return 'sha512';
+		default:
+			return null;
+	}
+}

--- a/src/lib/tools/json-csv.ts
+++ b/src/lib/tools/json-csv.ts
@@ -72,6 +72,31 @@ function makeUniqueHeaders(headers: readonly string[]): string[] {
 	});
 }
 
+function normalizeRecordNewlines(csvText: string): string {
+	let normalized = '';
+	let inQuotes = false;
+	for (let i = 0; i < csvText.length; i++) {
+		const ch = csvText[i];
+		if (ch === '"') {
+			normalized += ch;
+			if (inQuotes && csvText[i + 1] === '"') {
+				normalized += csvText[i + 1];
+				i++;
+				continue;
+			}
+			inQuotes = !inQuotes;
+			continue;
+		}
+		if (!inQuotes && ch === '\r') {
+			if (csvText[i + 1] === '\n') i++;
+			normalized += '\n';
+			continue;
+		}
+		normalized += ch;
+	}
+	return normalized;
+}
+
 /**
  * ネスト構造をドット記法（user.name）にフラット化する。配列はインデックス記法（items.0）。
  * 空オブジェクト・空配列はキーを生成しない（完全復元は対象外）。
@@ -311,13 +336,10 @@ export function csvToJson(
 
 	const delimiter =
 		options.delimiter === 'auto' ? detectDelimiter(text) : options.delimiter;
-
-	// \r\n と \n の混在入力を読み取れるよう正規化する
-	// （クォート内の \r\n も \n になるが、混在入力の安全な読み取りを優先する）
-	const normalized = text.replace(/\r\n/g, '\n');
+	const parseText = normalizeRecordNewlines(text);
 
 	// ヘッダー処理・列数調整・型推論は自前で行うため header: false 固定
-	const result = Papa.parse<string[]>(normalized, {
+	const result = Papa.parse<string[]>(parseText, {
 		delimiter,
 		header: false,
 		skipEmptyLines: 'greedy',

--- a/src/lib/tools/json-csv.ts
+++ b/src/lib/tools/json-csv.ts
@@ -38,6 +38,40 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 	);
 }
 
+function getOwnValue(obj: Record<string, unknown>, key: string): unknown {
+	return Object.hasOwn(obj, key) ? obj[key] : undefined;
+}
+
+function setOwnValue(
+	obj: Record<string, unknown>,
+	key: string,
+	value: unknown,
+): void {
+	Object.defineProperty(obj, key, {
+		value,
+		enumerable: true,
+		configurable: true,
+		writable: true,
+	});
+}
+
+function makeUniqueHeaders(headers: readonly string[]): string[] {
+	const used = new Set<string>();
+	const counts = new Map<string, number>();
+	return headers.map((header) => {
+		let count = (counts.get(header) ?? 0) + 1;
+		counts.set(header, count);
+		let candidate = count === 1 ? header : `${header}_${count}`;
+		while (used.has(candidate)) {
+			count++;
+			counts.set(header, count);
+			candidate = `${header}_${count}`;
+		}
+		used.add(candidate);
+		return candidate;
+	});
+}
+
 /**
  * ネスト構造をドット記法（user.name）にフラット化する。配列はインデックス記法（items.0）。
  * 空オブジェクト・空配列はキーを生成しない（完全復元は対象外）。
@@ -59,8 +93,11 @@ export function flattenObject(
 			}
 			return;
 		}
-		out[prefix] =
-			typeof value === 'object' && value !== null ? String(value) : value;
+		setOwnValue(
+			out,
+			prefix,
+			typeof value === 'object' && value !== null ? String(value) : value,
+		);
 	};
 	for (const [key, value] of Object.entries(obj)) {
 		walk(value, key);
@@ -84,13 +121,13 @@ export function unflattenObject(
 			const nextIsIndex = /^\d+$/.test(segments[i + 1]);
 			let child = Array.isArray(current)
 				? current[Number(segment)]
-				: current[segment];
+				: getOwnValue(current, segment);
 			if (child == null || typeof child !== 'object') {
 				child = nextIsIndex ? [] : {};
 				if (Array.isArray(current)) {
 					current[Number(segment)] = child;
 				} else {
-					current[segment] = child;
+					setOwnValue(current, segment, child);
 				}
 			}
 			current = child as Record<string, unknown> | unknown[];
@@ -99,7 +136,7 @@ export function unflattenObject(
 		if (Array.isArray(current)) {
 			current[Number(last)] = value;
 		} else {
-			current[last] = value;
+			setOwnValue(current, last, value);
 		}
 	}
 	return root;
@@ -319,7 +356,7 @@ export function csvToJson(
 	let headers: string[];
 	let dataRows: string[][];
 	if (options.hasHeader) {
-		headers = rawRows[0];
+		headers = makeUniqueHeaders(rawRows[0]);
 		dataRows = rawRows.slice(1);
 	} else {
 		const maxCols = Math.max(...rawRows.map((row) => row.length));
@@ -335,7 +372,7 @@ export function csvToJson(
 			const key =
 				i < headers.length ? headers[i] : `extra_${i - headers.length + 1}`;
 			const raw = i < row.length ? row[i] : '';
-			record[key] = options.inferTypes ? inferCellValue(raw) : raw;
+			setOwnValue(record, key, options.inferTypes ? inferCellValue(raw) : raw);
 		}
 		return options.unflattenDotKeys ? unflattenObject(record) : record;
 	});

--- a/src/lib/tools/json-csv.ts
+++ b/src/lib/tools/json-csv.ts
@@ -1,0 +1,356 @@
+import Papa from 'papaparse';
+
+export type CsvDelimiter = ',' | '\t' | ';';
+
+export interface JsonToCsvOptions {
+	delimiter: CsvDelimiter;
+	includeHeader: boolean;
+	flattenNested: boolean;
+	newline: '\r\n' | '\n';
+}
+
+export interface CsvToJsonOptions {
+	delimiter: CsvDelimiter | 'auto';
+	hasHeader: boolean;
+	inferTypes: boolean;
+	unflattenDotKeys: boolean;
+}
+
+export type ConvertResult =
+	| { ok: true; output: string; rowCount: number }
+	| { ok: false; error: string; line?: number };
+
+// ---------------------------------------------------------------------------
+// 共通ユーティリティ
+// ---------------------------------------------------------------------------
+
+/** 入力先頭のBOMを除去する */
+export function stripBom(text: string): string {
+	return text.charCodeAt(0) === 0xfeff ? text.slice(1) : text;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return (
+		typeof value === 'object' &&
+		value !== null &&
+		!Array.isArray(value) &&
+		Object.getPrototypeOf(value) === Object.prototype
+	);
+}
+
+/**
+ * ネスト構造をドット記法（user.name）にフラット化する。配列はインデックス記法（items.0）。
+ * 空オブジェクト・空配列はキーを生成しない（完全復元は対象外）。
+ */
+export function flattenObject(
+	obj: Record<string, unknown>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	const walk = (value: unknown, prefix: string): void => {
+		if (Array.isArray(value)) {
+			value.forEach((item, index) => {
+				walk(item, `${prefix}.${index}`);
+			});
+			return;
+		}
+		if (isPlainObject(value)) {
+			for (const [key, child] of Object.entries(value)) {
+				walk(child, `${prefix}.${key}`);
+			}
+			return;
+		}
+		out[prefix] =
+			typeof value === 'object' && value !== null ? String(value) : value;
+	};
+	for (const [key, value] of Object.entries(obj)) {
+		walk(value, key);
+	}
+	return out;
+}
+
+/**
+ * ドット記法キーをネスト構造へ復元する。数値セグメントは配列として解釈する。
+ * 実キー名に `.` を含むケースや `items.0` 形式の実キーとの衝突は対象外（last-write-wins）。
+ */
+export function unflattenObject(
+	flat: Record<string, unknown>,
+): Record<string, unknown> {
+	const root: Record<string, unknown> = {};
+	for (const [key, value] of Object.entries(flat)) {
+		const segments = key.split('.');
+		let current: Record<string, unknown> | unknown[] = root;
+		for (let i = 0; i < segments.length - 1; i++) {
+			const segment = segments[i];
+			const nextIsIndex = /^\d+$/.test(segments[i + 1]);
+			let child = Array.isArray(current)
+				? current[Number(segment)]
+				: current[segment];
+			if (child == null || typeof child !== 'object') {
+				child = nextIsIndex ? [] : {};
+				if (Array.isArray(current)) {
+					current[Number(segment)] = child;
+				} else {
+					current[segment] = child;
+				}
+			}
+			current = child as Record<string, unknown> | unknown[];
+		}
+		const last = segments[segments.length - 1];
+		if (Array.isArray(current)) {
+			current[Number(last)] = value;
+		} else {
+			current[last] = value;
+		}
+	}
+	return root;
+}
+
+/**
+ * 1行目のクォート外に出現する区切り文字候補の数で判定する。同数の場合はカンマを優先。
+ */
+export function detectDelimiter(csvText: string): CsvDelimiter {
+	const counts: Record<CsvDelimiter, number> = { ',': 0, '\t': 0, ';': 0 };
+	let inQuotes = false;
+	for (let i = 0; i < csvText.length; i++) {
+		const ch = csvText[i];
+		if (ch === '"') {
+			if (inQuotes && csvText[i + 1] === '"') {
+				i++;
+				continue;
+			}
+			inQuotes = !inQuotes;
+			continue;
+		}
+		if (!inQuotes) {
+			if (ch === '\n' || ch === '\r') break;
+			if (ch === ',' || ch === '\t' || ch === ';') counts[ch]++;
+		}
+	}
+	if (counts[','] >= counts['\t'] && counts[','] >= counts[';']) return ',';
+	if (counts['\t'] >= counts[';']) return '\t';
+	return ';';
+}
+
+/**
+ * セル値の型推論。
+ * - 空セルのみ null
+ * - 完全小文字の "true" / "false" のみ boolean
+ * - "null" は文字列のまま保持
+ * - 先頭ゼロ付き数値（"007"・"001.23"）は文字列のまま保持（"0" は number）
+ * - 日付文字列は変換しない
+ */
+export function inferCellValue(raw: string): string | number | boolean | null {
+	if (raw === '') return null;
+	if (raw === 'true') return true;
+	if (raw === 'false') return false;
+	if (raw === 'null') return raw;
+	if (/^-?(0|[1-9]\d*)(\.\d+)?$/.test(raw)) {
+		const num = Number(raw);
+		if (Number.isFinite(num)) return num;
+	}
+	return raw;
+}
+
+function jsonErrorLine(text: string, message: string): number | undefined {
+	const lineMatch = message.match(/line (\d+)/);
+	if (lineMatch) return Number(lineMatch[1]);
+	const posMatch = message.match(/position (\d+)/);
+	if (posMatch) {
+		return text.slice(0, Number(posMatch[1])).split('\n').length;
+	}
+	return undefined;
+}
+
+function cellToString(value: unknown): string {
+	if (value == null) return '';
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean') {
+		return String(value);
+	}
+	return JSON.stringify(value);
+}
+
+// ---------------------------------------------------------------------------
+// JSON → CSV
+// ---------------------------------------------------------------------------
+
+export function jsonToCsv(
+	jsonText: string,
+	options: JsonToCsvOptions,
+): ConvertResult {
+	const text = stripBom(jsonText);
+	if (!text.trim()) {
+		return { ok: false, error: 'JSONを入力してください。' };
+	}
+
+	let parsed: unknown;
+	try {
+		parsed = JSON.parse(text);
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		const line = jsonErrorLine(text, message);
+		return {
+			ok: false,
+			error:
+				line != null
+					? `${line}行目付近: JSONの構文エラーです。`
+					: 'JSONの構文エラーです。入力内容を確認してください。',
+			line,
+		};
+	}
+
+	let rows: Record<string, unknown>[];
+	if (Array.isArray(parsed)) {
+		if (parsed.length === 0) {
+			return {
+				ok: false,
+				error: '変換できるデータがありません（空の配列です）。',
+			};
+		}
+		if (!parsed.every(isPlainObject)) {
+			return {
+				ok: false,
+				error:
+					'CSVに変換できるのはオブジェクトの配列です。プリミティブ値やnullを含む配列は変換できません。',
+			};
+		}
+		rows = parsed;
+	} else if (isPlainObject(parsed)) {
+		// 単一オブジェクトは1行として扱う
+		rows = [parsed];
+	} else {
+		return {
+			ok: false,
+			error:
+				'CSVに変換できるのはオブジェクトまたはオブジェクトの配列です。文字列・数値・nullは変換できません。',
+		};
+	}
+
+	const flatRows = options.flattenNested
+		? rows.map((row) => flattenObject(row))
+		: rows;
+
+	// ヘッダーは全行のキーの和集合（出現順）
+	const headers: string[] = [];
+	const seen = new Set<string>();
+	for (const row of flatRows) {
+		for (const key of Object.keys(row)) {
+			if (!seen.has(key)) {
+				seen.add(key);
+				headers.push(key);
+			}
+		}
+	}
+
+	const data = flatRows.map((row) =>
+		headers.map((header) => cellToString(row[header])),
+	);
+
+	const csv = options.includeHeader
+		? Papa.unparse(
+				{ fields: headers, data },
+				{ delimiter: options.delimiter, newline: options.newline },
+			)
+		: Papa.unparse(data, {
+				delimiter: options.delimiter,
+				newline: options.newline,
+			});
+
+	return { ok: true, output: csv, rowCount: flatRows.length };
+}
+
+// ---------------------------------------------------------------------------
+// CSV → JSON
+// ---------------------------------------------------------------------------
+
+export function csvToJson(
+	csvText: string,
+	options: CsvToJsonOptions,
+): ConvertResult {
+	const text = stripBom(csvText);
+	if (!text.trim()) {
+		return { ok: false, error: 'CSVを入力してください。' };
+	}
+
+	const delimiter =
+		options.delimiter === 'auto' ? detectDelimiter(text) : options.delimiter;
+
+	// \r\n と \n の混在入力を読み取れるよう正規化する
+	// （クォート内の \r\n も \n になるが、混在入力の安全な読み取りを優先する）
+	const normalized = text.replace(/\r\n/g, '\n');
+
+	// ヘッダー処理・列数調整・型推論は自前で行うため header: false 固定
+	const result = Papa.parse<string[]>(normalized, {
+		delimiter,
+		header: false,
+		skipEmptyLines: 'greedy',
+	});
+
+	for (const err of result.errors) {
+		// Papa の row はクォート内改行を含む場合、論理行番号になる
+		const line = err.row != null ? err.row + 1 : undefined;
+		if (err.code === 'MissingQuotes') {
+			return {
+				ok: false,
+				error:
+					line != null
+						? `${line}行目付近: 引用符（"）が閉じられていません。`
+						: '引用符（"）が閉じられていません。',
+				line,
+			};
+		}
+		if (err.code === 'InvalidQuotes') {
+			return {
+				ok: false,
+				error:
+					line != null
+						? `${line}行目付近: 引用符で囲まれたセルの後に不正な文字があります。`
+						: '引用符で囲まれたセルの後に不正な文字があります。',
+				line,
+			};
+		}
+	}
+
+	const rawRows = result.data;
+	if (rawRows.length === 0 || (options.hasHeader && rawRows.length === 1)) {
+		return { ok: false, error: '変換できるデータ行がありません。' };
+	}
+
+	let headers: string[];
+	let dataRows: string[][];
+	if (options.hasHeader) {
+		headers = rawRows[0];
+		dataRows = rawRows.slice(1);
+	} else {
+		const maxCols = Math.max(...rawRows.map((row) => row.length));
+		headers = Array.from({ length: maxCols }, (_, i) => `column_${i + 1}`);
+		dataRows = rawRows;
+	}
+
+	const objects = dataRows.map((row) => {
+		const record: Record<string, unknown> = {};
+		// 列数不足は空文字として扱い、超過分は extra_1, extra_2 ... に格納する
+		const colCount = Math.max(headers.length, row.length);
+		for (let i = 0; i < colCount; i++) {
+			const key =
+				i < headers.length ? headers[i] : `extra_${i - headers.length + 1}`;
+			const raw = i < row.length ? row[i] : '';
+			record[key] = options.inferTypes ? inferCellValue(raw) : raw;
+		}
+		return options.unflattenDotKeys ? unflattenObject(record) : record;
+	});
+
+	return {
+		ok: true,
+		output: JSON.stringify(objects, null, 2),
+		rowCount: objects.length,
+	};
+}
+
+/** CSV文字列からBlobを生成する。withBom: true で先頭にBOM（Excel文字化け対策） */
+export function buildCsvBlob(csv: string, withBom: boolean): Blob {
+	const content = withBom ? '\u{FEFF}'.concat(csv) : csv;
+	return new Blob([content], {
+		type: 'text/csv;charset=utf-8',
+	});
+}

--- a/src/pages/csv-editor.astro
+++ b/src/pages/csv-editor.astro
@@ -27,6 +27,11 @@ import CsvEditorTool from '../components/tools/CsvEditor.tsx';
         <div class="mt-2 text-xs bg-muted/50 p-2 rounded">
           ⚠️ ブラウザのメモリ制限のため、極端に大きなファイル（数十万行、数百MB以上）の場合は表示が遅くなる、または開けない場合があります。
         </div>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
+          <a href="/csv-fixer" class="text-xs text-primary hover:underline">CSV文字化け修復</a>
+        </div>
       </div>
     </details>
   </div>

--- a/src/pages/csv-fixer.astro
+++ b/src/pages/csv-fixer.astro
@@ -25,6 +25,11 @@ import CsvFixerTool from '../components/tools/CsvFixer';
           <li><strong>Macで作ったCSVをWindowsに渡したい:</strong> 改行コードが異なる場合があります。改行コードの設定で「CRLF (Windows)」を指定して変換してください。</li>
           <li><strong>即時変換モード:</strong> 同じ形式のファイルを繰り返し処理する場合、オプションで「即時変換」をオンにすると、ドラッグ＆ドロップ後すぐに変換済みのファイルがダウンロードされます。</li>
         </ul>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
+          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
+        </div>
       </div>
     </details>
   </div>

--- a/src/pages/hash.astro
+++ b/src/pages/hash.astro
@@ -1,0 +1,48 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import { HashPage } from '../components/tools/hash-generator/HashPage';
+---
+
+<ToolLayout
+  title="ハッシュ値計算ツール（MD5 / SHA-1 / SHA-256 / SHA-512 / CRC32）"
+  description="テキストやファイルのMD5・SHA-1・SHA-256・SHA-512・CRC32ハッシュ値をブラウザだけで計算できる無料ツール。期待値との照合でダウンロードファイルの改ざん・破損チェックも。完全クライアントサイド処理でデータはサーバーに送信されません。"
+  path="/hash"
+>
+  <HashPage client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4">
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>
+          ハッシュ値の計算をオンラインで完結できるツールです。テキストはもちろん、ファイルをドラッグ＆ドロップするだけでSHA-256などのチェックサムを取得できます。すべてブラウザ内で処理されるため、機密ファイルを外部サービスに送信する必要はありません。
+        </p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>
+            <strong>ダウンロードファイルの改ざん・破損チェック:</strong>
+            配布元サイトに記載されたハッシュ値（チェックサム）をコピーし、「期待値との照合」欄に貼り付けます。ダウンロードしたファイルをドロップして計算すると、一致（✅）か不一致（❌）かを自動で判定します。MD5の確認にもツール上でそのまま対応できます。
+          </li>
+          <li>
+            <strong>アルゴリズムの使い分け:</strong>
+            セキュリティ用途（改ざん検知・パスワード関連など）には SHA-256 以上を使用してください。MD5・SHA-1
+            は衝突攻撃が知られているため、ファイルの同一性確認や互換目的に限定して使うことを推奨します。CRC32
+            は誤り検出向けの軽量なチェックサムです。
+          </li>
+          <li>
+            <strong>テキストのハッシュ化:</strong>
+            入力するたびに自動で計算されます。日本語や絵文字を含むテキストもUTF-8でエンコードして正確に計算します。
+          </li>
+        </ul>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/cipher" class="text-xs text-primary hover:underline">暗号化・難読化</a>
+          <a href="/base64" class="text-xs text-primary hover:underline">Base64変換</a>
+          <a href="/masking" class="text-xs text-primary hover:underline">個人情報マスキング</a>
+        </div>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/src/pages/json-csv.astro
+++ b/src/pages/json-csv.astro
@@ -1,0 +1,48 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import { JsonCsvPage } from '../components/tools/json-csv/JsonCsvPage';
+---
+
+<ToolLayout
+  title="JSON ↔ CSV 相互変換ツール"
+  description="JSONとCSVをブラウザだけで相互変換できる無料ツール。ネスト構造のフラット化、BOM付きUTF-8出力でExcelの文字化けも防止。完全クライアントサイド処理でデータはサーバーに送信されません。"
+  path="/json-csv"
+>
+  <JsonCsvPage client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4">
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>
+          JSONとCSVの相互変換をオンラインで無料で行えるツールです。APIレスポンスのJSONをExcelで集計したいとき、CSVデータをプログラムで扱えるJSONにしたいときに、入力を貼り付けるだけで自動変換します。
+        </p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>
+            <strong>Excelで文字化けさせないコツ（BOM付きUTF-8）:</strong>
+            日本語のUTF-8 CSVをExcelで開くと文字化けすることがあります。これはExcelがBOM（バイトオーダーマーク）のないUTF-8をShift_JISと誤判定するためです。本ツールは「BOM付きUTF-8」オプションが標準でONになっており、ダウンロードしたCSVをそのままExcelで開いても文字化けしません。
+          </li>
+          <li>
+            <strong>ネストJSONのフラット化:</strong>
+            <code>{'{"user":{"name":"太郎"}}'}</code> のようなネスト構造は <code>user.name</code>
+            というドット記法の列に展開され、表計算ソフトでそのまま扱えます。配列は <code>items.0</code>
+            のようにインデックス付きの列になります。CSV→JSON方向では「ドット記法キーをネスト復元」をONにすると元の構造に戻せます。
+          </li>
+          <li>
+            <strong>型推論:</strong>
+            CSV→JSON変換時、数値・真偽値・空セル（null）を自動で型変換します。電話番号や郵便番号のような先頭ゼロ付きの値（007など）は文字列のまま保持されるので安心です。
+          </li>
+        </ul>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/json-formatter" class="text-xs text-primary hover:underline">JSON整形</a>
+          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
+          <a href="/csv-fixer" class="text-xs text-primary hover:underline">CSV文字化け修復</a>
+        </div>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/src/pages/json-formatter.astro
+++ b/src/pages/json-formatter.astro
@@ -26,6 +26,11 @@ import JsonFormatterTool from '../components/tools/JsonFormatter.tsx';
           <li>設定ファイルのJSONをきれいにフォーマットしたい</li>
           <li>JSONデータを圧縮して軽量化したい</li>
         </ul>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
+          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
+        </div>
       </div>
     </details>
   </div>

--- a/tests/e2e/fixtures/hash-sample.txt
+++ b/tests/e2e/fixtures/hash-sample.txt
@@ -1,0 +1,1 @@
+CODE:LIFE hash fixture v1

--- a/tests/e2e/hash.spec.ts
+++ b/tests/e2e/hash.spec.ts
@@ -1,0 +1,229 @@
+import path from 'node:path';
+import { expect, test } from './fixtures/base';
+
+// tests/e2e/fixtures/hash-sample.txt（scripts/generate-fixtures.ts で生成）の既知ハッシュ値
+const FIXTURE = {
+	path: path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'hash-sample.txt'),
+	md5: '0815c77156afa38b4fd65109f46b55de',
+	sha1: '8dc4cf8bb64e0d795012d71e2266b4820f877152',
+	sha256: '7b7077ac778313b109b267afadc2be2f4ea36b519acce86d3ff9e07a65a70ca1',
+	crc32: 'ebf9b3f3',
+};
+
+const ABC_SHA256 =
+	'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad';
+const KONNICHIWA_SHA256 =
+	'125aeadf27b0459b8760c13a3d80912dfa8a81a68261906f60d87f4a0268646c';
+
+test.describe('Hash Generator Tool', () => {
+	test('ページが正しく表示されること', async ({ createToolPage }) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+		await toolPage.expectTitle('ハッシュ値計算ツール');
+		await toolPage.expectSafetyBadge();
+	});
+
+	test('テキスト "abc" のSHA-256が既知ベクトルと一致すること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByLabel('ハッシュ計算するテキスト').fill('abc');
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			ABC_SHA256,
+		);
+		await expect(page.getByTestId('hash-result-md5')).toContainText(
+			'900150983cd24fb0d6963f7d28e17f72',
+		);
+	});
+
+	test('日本語テキストのハッシュが決定的であること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByLabel('ハッシュ計算するテキスト').fill('こんにちは');
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			KONNICHIWA_SHA256,
+		);
+	});
+
+	test('アルゴリズムの選択切替で結果行が増減すること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByLabel('ハッシュ計算するテキスト').fill('abc');
+		await expect(page.getByTestId('hash-result-sha256')).toBeVisible();
+		await expect(page.getByTestId('hash-result-sha512')).not.toBeVisible();
+		await expect(page.getByTestId('hash-result-crc32')).not.toBeVisible();
+
+		// SHA-512 を追加
+		await page.getByRole('checkbox', { name: 'SHA-512' }).click();
+		await expect(page.getByTestId('hash-result-sha512')).toContainText(
+			/[0-9a-f]{128}/,
+		);
+
+		// MD5 を外す
+		await page.getByRole('checkbox', { name: 'MD5', exact: true }).click();
+		await expect(page.getByTestId('hash-result-md5')).not.toBeVisible();
+	});
+
+	test('ファイルアップロードで全選択アルゴリズムの結果が表示されること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'ファイル' }).click();
+		// CRC32 も選択して4アルゴリズム
+		await page.getByRole('checkbox', { name: 'CRC32' }).click();
+		await page.getByTestId('hash-file-input').setInputFiles(FIXTURE.path);
+
+		await expect(page.getByTestId('hash-result-md5')).toContainText(
+			FIXTURE.md5,
+		);
+		await expect(page.getByTestId('hash-result-sha1')).toContainText(
+			FIXTURE.sha1,
+		);
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			FIXTURE.sha256,
+		);
+		await expect(page.getByTestId('hash-result-crc32')).toContainText(
+			FIXTURE.crc32,
+		);
+	});
+
+	test('ファイル差し替え時に前回の結果がクリアされること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'ファイル' }).click();
+		await page.getByTestId('hash-file-input').setInputFiles(FIXTURE.path);
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			FIXTURE.sha256,
+		);
+
+		// 別ファイルに差し替えると前回の値は消え、新しい値が表示される
+		await page
+			.getByTestId('hash-file-input')
+			.setInputFiles(
+				path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'utf8_no_bom.csv'),
+			);
+		await expect(page.getByTestId('hash-result-sha256')).not.toContainText(
+			FIXTURE.sha256,
+		);
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			/[0-9a-f]{64}/,
+		);
+	});
+
+	test('期待値照合: 一致・不一致・判定不能・未選択アルゴリズム', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByLabel('ハッシュ計算するテキスト').fill('abc');
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			ABC_SHA256,
+		);
+
+		const expectedInput = page.getByLabel('期待値との照合', { exact: false });
+		const verifyResult = page.getByTestId('hash-verify-result');
+
+		// 一致（大文字・ハイフン混在でも吸収される）
+		await expectedInput.fill(ABC_SHA256.toUpperCase());
+		await expect(verifyResult).toContainText('一致');
+		await expect(verifyResult).not.toContainText('不一致');
+
+		// 不一致
+		await expectedInput.fill(`${ABC_SHA256.slice(0, 63)}0`);
+		await expect(verifyResult).toContainText('不一致');
+
+		// 判定不能な長さ
+		await expectedInput.fill('abcdef1234');
+		await expect(verifyResult).toContainText('判定できません');
+
+		// CRC32 長（8桁）はデフォルト未選択 → 自動追加せず案内を表示
+		await expectedInput.fill('352441c2');
+		await expect(verifyResult).toContainText(
+			'対象アルゴリズムを選択してください',
+		);
+	});
+
+	test('コピーと大文字トグルが動作すること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByLabel('ハッシュ計算するテキスト').fill('abc');
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			ABC_SHA256,
+		);
+
+		// 大文字トグル
+		await page.getByRole('switch', { name: '大文字で表示' }).click();
+		await expect(page.getByTestId('hash-result-sha256')).toContainText(
+			ABC_SHA256.toUpperCase(),
+		);
+
+		// コピー
+		await page
+			.getByTestId('hash-result-sha256')
+			.getByRole('button', { name: /コピー/ })
+			.click();
+		await expect(
+			page.getByTestId('hash-result-sha256').getByRole('button'),
+		).toContainText('コピー済み');
+	});
+
+	test('上限超ファイルで日本語エラーが表示されること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'ファイル' }).click();
+		// File.prototype.size を偽装して256MB超を再現（実ファイルは作らない）
+		await page.evaluate(() => {
+			Object.defineProperty(File.prototype, 'size', {
+				get: () => 257 * 1024 * 1024,
+				configurable: true,
+			});
+		});
+		await page.getByTestId('hash-file-input').setInputFiles(FIXTURE.path);
+
+		await expect(page.getByRole('alert')).toContainText('ファイルサイズが上限');
+	});
+
+	test('レスポンシブ表示（375px / 1440px）', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.setViewportSize({ width: 375, height: 667 });
+		const textarea = page.getByLabel('ハッシュ計算するテキスト');
+		await expect(textarea).toBeVisible();
+		await expect(page.getByRole('checkbox', { name: 'SHA-256' })).toBeVisible();
+
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await expect(textarea).toBeVisible();
+	});
+});

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -1,0 +1,197 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { expect, test } from './fixtures/base';
+
+// JsonCsvPage.tsx の SAMPLE_JSON をデフォルトオプションで変換した期待CSV。
+// 実際の出力（ダウンロード）は CRLF だが、textarea の value は DOM 仕様で LF に正規化される
+const SAMPLE_EXPECTED_CSV = [
+	'name,age,contact.email,contact.tel,tags.0,tags.1',
+	'山田太郎,30,taro@example.com,03-1234-5678,営業,リーダー',
+	'鈴木花子,25,hanako@example.com,06-9876-5432,開発,',
+].join('\n');
+
+test.describe('JSON-CSV Converter Tool', () => {
+	test('ページが正しく表示されること', async ({ createToolPage }) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+		await toolPage.expectTitle('JSON ↔ CSV 相互変換ツール');
+		await toolPage.expectSafetyBadge();
+	});
+
+	test('サンプルJSON → CSV 変換結果が期待値と一致すること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('button', { name: 'サンプルデータ' }).click();
+		await expect(page.getByLabel('CSV出力')).toHaveValue(SAMPLE_EXPECTED_CSV);
+		await expect(page.getByText('2行を変換しました')).toBeVisible();
+	});
+
+	test('ネストJSON + フラット化ONでドット記法ヘッダーになること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page
+			.getByLabel('JSON入力')
+			.fill('[{"user":{"name":"太郎"},"items":["a","b"]}]');
+		await expect(page.getByLabel('CSV出力')).toHaveValue(
+			'user.name,items.0,items.1\n太郎,a,b',
+		);
+
+		// フラット化OFFではネストがJSON文字列セルになる
+		await page
+			.getByRole('switch', { name: 'ネストを展開（ドット記法）' })
+			.click();
+		await expect(page.getByLabel('CSV出力')).toHaveValue(
+			/\{""name"":""太郎""\}/,
+		);
+	});
+
+	test('CSV → JSON 変換（型推論ON/OFF）', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'CSV → JSON' }).click();
+		await page
+			.getByLabel('CSV入力')
+			.fill('name,age,active,zip\n太郎,30,true,007');
+
+		// 型推論ON: 数値・真偽値に変換、先頭ゼロは文字列のまま
+		const output = page.getByLabel('JSON出力');
+		await expect(output).toHaveValue(/"age": 30/);
+		await expect(output).toHaveValue(/"active": true/);
+		await expect(output).toHaveValue(/"zip": "007"/);
+
+		// 型推論OFF: すべて文字列
+		await page.getByRole('switch', { name: '型推論' }).click();
+		await expect(output).toHaveValue(/"age": "30"/);
+		await expect(output).toHaveValue(/"active": "true"/);
+	});
+
+	test('不正JSONで日本語エラーが表示されクラッシュしないこと', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByLabel('JSON入力').fill('{"a": }');
+		await expect(page.getByTestId('json-csv-error')).toContainText(
+			'JSONの構文エラー',
+		);
+
+		// 修正すると復帰する
+		await page.getByLabel('JSON入力').fill('{"a": 1}');
+		await expect(page.getByLabel('CSV出力')).toHaveValue('a\n1');
+	});
+
+	test('クォート未閉じCSVで行番号付きエラーが表示されること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'CSV → JSON' }).click();
+		await page.getByLabel('CSV入力').fill('a,b\n1,"未閉じ');
+		await expect(page.getByTestId('json-csv-error')).toContainText('行目');
+		await expect(page.getByTestId('json-csv-error')).toContainText('引用符');
+	});
+
+	test('CSVダウンロード: BOM ON で先頭3バイトが EF BB BF', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('button', { name: 'サンプルデータ' }).click();
+		await expect(page.getByLabel('CSV出力')).toHaveValue(SAMPLE_EXPECTED_CSV);
+
+		const downloadPromise = page.waitForEvent('download');
+		await page.getByRole('button', { name: 'ダウンロード' }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toBe('converted.csv');
+
+		const savePath = path.join(os.tmpdir(), `json-csv-bom-${Date.now()}.csv`);
+		await download.saveAs(savePath);
+		const bytes = fs.readFileSync(savePath);
+		expect([...bytes.subarray(0, 3)]).toEqual([0xef, 0xbb, 0xbf]);
+		fs.unlinkSync(savePath);
+	});
+
+	test('CSVダウンロード: BOM OFF では先頭にBOMが付かないこと', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('button', { name: 'サンプルデータ' }).click();
+		await expect(page.getByLabel('CSV出力')).toHaveValue(SAMPLE_EXPECTED_CSV);
+		await page.getByRole('switch', { name: 'BOM付きUTF-8' }).click();
+
+		const downloadPromise = page.waitForEvent('download');
+		await page.getByRole('button', { name: 'ダウンロード' }).click();
+		const download = await downloadPromise;
+
+		const savePath = path.join(os.tmpdir(), `json-csv-nobom-${Date.now()}.csv`);
+		await download.saveAs(savePath);
+		const bytes = fs.readFileSync(savePath);
+		expect([...bytes.subarray(0, 3)]).not.toEqual([0xef, 0xbb, 0xbf]);
+		fs.unlinkSync(savePath);
+	});
+
+	test('JSONダウンロード: ファイル名が converted.json になること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'CSV → JSON' }).click();
+		await page.getByRole('button', { name: 'サンプルデータ' }).click();
+		await expect(page.getByLabel('JSON出力')).toHaveValue(/山田太郎/);
+
+		const downloadPromise = page.waitForEvent('download');
+		await page.getByRole('button', { name: 'ダウンロード' }).click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toBe('converted.json');
+	});
+
+	test('コピーが動作すること', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.getByRole('button', { name: 'サンプルデータ' }).click();
+		await expect(page.getByLabel('CSV出力')).toHaveValue(SAMPLE_EXPECTED_CSV);
+		await page.getByRole('button', { name: 'コピー', exact: true }).click();
+		// コピー後は aria-label が「コピーしました」に変わる
+		await expect(
+			page.getByRole('button', { name: 'コピーしました' }),
+		).toBeVisible();
+	});
+
+	test('レスポンシブ表示（375px / 1440px）', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		await page.setViewportSize({ width: 375, height: 667 });
+		await expect(page.getByLabel('JSON入力')).toBeVisible();
+		await expect(page.getByLabel('CSV出力')).toBeVisible();
+
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await expect(page.getByLabel('JSON入力')).toBeVisible();
+		await expect(page.getByLabel('CSV出力')).toBeVisible();
+	});
+});

--- a/tests/e2e/json-csv.spec.ts
+++ b/tests/e2e/json-csv.spec.ts
@@ -166,6 +166,31 @@ test.describe('JSON-CSV Converter Tool', () => {
 		expect(download.suggestedFilename()).toBe('converted.json');
 	});
 
+	test('ファイルドロップ時もaccept対象外の形式を拒否すること', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-csv');
+		await toolPage.goto();
+
+		const dropzone = page.getByRole('button', { name: /ファイルから読み込み/ });
+		const dataTransfer = await page.evaluateHandle(() => {
+			const transfer = new DataTransfer();
+			transfer.items.add(
+				new File(['not a json csv text file'], 'sample.png', {
+					type: 'image/png',
+				}),
+			);
+			return transfer;
+		});
+		await dropzone.dispatchEvent('drop', { dataTransfer });
+
+		await expect(page.getByTestId('json-csv-error')).toContainText(
+			'対応していないファイル形式です',
+		);
+		await expect(page.getByLabel('JSON入力')).toHaveValue('');
+	});
+
 	test('コピーが動作すること', async ({ page, createToolPage }) => {
 		const toolPage = createToolPage('json-csv');
 		await toolPage.goto();

--- a/tests/unit/hash.test.ts
+++ b/tests/unit/hash.test.ts
@@ -1,0 +1,216 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/hash.test.ts
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+import {
+	compareHash,
+	createCrc32,
+	createMd5,
+	detectAlgorithmByLength,
+	hashFile,
+	hashText,
+	normalizeHash,
+	validateHashFile,
+} from '../../src/lib/tools/hash.ts';
+
+const MB = 1024 * 1024;
+
+function nodeHash(algorithm: string, data: string | Uint8Array): string {
+	return createHash(algorithm).update(data).digest('hex');
+}
+
+test('MD5: 既知のテストベクトル', async () => {
+	const vectors: [string, string][] = [
+		['', 'd41d8cd98f00b204e9800998ecf8427e'],
+		['abc', '900150983cd24fb0d6963f7d28e17f72'],
+		['message digest', 'f96b697d7cb7938d525a2f31aaf161d0'],
+	];
+	for (const [input, expected] of vectors) {
+		const { md5 } = await hashText(input, ['md5']);
+		assert.equal(md5, expected, `MD5("${input}")`);
+	}
+});
+
+test('MD5: パディング境界の入力長 55/56/57/64/65 bytes', async () => {
+	for (const n of [55, 56, 57, 64, 65]) {
+		const input = 'a'.repeat(n);
+		const { md5 } = await hashText(input, ['md5']);
+		assert.equal(md5, nodeHash('md5', input), `length=${n}`);
+	}
+});
+
+test('MD5: インクリメンタル計算がチャンクサイズに依存しない', () => {
+	const data = new TextEncoder().encode(`${'x'.repeat(1000)}こんにちは🍣`);
+	const expected = nodeHash('md5', data);
+	for (const chunkSize of [1, 3, 63, 64, 65, data.length]) {
+		const hasher = createMd5();
+		for (let i = 0; i < data.length; i += chunkSize) {
+			hasher.update(data.subarray(i, i + chunkSize));
+		}
+		assert.equal(hasher.digest(), expected, `chunkSize=${chunkSize}`);
+	}
+});
+
+test('MD5: ランダムデータで node:crypto とクロスチェック', () => {
+	for (const len of [0, 1, 100, 4096, 100_000]) {
+		const data = new Uint8Array(len);
+		for (let i = 0; i < len; i++) data[i] = (i * 31 + 7) % 256;
+		const hasher = createMd5();
+		hasher.update(data);
+		assert.equal(hasher.digest(), nodeHash('md5', data), `length=${len}`);
+	}
+});
+
+test('CRC32: 既知のテストベクトル（ゼロ埋め8桁・小文字）', () => {
+	const vectors: [string, string][] = [
+		['', '00000000'],
+		['abc', '352441c2'],
+		['123456789', 'cbf43926'],
+	];
+	for (const [input, expected] of vectors) {
+		const hasher = createCrc32();
+		hasher.update(new TextEncoder().encode(input));
+		const result = hasher.digest();
+		assert.equal(result, expected, `CRC32("${input}")`);
+		assert.equal(result.length, 8, '常に8桁');
+		assert.match(result, /^[0-9a-f]{8}$/, '小文字hex・負値にならない');
+	}
+});
+
+test('hashText: SHA系の既知ベクトル', async () => {
+	const results = await hashText('abc', ['sha1', 'sha256', 'sha512']);
+	assert.equal(results.sha1, 'a9993e364706816aba3e25717850c26c9cd0d89d');
+	assert.equal(
+		results.sha256,
+		'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+	);
+	assert.equal(results.sha512, nodeHash('sha512', 'abc'));
+});
+
+test('hashText: 空文字列・日本語・絵文字で全アルゴリズム一致', async () => {
+	for (const input of [
+		'',
+		'こんにちは世界',
+		'絵文字🍣🎉テスト',
+		'mixed 日本語 text',
+	]) {
+		const results = await hashText(input, [
+			'md5',
+			'sha1',
+			'sha256',
+			'sha512',
+			'crc32',
+		]);
+		const bytes = new TextEncoder().encode(input);
+		assert.equal(results.md5, nodeHash('md5', bytes), `md5("${input}")`);
+		assert.equal(results.sha1, nodeHash('sha1', bytes), `sha1("${input}")`);
+		assert.equal(
+			results.sha256,
+			nodeHash('sha256', bytes),
+			`sha256("${input}")`,
+		);
+		assert.equal(
+			results.sha512,
+			nodeHash('sha512', bytes),
+			`sha512("${input}")`,
+		);
+		assert.match(results.crc32 ?? '', /^[0-9a-f]{8}$/);
+	}
+});
+
+test('hashFile: チャンク経路とフルバッファ経路が hashText と一致', async () => {
+	const content = 'CODE:LIFE hash test データ🍣'.repeat(10);
+	const file = new File([content], 'test.txt');
+	const fromFile = await hashFile(
+		file,
+		['md5', 'sha1', 'sha256', 'sha512', 'crc32'],
+		undefined,
+		7, // 小さいチャンクサイズでバッファ境界を跨がせる
+	);
+	const fromText = await hashText(content, [
+		'md5',
+		'sha1',
+		'sha256',
+		'sha512',
+		'crc32',
+	]);
+	assert.deepEqual(fromFile, fromText);
+});
+
+test('hashFile: 空ファイル', async () => {
+	const file = new File([], 'empty.txt');
+	const results = await hashFile(file, ['md5', 'sha256', 'crc32']);
+	assert.equal(results.md5, 'd41d8cd98f00b204e9800998ecf8427e');
+	assert.equal(results.crc32, '00000000');
+	assert.equal(results.sha256, nodeHash('sha256', new Uint8Array(0)));
+});
+
+test('hashFile: onProgress が単調増加し最後に100になる', async () => {
+	const file = new File(['a'.repeat(1000)], 'progress.txt');
+	const values: number[] = [];
+	await hashFile(file, ['md5', 'sha256'], (p) => values.push(p), 100);
+	assert.ok(values.length > 0);
+	for (let i = 1; i < values.length; i++) {
+		assert.ok(values[i] >= values[i - 1], '単調増加');
+	}
+	assert.equal(values[values.length - 1], 100);
+});
+
+test('validateHashFile: 256MB上限と警告段階', () => {
+	assert.deepEqual(validateHashFile({ size: 99 * MB }), {
+		ok: true,
+		warnLevel: 'none',
+	});
+	assert.deepEqual(validateHashFile({ size: 150 * MB }), {
+		ok: true,
+		warnLevel: 'large',
+	});
+	assert.deepEqual(validateHashFile({ size: 250 * MB }), {
+		ok: true,
+		warnLevel: 'huge',
+	});
+	assert.deepEqual(validateHashFile({ size: 257 * MB }), {
+		ok: false,
+		reason: 'too-large-file',
+	});
+	// 境界値: ちょうど100MB/200MB/256MBは超過扱いにしない
+	assert.deepEqual(validateHashFile({ size: 100 * MB }), {
+		ok: true,
+		warnLevel: 'none',
+	});
+	assert.deepEqual(validateHashFile({ size: 200 * MB }), {
+		ok: true,
+		warnLevel: 'large',
+	});
+	assert.deepEqual(validateHashFile({ size: 256 * MB }), {
+		ok: true,
+		warnLevel: 'huge',
+	});
+});
+
+test('normalizeHash / compareHash: 大文字小文字・空白・ハイフンの揺れを吸収', () => {
+	assert.equal(normalizeHash('  AB-CD ef\t12  '), 'abcdef12');
+	assert.ok(compareHash('ABCDEF12', 'ab-cd-ef-12'));
+	assert.ok(
+		compareHash(
+			'900150983cd24fb0d6963f7d28e17f72',
+			' 90015098 3CD24FB0 D6963F7D 28E17F72 ',
+		),
+	);
+	assert.ok(!compareHash('abcdef12', 'abcdef13'));
+});
+
+test('detectAlgorithmByLength: 長さによる判定', () => {
+	assert.equal(detectAlgorithmByLength('352441c2'), 'crc32');
+	assert.equal(
+		detectAlgorithmByLength('900150983cd24fb0d6963f7d28e17f72'),
+		'md5',
+	);
+	assert.equal(detectAlgorithmByLength('a'.repeat(40)), 'sha1');
+	assert.equal(detectAlgorithmByLength('A'.repeat(64)), 'sha256');
+	assert.equal(detectAlgorithmByLength('f'.repeat(128)), 'sha512');
+	assert.equal(detectAlgorithmByLength('abc'), null);
+	assert.equal(detectAlgorithmByLength('z'.repeat(32)), null, '非hexはnull');
+	assert.equal(detectAlgorithmByLength(''), null);
+});

--- a/tests/unit/json-csv.test.ts
+++ b/tests/unit/json-csv.test.ts
@@ -157,6 +157,33 @@ test('csvToJson: hasHeader OFF は column_N キー', () => {
 	]);
 });
 
+test('csvToJson: 重複ヘッダーは一意化して値を保持する', () => {
+	const result = expectOk(csvToJson('a,a,a_2\r\n1,2,3', CSV_OPTS));
+	assert.deepEqual(JSON.parse(result.output), [{ a: 1, a_2: 2, a_2_2: 3 }]);
+});
+
+test('csvToJson: __proto__ ヘッダーを通常列として保持する', () => {
+	const result = expectOk(
+		csvToJson('__proto__,constructor,prototype,x\r\np,c,t,1', {
+			...CSV_OPTS,
+			inferTypes: false,
+		}),
+	);
+	assert.equal(
+		result.output,
+		[
+			'[',
+			'  {',
+			'    "__proto__": "p",',
+			'    "constructor": "c",',
+			'    "prototype": "t",',
+			'    "x": "1"',
+			'  }',
+			']',
+		].join('\n'),
+	);
+});
+
 test('csvToJson: BOM付き入力の自動除去', () => {
 	const result = expectOk(csvToJson('\u{FEFF}a\r\n1', CSV_OPTS));
 	assert.deepEqual(JSON.parse(result.output), [{ a: 1 }]);
@@ -224,6 +251,23 @@ test('csvToJson: unflattenDotKeys ON でネスト復元', () => {
 	]);
 });
 
+test('csvToJson: unflattenDotKeys ON でも prototype pollution しない', () => {
+	const result = expectOk(
+		csvToJson('__proto__.polluted,constructor.prototype.x\r\nyes,no', {
+			...CSV_OPTS,
+			inferTypes: false,
+			unflattenDotKeys: true,
+		}),
+	);
+	assert.equal(({} as Record<string, unknown>).polluted, undefined);
+	assert.equal(({} as Record<string, unknown>).x, undefined);
+	assert.deepEqual(JSON.parse(result.output), [
+		JSON.parse(
+			'{"__proto__":{"polluted":"yes"},"constructor":{"prototype":{"x":"no"}}}',
+		),
+	]);
+});
+
 test('csvToJson: データ行なしはエラー', () => {
 	const result = expectError(csvToJson('a,b', CSV_OPTS));
 	assert.match(result.error, /データ行/);
@@ -287,6 +331,15 @@ test('flattenObject / unflattenObject: ネスト+配列の往復', () => {
 		active: true,
 	});
 	assert.deepEqual(unflattenObject(flat), original);
+});
+
+test('flattenObject / unflattenObject: __proto__ をデータキーとして扱う', () => {
+	const flat = flattenObject(JSON.parse('{"__proto__":{"value":"safe"}}'));
+	assert.equal(JSON.stringify(flat), '{"__proto__.value":"safe"}');
+
+	const nested = unflattenObject({ '__proto__.polluted': 'no' });
+	assert.equal(JSON.stringify(nested), '{"__proto__":{"polluted":"no"}}');
+	assert.equal(({} as Record<string, unknown>).polluted, undefined);
 });
 
 test('往復変換: JSON→CSV→JSON で構造が保たれる', () => {

--- a/tests/unit/json-csv.test.ts
+++ b/tests/unit/json-csv.test.ts
@@ -1,0 +1,318 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/json-csv.test.ts
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	buildCsvBlob,
+	type CsvToJsonOptions,
+	csvToJson,
+	detectDelimiter,
+	flattenObject,
+	inferCellValue,
+	type JsonToCsvOptions,
+	jsonToCsv,
+	stripBom,
+	unflattenObject,
+} from '../../src/lib/tools/json-csv.ts';
+
+const JSON_OPTS: JsonToCsvOptions = {
+	delimiter: ',',
+	includeHeader: true,
+	flattenNested: true,
+	newline: '\r\n',
+};
+
+const CSV_OPTS: CsvToJsonOptions = {
+	delimiter: 'auto',
+	hasHeader: true,
+	inferTypes: true,
+	unflattenDotKeys: false,
+};
+
+function expectOk(result: ReturnType<typeof jsonToCsv>): {
+	output: string;
+	rowCount: number;
+} {
+	assert.ok(result.ok, `ok を期待: ${JSON.stringify(result)}`);
+	return result;
+}
+
+function expectError(result: ReturnType<typeof jsonToCsv>): {
+	error: string;
+	line?: number;
+} {
+	assert.ok(!result.ok, `エラーを期待: ${JSON.stringify(result)}`);
+	return result;
+}
+
+// ---------------------------------------------------------------------------
+// jsonToCsv
+// ---------------------------------------------------------------------------
+
+test('jsonToCsv: オブジェクト配列の基本変換とRFC4180クォート', () => {
+	const input = JSON.stringify([
+		{ name: 'カンマ,入り', note: '改行\n入り', quote: 'ダブル"クォート' },
+		{ name: 'plain', note: 'b', quote: 'c' },
+	]);
+	const result = expectOk(jsonToCsv(input, JSON_OPTS));
+	assert.equal(result.rowCount, 2);
+	const lines = result.output.split('\r\n');
+	assert.equal(lines[0], 'name,note,quote');
+	assert.ok(result.output.includes('"カンマ,入り"'));
+	assert.ok(result.output.includes('"改行\n入り"'));
+	assert.ok(result.output.includes('"ダブル""クォート"'));
+});
+
+test('jsonToCsv: 単一オブジェクトは1行として扱う', () => {
+	const result = expectOk(jsonToCsv('{"a":1,"b":"x"}', JSON_OPTS));
+	assert.equal(result.rowCount, 1);
+	assert.equal(result.output, 'a,b\r\n1,x');
+});
+
+test('jsonToCsv: ヘッダーは全行キーの和集合（出現順）・欠損は空文字', () => {
+	const input = JSON.stringify([
+		{ a: 1, b: 2 },
+		{ b: 3, c: 4 },
+	]);
+	const result = expectOk(jsonToCsv(input, JSON_OPTS));
+	assert.equal(result.output, 'a,b,c\r\n1,2,\r\n,3,4');
+});
+
+test('jsonToCsv: flattenNested ON でドット記法・配列インデックス', () => {
+	const input = JSON.stringify([
+		{ user: { name: '太郎', age: 30 }, items: ['a', 'b'] },
+	]);
+	const result = expectOk(jsonToCsv(input, JSON_OPTS));
+	assert.equal(
+		result.output,
+		'user.name,user.age,items.0,items.1\r\n太郎,30,a,b',
+	);
+});
+
+test('jsonToCsv: flattenNested OFF はネスト値をJSON文字列セルにする', () => {
+	const input = JSON.stringify([{ user: { name: 'x' } }]);
+	const result = expectOk(
+		jsonToCsv(input, { ...JSON_OPTS, flattenNested: false }),
+	);
+	assert.equal(result.output, 'user\r\n"{""name"":""x""}"');
+});
+
+test('jsonToCsv: トップレベル不正は日本語エラー', () => {
+	for (const input of ['123', '"text"', 'null', '[1,2,3]', '["a",{"b":1}]']) {
+		const result = expectError(jsonToCsv(input, JSON_OPTS));
+		assert.match(result.error, /変換できる/, `input=${input}`);
+	}
+});
+
+test('jsonToCsv: 不正JSONは日本語エラー（位置情報があれば行番号付き）', () => {
+	const result = expectError(jsonToCsv('[\n{"a":1},\n{"b":}\n]', JSON_OPTS));
+	assert.match(result.error, /JSONの構文エラー/);
+	// 後続データありの構文エラーは V8 が position を返すため行番号が取れる
+	const trailing = expectError(jsonToCsv('[{"a":1}]\nxxx', JSON_OPTS));
+	assert.match(trailing.error, /JSONの構文エラー/);
+	assert.equal(trailing.line, 2);
+});
+
+test('jsonToCsv: includeHeader OFF / 区切り文字 / 改行コード', () => {
+	const input = JSON.stringify([{ a: 1, b: 2 }]);
+	const noHeader = expectOk(
+		jsonToCsv(input, { ...JSON_OPTS, includeHeader: false }),
+	);
+	assert.equal(noHeader.output, '1,2');
+	const tab = expectOk(jsonToCsv(input, { ...JSON_OPTS, delimiter: '\t' }));
+	assert.equal(tab.output, 'a\tb\r\n1\t2');
+	const semi = expectOk(jsonToCsv(input, { ...JSON_OPTS, delimiter: ';' }));
+	assert.equal(semi.output, 'a;b\r\n1;2');
+	const lf = expectOk(jsonToCsv(input, { ...JSON_OPTS, newline: '\n' }));
+	assert.equal(lf.output, 'a,b\n1,2');
+});
+
+test('jsonToCsv: 入力先頭のBOMを自動除去する', () => {
+	const result = expectOk(jsonToCsv('\u{FEFF}[{"a":1}]', JSON_OPTS));
+	assert.equal(result.output, 'a\r\n1');
+});
+
+// ---------------------------------------------------------------------------
+// csvToJson
+// ---------------------------------------------------------------------------
+
+test('csvToJson: 基本変換（hasHeader ON）と rowCount', () => {
+	const result = expectOk(
+		csvToJson('name,age\r\n太郎,30\r\n花子,25', CSV_OPTS),
+	);
+	assert.equal(result.rowCount, 2);
+	assert.deepEqual(JSON.parse(result.output), [
+		{ name: '太郎', age: 30 },
+		{ name: '花子', age: 25 },
+	]);
+});
+
+test('csvToJson: hasHeader OFF は column_N キー', () => {
+	const result = expectOk(
+		csvToJson('a,b\r\nc,d', { ...CSV_OPTS, hasHeader: false }),
+	);
+	assert.deepEqual(JSON.parse(result.output), [
+		{ column_1: 'a', column_2: 'b' },
+		{ column_1: 'c', column_2: 'd' },
+	]);
+});
+
+test('csvToJson: BOM付き入力の自動除去', () => {
+	const result = expectOk(csvToJson('\u{FEFF}a\r\n1', CSV_OPTS));
+	assert.deepEqual(JSON.parse(result.output), [{ a: 1 }]);
+});
+
+test('csvToJson: 空行は無視する', () => {
+	const result = expectOk(
+		csvToJson('a,b\r\n\r\n1,2\r\n\r\n3,4\r\n\r\n', CSV_OPTS),
+	);
+	assert.equal(result.rowCount, 2);
+});
+
+test('csvToJson: 列数不足は空文字（型推論でnull）・超過は extra_N', () => {
+	const result = expectOk(csvToJson('a,b\r\n1\r\n1,2,3,4', CSV_OPTS));
+	assert.deepEqual(JSON.parse(result.output), [
+		{ a: 1, b: null },
+		{ a: 1, b: 2, extra_1: 3, extra_2: 4 },
+	]);
+	// inferTypes OFF では不足セルは空文字
+	const noInfer = expectOk(
+		csvToJson('a,b\r\n1', { ...CSV_OPTS, inferTypes: false }),
+	);
+	assert.deepEqual(JSON.parse(noInfer.output), [{ a: '1', b: '' }]);
+});
+
+test('csvToJson: クォート未閉じは行番号付き日本語エラー', () => {
+	const result = expectError(csvToJson('a,b\r\n1,"未閉じ\r\n2,3', CSV_OPTS));
+	assert.match(result.error, /引用符/);
+	assert.match(result.error, /行目/);
+	assert.ok(result.line != null);
+});
+
+test('csvToJson: quoted cell 後の不正文字は行番号付きエラー', () => {
+	const result = expectError(csvToJson('a,b\r\n"x"y,2', CSV_OPTS));
+	assert.match(result.error, /引用符/);
+	assert.match(result.error, /行目/);
+});
+
+test('csvToJson: クォート内の改行・区切り文字・エスケープを保持', () => {
+	const result = expectOk(
+		csvToJson('a,b\r\n"改行\nあり","カンマ,と""引用"""', CSV_OPTS),
+	);
+	assert.deepEqual(JSON.parse(result.output), [
+		{ a: '改行\nあり', b: 'カンマ,と"引用"' },
+	]);
+});
+
+test('csvToJson: \\r\\n と \\n の混在を読み取れる', () => {
+	const result = expectOk(csvToJson('a,b\n1,2\r\n3,4', CSV_OPTS));
+	assert.deepEqual(JSON.parse(result.output), [
+		{ a: 1, b: 2 },
+		{ a: 3, b: 4 },
+	]);
+});
+
+test('csvToJson: unflattenDotKeys ON でネスト復元', () => {
+	const result = expectOk(
+		csvToJson('user.name,user.age,items.0,items.1\r\n太郎,30,a,b', {
+			...CSV_OPTS,
+			unflattenDotKeys: true,
+		}),
+	);
+	assert.deepEqual(JSON.parse(result.output), [
+		{ user: { name: '太郎', age: 30 }, items: ['a', 'b'] },
+	]);
+});
+
+test('csvToJson: データ行なしはエラー', () => {
+	const result = expectError(csvToJson('a,b', CSV_OPTS));
+	assert.match(result.error, /データ行/);
+});
+
+// ---------------------------------------------------------------------------
+// detectDelimiter / inferCellValue / flatten / unflatten / buildCsvBlob
+// ---------------------------------------------------------------------------
+
+test('detectDelimiter: 出現数による判定・同数はカンマ優先・クォート内は数えない', () => {
+	assert.equal(detectDelimiter('a,b,c'), ',');
+	assert.equal(detectDelimiter('a\tb\tc'), '\t');
+	assert.equal(detectDelimiter('a;b;c'), ';');
+	assert.equal(detectDelimiter('a,b;c'), ',', '同数はカンマ優先');
+	assert.equal(
+		detectDelimiter('a\tb;c'),
+		'\t',
+		'タブとセミコロン同数はタブ優先',
+	);
+	assert.equal(detectDelimiter('"a,b,c"\tx\ty'), '\t', 'クォート内は数えない');
+	assert.equal(detectDelimiter('"x\ty";a;b'), ';');
+	assert.equal(detectDelimiter('plain'), ',', '候補なしはカンマ');
+	assert.equal(detectDelimiter('a;b\nc,d,e,f'), ';', '1行目のみで判定');
+});
+
+test('inferCellValue: 型推論の規則', () => {
+	assert.equal(inferCellValue('123'), 123);
+	assert.equal(inferCellValue('0'), 0);
+	assert.equal(inferCellValue('0.5'), 0.5);
+	assert.equal(inferCellValue('-12'), -12);
+	assert.equal(inferCellValue('007'), '007', '先頭ゼロは文字列保持');
+	assert.equal(inferCellValue('001.23'), '001.23');
+	assert.equal(inferCellValue('true'), true);
+	assert.equal(inferCellValue('false'), false);
+	assert.equal(inferCellValue('TRUE'), 'TRUE', '完全小文字のみboolean');
+	assert.equal(inferCellValue('True'), 'True');
+	assert.equal(inferCellValue(''), null, '空セルのみnull');
+	assert.equal(inferCellValue('null'), 'null', '"null"は文字列のまま');
+	assert.equal(
+		inferCellValue('2026-06-11'),
+		'2026-06-11',
+		'日付は文字列のまま',
+	);
+});
+
+test('flattenObject / unflattenObject: ネスト+配列の往復', () => {
+	const original = {
+		user: { name: '太郎', address: { city: '東京' } },
+		items: [{ id: 1 }, { id: 2 }],
+		tags: ['a', 'b'],
+		active: true,
+	};
+	const flat = flattenObject(original);
+	assert.deepEqual(flat, {
+		'user.name': '太郎',
+		'user.address.city': '東京',
+		'items.0.id': 1,
+		'items.1.id': 2,
+		'tags.0': 'a',
+		'tags.1': 'b',
+		active: true,
+	});
+	assert.deepEqual(unflattenObject(flat), original);
+});
+
+test('往復変換: JSON→CSV→JSON で構造が保たれる', () => {
+	const original = [
+		{ user: { name: '太郎', age: 30 }, tags: ['x', 'y'], active: true },
+		{ user: { name: '花子', age: 25 }, tags: ['z', 'w'], active: false },
+	];
+	const csv = expectOk(jsonToCsv(JSON.stringify(original), JSON_OPTS));
+	const back = expectOk(
+		csvToJson(csv.output, { ...CSV_OPTS, unflattenDotKeys: true }),
+	);
+	assert.deepEqual(JSON.parse(back.output), original);
+});
+
+test('buildCsvBlob: BOM ON で先頭3バイトが EF BB BF', async () => {
+	const withBom = buildCsvBlob('a,b\r\n1,2', true);
+	const bytes = new Uint8Array(await withBom.arrayBuffer());
+	assert.deepEqual([...bytes.slice(0, 3)], [0xef, 0xbb, 0xbf]);
+	const withoutBom = buildCsvBlob('a,b\r\n1,2', false);
+	const bytes2 = new Uint8Array(await withoutBom.arrayBuffer());
+	assert.notDeepEqual([...bytes2.slice(0, 3)], [0xef, 0xbb, 0xbf]);
+	assert.equal(withBom.type, 'text/csv;charset=utf-8');
+});
+
+test('stripBom: 先頭BOMのみ除去', () => {
+	assert.equal(stripBom('\u{FEFF}abc'), 'abc');
+	assert.equal(stripBom('abc'), 'abc');
+	assert.equal(stripBom(''), '');
+});

--- a/tests/unit/json-csv.test.ts
+++ b/tests/unit/json-csv.test.ts
@@ -231,6 +231,11 @@ test('csvToJson: クォート内の改行・区切り文字・エスケープを
 	]);
 });
 
+test('csvToJson: クォート内のCRLFをLFへ正規化せず保持する', () => {
+	const result = expectOk(csvToJson('a,b\r\n"改行\r\nあり",x', CSV_OPTS));
+	assert.deepEqual(JSON.parse(result.output), [{ a: '改行\r\nあり', b: 'x' }]);
+});
+
 test('csvToJson: \\r\\n と \\n の混在を読み取れる', () => {
 	const result = expectOk(csvToJson('a,b\n1,2\r\n3,4', CSV_OPTS));
 	assert.deepEqual(JSON.parse(result.output), [


### PR DESCRIPTION
## 概要

Phase 3c1 として、完全クライアントサイドで動作する開発・データ処理ツール2つを追加します。

- **ハッシュ値計算** (`/hash`) — テキスト・ファイルから MD5 / SHA-1 / SHA-256 / SHA-512 / CRC32 を計算し、期待値照合にも対応
- **JSON ↔ CSV 相互変換** (`/json-csv`) — JSON/CSV の双方向変換、ネスト展開、型推論、BOM付きUTF-8出力に対応

入力データやファイルはサーバーへ送信せず、すべてブラウザ内で処理します。

## 主な実装ポイント

- **ハッシュ計算ロジック** (`src/lib/tools/hash.ts`): MD5 / CRC32 はゼロ依存の純TS実装、SHA系は Web Crypto API を使用。ファイル入力はチャンク読み込みと進捗表示に対応。
- **ハッシュ照合UI**: 期待値の長さからアルゴリズムを推定し、一致・不一致・未選択アルゴリズムを日本語で案内。
- **JSON-CSV変換ロジック** (`src/lib/tools/json-csv.ts`): Papa Parse を利用しつつ、ヘッダー制御、型推論、ドット記法 flatten / unflatten、BOM付きCSV Blob生成を実装。
- **ファイル入力共通化**: `FileDropzone` を追加し、D&D / ファイル選択 / サイズ検証 / プライバシー表記を共通化。
- **導線・SEO**: `catalog.ts`、README、関連ツールリンク、各AstroページのSEO文言を更新。

## Codex レビュー反映

- `unflattenDotKeys` 有効時に `__proto__` / `constructor` / `prototype` 系キーで prototype pollution が起きないよう、独自プロパティとして安全に読み書きする処理へ変更。
- `__proto__` などのヘッダーを通常列として保持し、JSON出力から消えないよう修正。
- 重複CSVヘッダーを `a`, `a_2`, `a_2_2` のように一意化し、前列の値が静かに上書きされないよう修正。
- CSV→JSON変換時、クォート外のレコード区切りだけを正規化し、クォート内のCRLFを保持するよう修正。
- `FileDropzone` のD&D経路でも `accept` を検証し、対象外ファイル形式を拒否するよう修正。
- 上記の再発防止単体テスト・E2Eテストを追加。

## テスト

- [x] `npm run lint` — Biome エラーなし
- [x] `npm run test:unit` — 44 passed
- [x] `npm run build` — 26 pages built / Service Worker生成成功
- [x] `npx playwright test tests/e2e/json-csv.spec.ts` — 24 passed
- [x] `npx playwright test tests/e2e/hash.spec.ts tests/e2e/json-csv.spec.ts` — 44 passed

## デプロイ後の確認事項（マージ後・手動）

- [ ] `/hash` と `/json-csv` の本番URL動作確認（モバイル含む）
- [ ] OGP / Rich Results Test
- [ ] Google Search Console へのURL登録