### PR TITLE
feat: 検索モーダルにタイトル一致優先のランキングを導入

### DIFF
--- a/src/components/common/SearchModal.tsx
+++ b/src/components/common/SearchModal.tsx
@@ -3,6 +3,7 @@ import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 import { toolCatalog } from '@/lib/tools/catalog';
+import { searchTools } from '@/lib/tools/search';
 
 export default function SearchModal() {
 	const [isOpen, setIsOpen] = useState(false);
@@ -10,18 +11,7 @@ export default function SearchModal() {
 	const [activeIndex, setActiveIndex] = useState(0);
 	const inputRef = useRef<HTMLInputElement>(null);
 
-	const filteredTools = query
-		? toolCatalog.filter((tool) =>
-				(
-					tool.title +
-					tool.description +
-					tool.category +
-					tool.keywords.join(' ')
-				)
-					.toLowerCase()
-					.includes(query.toLowerCase()),
-			)
-		: toolCatalog;
+	const filteredTools = query ? searchTools(query) : toolCatalog;
 
 	// Search trigger & Keyboard shortcuts
 	useEffect(() => {
@@ -130,6 +120,7 @@ export default function SearchModal() {
 								<a
 									key={tool.id}
 									href={tool.href}
+									data-testid="search-result"
 									className={`flex flex-col gap-1 px-4 py-3 rounded-lg transition-colors ${
 										index === activeIndex
 											? 'bg-primary/10 text-foreground'

--- a/src/lib/tools/search.ts
+++ b/src/lib/tools/search.ts
@@ -1,0 +1,65 @@
+import { type ToolCatalogItem, toolCatalog } from './catalog';
+
+// マッチ箇所ごとの重み（大きいほど優先）
+const SCORE_TITLE_PREFIX = 100;
+const SCORE_TITLE_PARTIAL = 80;
+const SCORE_KEYWORD = 60;
+const SCORE_CATEGORY_DESCRIPTION = 40;
+
+/**
+ * 検索用にテキストを正規化する。
+ * 小文字化に加え、ひらがなをカタカナに変換することで
+ * 「かうんと」→「カウント」のような表記ゆれを吸収する。
+ */
+export function normalizeSearchText(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/[ぁ-ゖ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) + 0x60));
+}
+
+/**
+ * ツール1件に対するクエリの関連度スコアを返す（0 = 不一致）。
+ * 優先順: タイトル前方一致 > タイトル部分一致 > キーワード一致 > カテゴリ・説明文一致
+ */
+export function scoreToolMatch(tool: ToolCatalogItem, query: string): number {
+	const q = normalizeSearchText(query);
+	if (!q) return 0;
+
+	const title = normalizeSearchText(tool.title);
+	if (title.startsWith(q)) return SCORE_TITLE_PREFIX;
+	if (title.includes(q)) return SCORE_TITLE_PARTIAL;
+
+	if (
+		tool.keywords.some((keyword) => normalizeSearchText(keyword).includes(q))
+	) {
+		return SCORE_KEYWORD;
+	}
+
+	const rest = normalizeSearchText(`${tool.category} ${tool.description}`);
+	if (rest.includes(q)) return SCORE_CATEGORY_DESCRIPTION;
+
+	return 0;
+}
+
+/**
+ * クエリに一致するツールを関連度の降順で返す。
+ * 同スコアの場合はカタログ定義順を維持する（安定ソート）。
+ * クエリが空の場合はカタログ全件をそのまま返す。
+ */
+export function searchTools(
+	query: string,
+	catalog: readonly ToolCatalogItem[] = toolCatalog,
+): readonly ToolCatalogItem[] {
+	const trimmed = query.trim();
+	if (!trimmed) return catalog;
+
+	return catalog
+		.map((tool, index) => ({
+			tool,
+			index,
+			score: scoreToolMatch(tool, trimmed),
+		}))
+		.filter((entry) => entry.score > 0)
+		.sort((a, b) => b.score - a.score || a.index - b.index)
+		.map((entry) => entry.tool);
+}

--- a/src/lib/tools/search.ts
+++ b/src/lib/tools/search.ts
@@ -18,27 +18,57 @@ export function normalizeSearchText(text: string): string {
 }
 
 /**
- * ツール1件に対するクエリの関連度スコアを返す（0 = 不一致）。
+ * 正規化済みの単一検索語に対するツール1件のスコアを返す（0 = 不一致）。
  * 優先順: タイトル前方一致 > タイトル部分一致 > キーワード一致 > カテゴリ・説明文一致
  */
-export function scoreToolMatch(tool: ToolCatalogItem, query: string): number {
-	const q = normalizeSearchText(query);
-	if (!q) return 0;
-
+function scoreSingleTerm(tool: ToolCatalogItem, term: string): number {
 	const title = normalizeSearchText(tool.title);
-	if (title.startsWith(q)) return SCORE_TITLE_PREFIX;
-	if (title.includes(q)) return SCORE_TITLE_PARTIAL;
+	if (title.startsWith(term)) return SCORE_TITLE_PREFIX;
+	if (title.includes(term)) return SCORE_TITLE_PARTIAL;
 
 	if (
-		tool.keywords.some((keyword) => normalizeSearchText(keyword).includes(q))
+		tool.keywords.some((keyword) => normalizeSearchText(keyword).includes(term))
 	) {
 		return SCORE_KEYWORD;
 	}
 
 	const rest = normalizeSearchText(`${tool.category} ${tool.description}`);
-	if (rest.includes(q)) return SCORE_CATEGORY_DESCRIPTION;
+	if (rest.includes(term)) return SCORE_CATEGORY_DESCRIPTION;
 
 	return 0;
+}
+
+/**
+ * クエリを空白（半角・全角）区切りで検索語に分割し、それぞれを正規化する。
+ */
+function splitQueryTerms(query: string): string[] {
+	return query
+		.split(/[\s　]+/)
+		.map((term) => normalizeSearchText(term.trim()))
+		.filter((term) => term.length > 0);
+}
+
+/**
+ * ツール1件に対するクエリの関連度スコアを返す（0 = 不一致）。
+ *
+ * クエリが空白区切りの複数語を含む場合は AND セマンティクスで評価する:
+ * すべての検索語がいずれかのフィールド（タイトル / キーワード /
+ * カテゴリ・説明文）にマッチした場合のみスコアを返し、各語の最良マッチの
+ * 重みを合算する。1語でも一致しなければ 0（不一致）。
+ *
+ * 優先順: タイトル前方一致 > タイトル部分一致 > キーワード一致 > カテゴリ・説明文一致
+ */
+export function scoreToolMatch(tool: ToolCatalogItem, query: string): number {
+	const terms = splitQueryTerms(query);
+	if (terms.length === 0) return 0;
+
+	let total = 0;
+	for (const term of terms) {
+		const termScore = scoreSingleTerm(tool, term);
+		if (termScore === 0) return 0; // 1語でも不一致なら全体を不一致とする
+		total += termScore;
+	}
+	return total;
 }
 
 /**

--- a/tests/e2e/search-ranking.spec.ts
+++ b/tests/e2e/search-ranking.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from './fixtures/base';
+
+test.describe('Search result ranking', () => {
+	// 検索モーダルはデスクトップサイズでのみ操作可能なため、モバイルテストはスキップ
+	test.skip(
+		({ isMobile }) => isMobile,
+		'Search modal is only operable on desktop',
+	);
+
+	test('「csv」検索でタイトルにCSVを含むツールが先頭グループに来る', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await searchInput.fill('csv');
+
+		const results = page.getByTestId('search-result');
+		await expect(results.first()).toBeVisible();
+
+		// タイトル前方一致の「CSVビューア/エディタ」が最優先で先頭に来る
+		await expect(results.nth(0)).toContainText('CSVビューア/エディタ');
+		await expect(results.nth(1)).toContainText('CSV文字化け修復');
+
+		// 説明文・キーワードのみ一致の「ダミーデータ生成」はタイトル一致グループより後ろ
+		const titles = await results.locator('span.font-medium').allTextContents();
+		const dummyIndex = titles.indexOf('ダミーデータ生成');
+		const csvEditorIndex = titles.indexOf('CSVビューア/エディタ');
+		expect(dummyIndex).toBeGreaterThan(-1);
+		expect(csvEditorIndex).toBe(0);
+
+		// タイトルにCSVを含むツールはすべてダミーデータ生成より上位
+		for (const [index, title] of titles.entries()) {
+			if (title.toLowerCase().includes('csv')) {
+				expect(index).toBeLessThan(dummyIndex);
+			}
+		}
+	});
+
+	test('ひらがな検索「かうんと」でカタカナタイトルのツールがヒットする', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await searchInput.fill('かうんと');
+
+		const results = page.getByTestId('search-result');
+		await expect(results.first()).toBeVisible();
+		await expect(results.first()).toContainText('文字数カウント');
+	});
+
+	test('一致しないクエリでは結果が空になる', async ({ page }) => {
+		await page.goto('/');
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await searchInput.fill('存在しないツールxyz');
+
+		await expect(
+			page.getByText('一致するツールが見つかりません。'),
+		).toBeVisible();
+	});
+});

--- a/tests/e2e/search-ranking.spec.ts
+++ b/tests/e2e/search-ranking.spec.ts
@@ -54,6 +54,72 @@ test.describe('Search result ranking', () => {
 		await expect(results.first()).toContainText('文字数カウント');
 	});
 
+	test('複数語クエリ「json csv」でJSON↔CSV変換がヒットする（AND一致）', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		// React Island のハイドレーション完了を待ってから検索を開く
+		await expect(page.locator('#search-trigger')).toBeVisible();
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await searchInput.fill('json csv');
+
+		const results = page.getByTestId('search-result');
+		await expect(results.first()).toBeVisible();
+
+		// 語が別々のキーワードに分かれているエントリもマッチする
+		// （タイトルに "json csv" の連結文字列は含まれないが、
+		//  キーワード ['JSON', 'CSV', ...] の両方にマッチするためヒットする）
+		const titles = await results.locator('span.font-medium').allTextContents();
+		expect(titles).toContain('JSON ↔ CSV 変換');
+	});
+
+	test('複数語クエリに無関係な語を足すとヒットしなくなる（AND一致）', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		// React Island のハイドレーション完了を待ってから検索を開く
+		await expect(page.locator('#search-trigger')).toBeVisible();
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+		// 「json csv」単体ではヒットすることを確認
+		await searchInput.fill('json csv');
+		const results = page.getByTestId('search-result');
+		await expect(results.first()).toBeVisible();
+		const hitTitles = await results
+			.locator('span.font-medium')
+			.allTextContents();
+		expect(hitTitles).toContain('JSON ↔ CSV 変換');
+
+		// 無関係な語を足すと、全語AND一致が必要なため結果が空になる
+		await searchInput.fill('json csv 存在しないツールxyz');
+		await expect(
+			page.getByText('一致するツールが見つかりません。'),
+		).toBeVisible();
+	});
+
+	test('全角スペース区切りの複数語クエリでもAND一致する', async ({ page }) => {
+		await page.goto('/');
+		// React Island のハイドレーション完了を待ってから検索を開く
+		await expect(page.locator('#search-trigger')).toBeVisible();
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		// 全角スペース区切り
+		await searchInput.fill('json　csv');
+
+		const results = page.getByTestId('search-result');
+		await expect(results.first()).toBeVisible();
+		const titles = await results.locator('span.font-medium').allTextContents();
+		expect(titles).toContain('JSON ↔ CSV 変換');
+	});
+
 	test('一致しないクエリでは結果が空になる', async ({ page }) => {
 		await page.goto('/');
 		await page.keyboard.press('Control+k');


### PR DESCRIPTION
## 概要

検索モーダルの結果が「カタログ定義順のフィルタ」のみで関連度ランキングがなかった問題を修正します。外部ライブラリ不要の軽量実装です。

Closes #107

## ランキング仕様

`src/lib/tools/search.ts` を新設し、マッチ箇所ごとに重み付けして降順ソートします。

| 優先度 | マッチ箇所 | スコア |
|-|-|-|
| 1 | タイトル前方一致 | 100 |
| 2 | タイトル部分一致 | 80 |
| 3 | キーワード一致 | 60 |
| 4 | カテゴリ・説明文一致 | 40 |

- 同スコアの場合はカタログ定義順を維持（インデックスによる安定ソート）
- ひらがな→カタカナ正規化＋小文字化により「かうんと」→「カウント」のような表記ゆれを吸収
- クエリが空の場合はカタログ全件をそのまま表示（従来どおり）

これにより、例えば「csv」検索時にタイトル一致の「CSVビューア/エディタ」が、説明文のみ一致の「ダミーデータ生成」より上位に表示されます。

## 変更ファイル

- `src/lib/tools/search.ts`（新規）— 正規化・スコアリング・検索の純粋関数
- `src/components/common/SearchModal.tsx` — フィルタ処理を `searchTools()` に置き換え（キーボードハンドラは未変更、#111 と競合しません）
- `tests/e2e/search-ranking.spec.ts`（新規）— ランキング・ひらがな正規化・0件表示のE2Eテスト

## テスト結果

- `npm run lint` — エラーなし（182ファイル）
- `npm run build` — 成功
- `npx playwright test tests/e2e/search-ranking.spec.ts tests/e2e/search-navigation.spec.ts` — **7 passed, 7 skipped (mobile)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)