### PR TITLE
fix: カスタム404ページを追加しsoft 404を解消

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -186,7 +186,8 @@ self.addEventListener('fetch', (event) => {
 			fetch(event.request)
 				.then((response) => {
 					// ナビゲーション時のみキャッシュを更新（View Transitions fetchは除外）
-					if (event.request.mode === 'navigate') {
+					// 404等のエラーページをキャッシュしないよう response.ok を確認する
+					if (event.request.mode === 'navigate' && response.ok) {
 						const clone = response.clone();
 						caches
 							.open(CACHE_NAME)

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,89 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { toolCatalog } from '../lib/tools/catalog';
+
+// 404ページに表示する人気ツール
+const POPULAR_TOOL_IDS = [
+	'zenkaku-hankaku',
+	'json-formatter',
+	'text-diff',
+	'csv-editor',
+	'qr-generator',
+	'tax',
+] as const;
+const popularTools = POPULAR_TOOL_IDS.map((id) =>
+	toolCatalog.find((tool) => tool.id === id),
+).filter((tool) => tool !== undefined);
+---
+
+<BaseLayout
+  title="ページが見つかりません"
+  description="お探しのページは見つかりませんでした。URLをご確認いただくか、検索や人気ツールからお探しください。"
+  path="/404/"
+>
+  <Fragment slot="head">
+    <meta name="robots" content="noindex" />
+  </Fragment>
+
+  <div class="mx-auto max-w-3xl px-4 py-12 sm:px-6 lg:px-8 flex items-center justify-center min-h-[60vh]">
+    <div class="rounded-xl border border-border bg-card p-8 text-center shadow-sm w-full max-w-lg">
+      <p class="text-5xl font-bold tracking-tight text-primary mb-4">404</p>
+      <h1 class="text-2xl font-bold tracking-tight text-foreground sm:text-3xl mb-2">ページが見つかりません</h1>
+      <p class="text-muted-foreground mb-6">
+        お探しのページは移動または削除されたか、<br class="hidden sm:inline">URLが間違っている可能性があります。
+      </p>
+
+      <div class="flex flex-wrap justify-center gap-4 mb-8">
+        <a
+          href="/"
+          class="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring bg-primary text-primary-foreground shadow hover:bg-primary/90 h-9 px-4 py-2"
+        >
+          トップページへ
+        </a>
+        <button
+          type="button"
+          id="not-found-search"
+          class="inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring border border-input bg-background hover:bg-accent hover:text-accent-foreground h-9 px-4 py-2"
+        >
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"></circle><path d="m21 21-4.3-4.3"></path></svg>
+          ツールを検索
+          <kbd class="hidden md:inline rounded border border-border bg-muted px-1.5 py-0.5 text-xs font-mono">Ctrl+K</kbd>
+        </button>
+      </div>
+
+      <div class="text-left">
+        <h2 class="text-sm font-semibold text-foreground mb-3">人気のツール</h2>
+        <ul class="grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {popularTools.map((tool) => (
+            <li>
+              <a
+                href={tool.href}
+                class="flex items-center gap-2 rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+              >
+                <span aria-hidden="true">{tool.icon}</span>
+                <span>{tool.title}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    function setupNotFoundSearch() {
+      const trigger = document.getElementById('not-found-search');
+      if (trigger) {
+        // 既存リスナーの重複を防ぐためclone & replace
+        const newTrigger = trigger.cloneNode(true) as Element;
+        trigger.parentNode?.replaceChild(newTrigger, trigger);
+        newTrigger.addEventListener('click', () => {
+          window.dispatchEvent(new CustomEvent('open-search'));
+        });
+      }
+    }
+
+    setupNotFoundSearch();
+    document.addEventListener('astro:page-load', setupNotFoundSearch);
+  </script>
+</BaseLayout>

--- a/tests/e2e/not-found.spec.ts
+++ b/tests/e2e/not-found.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from './fixtures/base';
+
+test.describe('404ページ', () => {
+	test('存在しないURLで404ページの内容が表示される', async ({ page }) => {
+		const response = await page.goto('/this-page-does-not-exist');
+
+		// プレビューサーバーは dist/404.html を404ステータスで返す
+		expect(response?.status()).toBe(404);
+
+		await expect(
+			page.getByRole('heading', { name: 'ページが見つかりません' }),
+		).toBeVisible();
+
+		// noindex メタが付与されている
+		await expect(page.locator('meta[name="robots"]')).toHaveAttribute(
+			'content',
+			'noindex',
+		);
+	});
+
+	test('トップページへのリンクと人気ツールへのリンクが機能する', async ({
+		page,
+	}) => {
+		await page.goto('/this-page-does-not-exist');
+
+		// 人気ツールのリンクが表示されている
+		await expect(page.getByRole('link', { name: /JSON整形/ })).toBeVisible();
+
+		// トップページへのリンクで回遊できる
+		await page.getByRole('link', { name: 'トップページへ' }).click();
+		await expect(page).toHaveURL(/\/$/);
+	});
+
+	test('検索ボタンで検索モーダルが開く', async ({ page }) => {
+		await page.goto('/this-page-does-not-exist');
+
+		await page.locator('#not-found-search').click();
+		await expect(
+			page.getByPlaceholder('ツールを検索... (Enterで移動)'),
+		).toBeVisible();
+	});
+});


### PR DESCRIPTION
## 概要

Closes #106

存在しないURLにアクセスすると HTTP 200 でトップページが返る soft 404 状態を解消するため、カスタム404ページを追加しました。

## 変更内容

### `src/pages/404.astro`（新規）
- 「ページが見つかりません」を明示する404ページ。Astro が `dist/404.html` を生成し、Cloudflare Pages はこれを自動的に 404 ステータスで配信します
- 回遊導線として以下を配置:
  - トップページへのリンク
  - 検索モーダルを開くボタン（Ctrl+K の案内付き、Header と同じ `open-search` イベントを発火）
  - 人気ツール6件へのリンク（`src/lib/tools/catalog.ts` から取得）
- `<meta name="robots" content="noindex">` を付与。サイトマップ（`@astrojs/sitemap`）には含まれないことをビルドで確認済み

### `public/sw.js`（最小修正）
- ナビゲーション時のキャッシュ更新で `response.ok` を確認するよう修正。従来は未知URLへの404レスポンスもそのURLキーでキャッシュされ、キャッシュを汚染していました
- `scripts/generate-sw.mjs` はディレクトリのみをページとして収集するため、`dist/404.html`（ルート直下のファイル）はプリキャッシュ対象に含まれません（確認済み・変更不要）

### `tests/e2e/not-found.spec.ts`（新規）
- 存在しないURLで 404 ステータス + 404ページ内容 + noindex メタを検証
- トップページリンク・人気ツールリンク・検索モーダルの動作を検証

## テスト結果

- `npm run lint` — エラーなし
- `npm run build` — `dist/404.html` 生成を確認、`sitemap-0.xml` / `sw.js` プリキャッシュリストに 404 が含まれないことを確認
- `npx playwright test tests/e2e/not-found.spec.ts` — 6 passed（chromium / mobile-chrome）
- 回帰確認: `smoke.spec.ts` / `layout.spec.ts` / `search-navigation.spec.ts` — 72 passed, 4 skipped

## Cloudflare Pages での配信挙動の注意点

- Cloudflare Pages は出力ルートの `404.html` を検出すると、未マッチのパスに対して自動的にこれを HTTP 404 で配信します（追加設定不要）
- ローカルの `astro preview` も同様に 404 ステータスで `404.html` を返すため、E2E ではステータスコードも検証しています
- 既存ユーザーの Service Worker は次回デプロイ時に新しい `CACHE_NAME` で更新され、過去にキャッシュされた可能性のある未知URLのエントリも自動失効します

🤖 Generated with [Claude Code](https://claude.com/claude-code)