### PR TITLE
[codex] READMEの収録ツール数を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 🔗 **[https://tools.codelife.cafe](https://tools.codelife.cafe)**
 
-## 📦 収録ツール（20種）
+## 📦 収録ツール（22種）
 
 ### テキスト処理
 


### PR DESCRIPTION
## 概要

直近リリース（#89）でハッシュ値計算とJSON ↔ CSV 変換が追加され、README本文のツール一覧には反映済みでしたが、見出しの収録ツール数が20種のまま残っていました。

## 変更内容

- READMEの「収録ツール」見出しを20種から22種に更新

## 確認内容

- `git diff --check`
- PowerShellで `src/lib/tools/catalog.ts` の `id` 件数と README 見出しの件数がどちらも22であることを確認
- `npm run check`（exit 0。既存の `playwright-report/trace` 由来のTypeScript warningあり）