### PR TITLE
使い方・ユースケースをデフォルトで開き、開閉状態を記憶

### DIFF
--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -44,7 +44,7 @@ const { title, description, path } = Astro.props;
   </div>
 </BaseLayout>
 
-<script is:inline define:vars={{ path }}>
+<script is:inline define:vars={{ path }} data-astro-rerun>
   {
     const details = document.querySelector('#tool-layout-container details.group');
     if (details) {

--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -43,3 +43,21 @@ const { title, description, path } = Astro.props;
     <slot name="usage" />
   </div>
 </BaseLayout>
+
+<script is:inline define:vars={{ path }}>
+  {
+    const details = document.querySelector('#tool-layout-container details.group');
+    if (details) {
+      const key = `usage-open:${path}`;
+      const stored = localStorage.getItem(key);
+      if (stored === 'closed') {
+        details.removeAttribute('open');
+      } else if (stored === 'open') {
+        details.setAttribute('open', '');
+      }
+      details.addEventListener('toggle', () => {
+        localStorage.setItem(key, details.open ? 'open' : 'closed');
+      });
+    }
+  }
+</script>

--- a/src/components/image-text/LayerPanel.tsx
+++ b/src/components/image-text/LayerPanel.tsx
@@ -37,7 +37,7 @@ export function LayerPanel({
 					「テキストを追加」を押すと画像中央にテキストが配置されます。
 				</p>
 			) : (
-				<ul className="space-y-1">
+				<ul className="space-y-1" aria-label="レイヤー一覧">
 					{layers.map((layer, index) => {
 						const isSelected = layer.id === selectedId;
 						return (

--- a/src/pages/base64.astro
+++ b/src/pages/base64.astro
@@ -11,7 +11,7 @@ import Base64Converter from '../components/tools/Base64Converter.tsx';
   <Base64Converter client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/bg-remove.astro
+++ b/src/pages/bg-remove.astro
@@ -11,7 +11,7 @@ import BgRemoveTool from '../components/tools/BgRemove.tsx';
   <BgRemoveTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/char-count.astro
+++ b/src/pages/char-count.astro
@@ -13,7 +13,7 @@ import CharCountTool from '../components/tools/CharCount.tsx';
   <CharCountTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/cipher.astro
+++ b/src/pages/cipher.astro
@@ -11,7 +11,7 @@ import { CipherPage } from '../components/tools/cipher/CipherPage';
   <CipherPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/color.astro
+++ b/src/pages/color.astro
@@ -11,7 +11,7 @@ import { ColorConvertPage } from '../components/tools/color/ColorConvertPage';
   <ColorConvertPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/csv-editor.astro
+++ b/src/pages/csv-editor.astro
@@ -11,7 +11,7 @@ import CsvEditorTool from '../components/tools/CsvEditor.tsx';
   <CsvEditorTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/csv-fixer.astro
+++ b/src/pages/csv-fixer.astro
@@ -13,7 +13,7 @@ import CsvFixerTool from '../components/tools/CsvFixer';
   </div>
 
   <div slot="usage" class="mt-12">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/dummy-data.astro
+++ b/src/pages/dummy-data.astro
@@ -11,7 +11,7 @@ import DummyDataGenerator from '../components/tools/DummyDataGenerator.tsx';
   <DummyDataGenerator client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/hash.astro
+++ b/src/pages/hash.astro
@@ -11,7 +11,7 @@ import { HashPage } from '../components/tools/hash-generator/HashPage';
   <HashPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/image-compress.astro
+++ b/src/pages/image-compress.astro
@@ -11,7 +11,7 @@ import { ImageCompressPage } from '../components/image-compress/ImageCompressPag
   <ImageCompressPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/image-mosaic.astro
+++ b/src/pages/image-mosaic.astro
@@ -11,7 +11,7 @@ import ImageMosaicPage from '../components/image-mosaic/ImageMosaicPage';
   <ImageMosaicPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/image-text.astro
+++ b/src/pages/image-text.astro
@@ -11,7 +11,7 @@ import ImageTextPage from '../components/image-text/ImageTextPage';
   <ImageTextPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/json-csv.astro
+++ b/src/pages/json-csv.astro
@@ -11,7 +11,7 @@ import { JsonCsvPage } from '../components/tools/json-csv/JsonCsvPage';
   <JsonCsvPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/json-formatter.astro
+++ b/src/pages/json-formatter.astro
@@ -13,7 +13,7 @@ import JsonFormatterTool from '../components/tools/JsonFormatter.tsx';
   <JsonFormatterTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/markdown.astro
+++ b/src/pages/markdown.astro
@@ -11,7 +11,7 @@ import { MarkdownPreviewPage } from '../components/tools/markdown/MarkdownPrevie
   <MarkdownPreviewPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/masking.astro
+++ b/src/pages/masking.astro
@@ -11,7 +11,7 @@ import MaskingTool from '../components/tools/Masking.tsx';
   <MaskingTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/pdf-merge.astro
+++ b/src/pages/pdf-merge.astro
@@ -11,7 +11,7 @@ import { PdfMergePage } from '../components/pdf-merge/PdfMergePage';
   <PdfMergePage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/pdf-split.astro
+++ b/src/pages/pdf-split.astro
@@ -11,7 +11,7 @@ import { PdfSplitPage } from '../components/pdf-split/PdfSplitPage';
   <PdfSplitPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/phone-formatter.astro
+++ b/src/pages/phone-formatter.astro
@@ -13,7 +13,7 @@ import PhoneFormatterPage from '../components/phone-formatter/PhoneFormatterPage
   </div>
 
   <div slot="usage" class="mt-12">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/qr-generator.astro
+++ b/src/pages/qr-generator.astro
@@ -13,7 +13,7 @@ import QrGeneratorTool from '../components/tools/QrGenerator.tsx';
   <QrGeneratorTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/regex-tester.astro
+++ b/src/pages/regex-tester.astro
@@ -11,7 +11,7 @@ import RegexTesterTool from '../components/tools/RegexTester.tsx';
   <RegexTesterTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/sql-formatter.astro
+++ b/src/pages/sql-formatter.astro
@@ -11,7 +11,7 @@ import SqlFormatterTool from '../components/tools/SqlFormatter.tsx';
   <SqlFormatterTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/tax.astro
+++ b/src/pages/tax.astro
@@ -11,7 +11,7 @@ import { TaxCalcPage } from '../components/tools/tax/TaxCalcPage';
   <TaxCalcPage client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/text-diff.astro
+++ b/src/pages/text-diff.astro
@@ -13,7 +13,7 @@ import TextDiffTool from '../components/tools/TextDiff.tsx';
   <TextDiffTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/unicode-converter.astro
+++ b/src/pages/unicode-converter.astro
@@ -11,7 +11,7 @@ import UnicodeConverterTool from '../components/tools/UnicodeConverter.tsx';
   <UnicodeConverterTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/url-encoder.astro
+++ b/src/pages/url-encoder.astro
@@ -11,7 +11,7 @@ import UrlEncoderTool from '../components/tools/UrlEncoder.tsx';
   <UrlEncoderTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/wareki-converter.astro
+++ b/src/pages/wareki-converter.astro
@@ -11,7 +11,7 @@ import WarekiConverterTool from '../components/tools/WarekiConverter.tsx';
   <WarekiConverterTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/zenkaku-hankaku.astro
+++ b/src/pages/zenkaku-hankaku.astro
@@ -13,7 +13,7 @@ import ZenkakuHankakuTool from '../components/tools/ZenkakuHankaku.tsx';
   <ZenkakuHankakuTool client:load />
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/src/pages/zipcode.astro
+++ b/src/pages/zipcode.astro
@@ -31,7 +31,7 @@ const sourceLabel = dataVersion
   <p class="mt-6 text-xs text-muted-foreground">{sourceLabel}</p>
 
   <div slot="usage" class="mt-8">
-    <details class="group rounded-xl border border-border p-4">
+    <details class="group rounded-xl border border-border p-4" open>
       <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
         📖 使い方・ユースケース
         <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -54,7 +54,11 @@ test.describe('背景削除ツール', () => {
 		const usageDetails = page.getByText('使い方・ユースケース');
 		await expect(usageDetails).toBeVisible();
 
-		await usageDetails.click();
+		// デフォルトで開いている
 		await expect(page.getByText('商品写真の背景を透過にしたい')).toBeVisible();
+
+		// クリックで閉じることができる
+		await usageDetails.click();
+		await expect(page.getByText('商品写真の背景を透過にしたい')).not.toBeVisible();
 	});
 });

--- a/tests/e2e/bg-remove.spec.ts
+++ b/tests/e2e/bg-remove.spec.ts
@@ -59,6 +59,8 @@ test.describe('背景削除ツール', () => {
 
 		// クリックで閉じることができる
 		await usageDetails.click();
-		await expect(page.getByText('商品写真の背景を透過にしたい')).not.toBeVisible();
+		await expect(
+			page.getByText('商品写真の背景を透過にしたい'),
+		).not.toBeVisible();
 	});
 });

--- a/tests/e2e/image-text.spec.ts
+++ b/tests/e2e/image-text.spec.ts
@@ -130,12 +130,14 @@ test.describe('画像テキスト挿入', () => {
 		await uploadSample(page);
 		await addLayer(page);
 
+		const layerList = page.getByRole('list', { name: 'レイヤー一覧' });
+
 		await page.getByRole('button', { name: 'レイヤーを複製' }).click();
-		await expect(page.getByRole('listitem')).toHaveCount(2);
+		await expect(layerList.getByRole('listitem')).toHaveCount(2);
 
 		// 2番目（複製）を上へ移動できる
 		await page.getByRole('button', { name: '上へ移動' }).last().click();
-		await expect(page.getByRole('listitem')).toHaveCount(2);
+		await expect(layerList.getByRole('listitem')).toHaveCount(2);
 	});
 
 	test('ダウンロードが _edited ファイル名で発火する', async ({ page }) => {


### PR DESCRIPTION
## Summary
- 各ツールページの「使い方・ユースケース」セクション(`<details class="group">`)をデフォルトで開いた状態にする
- ユーザーが手動で開閉した状態を `localStorage`(キー: `usage-open:<path>`)に保存し、再訪問時に復元する

## 実装
- `ToolLayout.astro` に `details.group` の開閉状態を制御する `is:inline` スクリプトを追加
- 全29ツールページの `<details class="group rounded-xl border border-border p-4">` に `open` 属性を付与（JS無効時のフォールバック・初回表示）

## Test plan
- [x] `npm run build` が成功することを確認
- [x] 生成された HTML に `open` 属性とスクリプトが正しく出力されていることを確認
- [ ] 実ブラウザで動作確認（トグル開閉が `localStorage` に保存され、リロード後も状態が復元される）

https://claude.ai/code/session_018b4MYwt1J22sfmzBVewVkb


---
_Generated by [Claude Code](https://claude.ai/code/session_018b4MYwt1J22sfmzBVewVkb)_