### PR TITLE
画像圧縮結果の前後プレビューを改善

### DIFF
--- a/src/components/image-compress/CompressResultList.tsx
+++ b/src/components/image-compress/CompressResultList.tsx
@@ -1,6 +1,12 @@
 // CompressResultList — ファイルごとの結果行（サムネ / サイズ比較 / 削減率 / DL / before-after比較）
 
-import { AlertTriangle, Download, ImageIcon, Loader2 } from 'lucide-react';
+import {
+	AlertTriangle,
+	Download,
+	ImageIcon,
+	Loader2,
+	MoveRight,
+} from 'lucide-react';
 import { useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -64,21 +70,51 @@ export function CompressResultList({
 				return (
 					<div
 						key={item.id}
-						className="flex items-center gap-3 rounded-lg border border-border p-3"
+						className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-center"
 					>
-						{/* サムネイル */}
+						{/* サムネイル比較 */}
 						<button
 							type="button"
 							onClick={() => item.status === 'done' && setPreview(item)}
-							className="shrink-0 rounded border border-border overflow-hidden bg-muted/30 disabled:cursor-default"
+							className="group flex w-fit shrink-0 items-center gap-2 rounded-lg border border-border bg-muted/20 p-2 text-left transition-colors hover:border-primary/50 hover:bg-primary/5 disabled:cursor-default disabled:hover:border-border disabled:hover:bg-muted/20"
 							disabled={item.status !== 'done'}
-							aria-label="拡大して比較"
+							aria-label="変換前後を拡大して比較"
 						>
-							<img
-								src={item.previewUrl}
-								alt={item.file.name}
-								className="h-14 w-14 object-cover"
-							/>
+							<figure className="space-y-1">
+								<div className="overflow-hidden rounded border border-border bg-[repeating-conic-gradient(#0001_0_25%,transparent_0_50%)] bg-[length:10px_10px]">
+									<img
+										src={item.previewUrl}
+										alt={`${item.file.name}の変換前プレビュー`}
+										className="h-14 w-14 object-cover"
+									/>
+								</div>
+								<figcaption className="text-center text-[10px] font-medium text-muted-foreground">
+									変換前
+								</figcaption>
+							</figure>
+							<MoveRight className="mb-5 h-4 w-4 shrink-0 text-muted-foreground" />
+							<figure className="space-y-1">
+								<div className="overflow-hidden rounded border border-border bg-[repeating-conic-gradient(#0001_0_25%,transparent_0_50%)] bg-[length:10px_10px]">
+									{item.status === 'done' && item.resultUrl ? (
+										<img
+											src={item.resultUrl}
+											alt={`${item.file.name}の変換後プレビュー`}
+											className="h-14 w-14 object-cover"
+										/>
+									) : (
+										<div className="flex h-14 w-14 items-center justify-center bg-muted/40 text-muted-foreground">
+											{item.status === 'pending' ? (
+												<Loader2 className="h-4 w-4 animate-spin" />
+											) : (
+												<AlertTriangle className="h-4 w-4" />
+											)}
+										</div>
+									)}
+								</div>
+								<figcaption className="text-center text-[10px] font-medium text-muted-foreground">
+									変換後
+								</figcaption>
+							</figure>
 						</button>
 
 						{/* 情報 */}


### PR DESCRIPTION
### Motivation
- 圧縮後一覧で「変換前／変換後」のプレビューが分かりづらいため、一覧上で前後比較が一目で分かるようにするため。 

### Description
- `src/components/image-compress/CompressResultList.tsx` を更新し、一覧行のサムネイルを「変換前 → 変換後」の横並び比較に変更した。 
- 小さな枠にそれぞれラベル（変換前 / 変換後）とチェッカーボード風背景を付け、透過画像でも分かりやすくした。 
- 処理中は `Loader2` スピナー、エラー時は `AlertTriangle` を変換後枠に表示するようにし、状態が一覧で分かるようにした。 
- 比較サムネイルをクリックすると既存の拡大比較モーダルを開くことが分かるように `aria-label` とボタンスタイルを調整し、`MoveRight` アイコンを追加した。 

### Testing
- `npm run lint` を実行し、Biome の整形エラーを1ファイル自動修正してパスさせた（成功）。
- `PATH=/root/.local/share/mise/installs/node/22.22.2/bin:$PATH npm run check` を実行し、`astro check` と `biome check` を通過した（警告は表示されたがエラーなし）。
- `PATH=/root/.local/share/mise/installs/node/22.22.2/bin:$PATH npm run build` を実行し、ビルドが正常に完了して `dist/` が生成された（成功）。
- Playwright を使ったスクリーンショット取得を試みたが、Chromium のダウンロード先で `403 Domain forbidden` が返りブラウザのインストールが失敗したためスクリーンショット取得は行えなかった（失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4aeda838832f8c16e1b5f19f563c)