### PR TITLE
fix: オフライン時のページ遷移がERR_INTERNET_DISCONNECTEDになる問題を修正

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -20,6 +20,25 @@ const ALL_ASSETS = [
 	/* __ALL_ASSETS__ */
 ];
 
+// redirected:true の Response はナビゲーションへの応答として使えない（ブラウザが拒否する）ため、
+// リダイレクトを経由したレスポンスは本体をコピーしてフラグを剥がす
+async function stripRedirect(response) {
+	if (!response || !response.redirected) return response;
+	const body = await response.blob();
+	return new Response(body, {
+		status: response.status,
+		statusText: response.statusText,
+		headers: response.headers,
+	});
+}
+
+// fetch して redirected フラグを剥がした上で指定 URL キーでキャッシュに保存する
+async function fetchAndCache(cache, url) {
+	const response = await fetch(url);
+	if (!response.ok) throw new Error(`HTTP ${response.status} for ${url}`);
+	await cache.put(url, await stripRedirect(response));
+}
+
 self.addEventListener('install', (event) => {
 	event.waitUntil(
 		Promise.all([
@@ -28,7 +47,7 @@ self.addEventListener('install', (event) => {
 			caches
 				.open(CACHE_NAME)
 				.then((cache) =>
-					Promise.allSettled(MIN_ASSETS.map((url) => cache.add(url))),
+					Promise.allSettled(MIN_ASSETS.map((url) => fetchAndCache(cache, url))),
 				),
 		]),
 	);
@@ -75,8 +94,9 @@ self.addEventListener('message', (event) => {
 				const promises = urls.map(async (url) => {
 					try {
 						const cached = await cache.match(url);
-						if (!cached) {
-							await cache.add(url);
+						// 旧バージョンの SW が redirected な Response を保存している可能性があるため再取得する
+						if (!cached || cached.redirected) {
+							await fetchAndCache(cache, url);
 						}
 					} catch (err) {
 						console.error(`Failed to cache ${url}:`, err);
@@ -107,7 +127,8 @@ self.addEventListener('message', (event) => {
 
 				for (const url of urls) {
 					const matched = await cache.match(url);
-					if (matched) {
+					// redirected な古いエントリはオフライン時に使えないため未キャッシュ扱い
+					if (matched && !matched.redirected) {
 						cachedCount++;
 					}
 				}
@@ -166,22 +187,27 @@ self.addEventListener('fetch', (event) => {
 				.then((response) => {
 					// ナビゲーション時のみキャッシュを更新（View Transitions fetchは除外）
 					if (event.request.mode === 'navigate') {
+						const clone = response.clone();
 						caches
 							.open(CACHE_NAME)
-							.then((cache) => cache.put(reqUrl, response.clone()));
+							.then(async (cache) =>
+								cache.put(reqUrl, await stripRedirect(clone)),
+							);
 					}
 					return response;
 				})
 				.catch(async () => {
 					const cache = await caches.open(CACHE_NAME);
 					// trailing slash の有無を両方試みる
-					const normalizedUrl = reqUrl.endsWith('/') ? reqUrl : reqUrl + '/';
+					const withSlash = reqUrl.endsWith('/') ? reqUrl : reqUrl + '/';
+					const withoutSlash = reqUrl.endsWith('/')
+						? reqUrl.slice(0, -1)
+						: reqUrl;
 					const matched =
-						(await cache.match(normalizedUrl, { ignoreVary: true })) ||
-						(await cache.match(reqUrl, { ignoreVary: true }));
-					return (
-						matched || (await cache.match('/offline/', { ignoreVary: true }))
-					);
+						(await cache.match(withSlash, { ignoreVary: true })) ||
+						(await cache.match(withoutSlash, { ignoreVary: true })) ||
+						(await cache.match('/offline/', { ignoreVary: true }));
+					return stripRedirect(matched);
 				}),
 		);
 		return;


### PR DESCRIPTION
## 問題
オフラインモード有効化（一括ダウンロード完了）後でも、オフライン状態でページ遷移すると `ERR_INTERNET_DISCONNECTED` になっていました。

## 原因
プリキャッシュは末尾スラッシュ付きURL（例: `/zenkaku-hankaku/`）で `cache.add` していますが、Cloudflare Pages の正規URLはスラッシュなし（`/zenkaku-hankaku`）のため、**308リダイレクトを経由した `redirected: true` な Response** がキャッシュに保存されていました。ブラウザはナビゲーションリクエスト（redirect mode: manual）への応答として redirected な Response を拒否するため、オフライン時の `respondWith` がネットワークエラーになります。

## 修正内容（`public/sw.js`）
- `stripRedirect()` ヘルパーを追加し、キャッシュ**保存時**（install / PRECACHE_ALL / ナビゲーション時のランタイムキャッシュ）と**提供時**（オフラインフォールバック）の両方で redirected フラグを除去
- 旧バージョンのSWが保存した redirected エントリは `PRECACHE_ALL` で再取得し、`CHECK_PRECACHE_STATUS` でも未キャッシュ扱いにして再ダウンロードを促す（CACHE_NAME が変わらない既存ユーザーも救済）
- フォールバック時のURL照合をスラッシュあり/なし両方向に対応

## 検証
- `npm run build` 正常完了、生成された `dist/sw.js` の構文チェックOK
- デプロイ後の確認手順: オフラインモードを再有効化（古い redirected エントリの再取得が走る）→ DevTools Network を Offline にしてページ遷移

https://claude.ai/code/session_01Cj7iGAYezf2fh5HK8fYGAy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cj7iGAYezf2fh5HK8fYGAy)_