### PR TITLE
fix: 検索モーダルでIME変換確定のEnterによる意図しないページ遷移を防止

### DIFF
--- a/src/components/common/SearchModal.tsx
+++ b/src/components/common/SearchModal.tsx
@@ -63,6 +63,9 @@ export default function SearchModal() {
 		if (!isOpen) return;
 
 		const handleModalKeyDown = (e: KeyboardEvent) => {
+			// IME変換中のキー操作（変換確定のEnter・候補選択の矢印キー）は無視する
+			// keyCode 229 は一部ブラウザでIME処理中を示すフォールバック
+			if (e.isComposing || e.keyCode === 229) return;
 			if (filteredTools.length === 0) return;
 
 			if (e.key === 'ArrowDown') {

--- a/tests/e2e/search-navigation.spec.ts
+++ b/tests/e2e/search-navigation.spec.ts
@@ -81,6 +81,38 @@ test.describe('Search after page navigation', () => {
 		}
 	});
 
+	test('Enter during IME composition does not navigate', async ({ page }) => {
+		// 1. トップページにアクセスして検索モーダルを開く
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+
+		await page.keyboard.press('Control+k');
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await expect(searchInput).toBeFocused();
+
+		// 2. IME変換中（isComposing: true）の Enter をディスパッチ
+		await page.evaluate(() => {
+			window.dispatchEvent(
+				new KeyboardEvent('keydown', {
+					key: 'Enter',
+					isComposing: true,
+					bubbles: true,
+				}),
+			);
+		});
+		await page.waitForTimeout(500);
+
+		// 3. ページ遷移せず、モーダルが開いたままであることを確認
+		expect(new URL(page.url()).pathname).toBe('/');
+		await expect(searchInput).toBeVisible();
+
+		// 4. 通常の Enter では選択中ツールへ遷移することを確認
+		await page.keyboard.press('Enter');
+		await page.waitForTimeout(1000);
+		expect(new URL(page.url()).pathname).not.toBe('/');
+	});
+
 	test('Keyboard shortcut label shows correct OS key', async ({ page }) => {
 		// Playwright runs on non-Mac typically, so expect Ctrl+K
 		await page.goto('/');


### PR DESCRIPTION
## 概要

検索モーダル（Ctrl+K）で日本語入力中、IMEの変換確定のために押した Enter が「選択中ツールへの遷移」として処理され、意図しないページ遷移が発生する問題を修正します。

Closes #105

## 変更内容

- `src/components/common/SearchModal.tsx`
  - モーダル内キーボードハンドラ（`handleModalKeyDown`）の冒頭に `if (e.isComposing || e.keyCode === 229) return;` を追加
  - IME変換確定の Enter に加え、IME候補ウィンドウ操作と競合する ArrowUp / ArrowDown も同時にガードされます
  - ハンドラは `window` への native `keydown` リスナーのため `e.isComposing` を直接参照（React合成イベントではない）
- `tests/e2e/search-navigation.spec.ts`
  - IME変換中（`isComposing: true`）の Enter ではページ遷移せずモーダルが開いたままであること、通常の Enter では遷移することを検証するテストケースを追加

## テスト結果

- `npm run lint` — エラーなし
- `npm run build` — 成功
- `npx playwright test tests/e2e/search-navigation.spec.ts` — **5 passed, 5 skipped**（mobile-chrome はデスクトップ専用UIのためスキップ）
  - 新規テスト `Enter during IME composition does not navigate` を含め全件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)