### PR TITLE
feat: ツールページにパンくずリスト + BreadcrumbList構造化データを追加

### DIFF
--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -1,5 +1,5 @@
 ---
-import { toolCatalog } from '../../lib/tools/catalog';
+import { getCategoryId, toolCatalog } from '../../lib/tools/catalog';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SafetyBadge from '../layout/SafetyBadge.tsx';
 import ToolJsonLd from '../common/ToolJsonLd.astro';
@@ -17,7 +17,8 @@ const SITE_URL = 'https://tools.codelife.cafe';
 // パンくずリスト: カタログから path でカテゴリを解決する
 const tool = toolCatalog.find((t) => t.href === path);
 const category = tool?.category;
-const categoryHref = category ? `/?category=${encodeURIComponent(category)}` : undefined;
+// #108 のカテゴリフィルタと整合させるため、英語のカテゴリID（?category=<id>）でリンクする
+const categoryHref = category ? `/?category=${getCategoryId(category)}` : undefined;
 
 const breadcrumbItems: { name: string; url?: string }[] = [
   { name: 'ホーム', url: `${SITE_URL}/` },

--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { toolCatalog } from '../../lib/tools/catalog';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SafetyBadge from '../layout/SafetyBadge.tsx';
 import ToolJsonLd from '../common/ToolJsonLd.astro';
@@ -10,14 +11,58 @@ interface Props {
 }
 
 const { title, description, path } = Astro.props;
+
+const SITE_URL = 'https://tools.codelife.cafe';
+
+// パンくずリスト: カタログから path でカテゴリを解決する
+const tool = toolCatalog.find((t) => t.href === path);
+const category = tool?.category;
+const categoryHref = category ? `/?category=${encodeURIComponent(category)}` : undefined;
+
+const breadcrumbItems: { name: string; url?: string }[] = [
+  { name: 'ホーム', url: `${SITE_URL}/` },
+  ...(category && categoryHref ? [{ name: category, url: `${SITE_URL}${categoryHref}` }] : []),
+  { name: title },
+];
+
+const breadcrumbSchema = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: breadcrumbItems.map((item, index) => ({
+    '@type': 'ListItem',
+    position: index + 1,
+    name: item.name,
+    ...(item.url ? { item: item.url } : {}),
+  })),
+};
 ---
 
 <BaseLayout title={title} description={description} path={path}>
   <Fragment slot="head">
     <ToolJsonLd name={title} description={description} url={`https://tools.codelife.cafe${path}`} />
+    <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />
   </Fragment>
 
   <div id="tool-layout-container" class="transition-all duration-300 mx-auto max-w-[800px] xl:max-w-5xl px-4 sm:px-6 py-8">
+    <!-- Breadcrumbs -->
+    <nav aria-label="パンくずリスト" class="mb-3">
+      <ol class="flex flex-wrap items-center gap-1.5 text-sm text-muted-foreground">
+        <li>
+          <a href="/" class="hover:text-foreground transition-colors">ホーム</a>
+        </li>
+        {category && categoryHref && (
+          <li class="flex items-center gap-1.5">
+            <span aria-hidden="true">›</span>
+            <a href={categoryHref} class="hover:text-foreground transition-colors">{category}</a>
+          </li>
+        )}
+        <li class="flex items-center gap-1.5">
+          <span aria-hidden="true">›</span>
+          <span aria-current="page" class="text-foreground">{title}</span>
+        </li>
+      </ol>
+    </nav>
+
     <!-- Tool Header -->
     <div class="mb-6">
       <h1 class="text-2xl font-bold mb-2">{title}</h1>

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -1,3 +1,4 @@
+import { getCategoryId, toolCatalog } from '../../src/lib/tools/catalog';
 import { expect, test } from './fixtures/base';
 
 test.describe('Layout & Navigation', () => {
@@ -64,12 +65,12 @@ test.describe('Layout & Navigation', () => {
 		await expect(homeLink).toBeVisible();
 		await expect(homeLink).toHaveAttribute('href', '/');
 
-		// カテゴリリンク（/?category=<カテゴリ名> へのリンク）
+		// カテゴリリンク（/?category=<英語ID> へのリンク。#108 のフィルタ形式と整合）
 		const categoryLink = nav.getByRole('link', { name: 'データ処理' });
 		await expect(categoryLink).toBeVisible();
 		await expect(categoryLink).toHaveAttribute(
 			'href',
-			`/?category=${encodeURIComponent('データ処理')}`,
+			`/?category=${getCategoryId('データ処理')}`,
 		);
 
 		// 現在ページ（リンクなし、aria-current="page"）
@@ -105,7 +106,7 @@ test.describe('Layout & Navigation', () => {
 			'@type': 'ListItem',
 			position: 2,
 			name: 'データ処理',
-			item: `https://tools.codelife.cafe/?category=${encodeURIComponent('データ処理')}`,
+			item: `https://tools.codelife.cafe/?category=${getCategoryId('データ処理')}`,
 		});
 		expect(current).toMatchObject({
 			'@type': 'ListItem',
@@ -113,6 +114,39 @@ test.describe('Layout & Navigation', () => {
 			name: 'CSVビューア/エディタ',
 		});
 		expect(current.item).toBeUndefined();
+	});
+
+	test('パンくずのカテゴリリンクからトップページのフィルタが適用される', async ({
+		page,
+	}) => {
+		// csv-editor は「データ処理」カテゴリ
+		const categoryName = 'データ処理';
+		const categoryId = getCategoryId(categoryName);
+		const categoryCount = toolCatalog.filter(
+			(t) => t.category === categoryName,
+		).length;
+
+		await page.goto('/csv-editor');
+
+		const nav = page.getByRole('navigation', { name: 'パンくずリスト' });
+		await nav.getByRole('link', { name: categoryName }).click();
+
+		// トップページに遷移し、?category=<英語ID> が付与される
+		await expect(page).toHaveURL(new RegExp(`/\\?category=${categoryId}$`));
+
+		// 該当カテゴリのカードのみ表示され、それ以外は非表示になる
+		const visibleCards = page.locator('#tool-grid [data-category]:visible');
+		await expect(visibleCards).toHaveCount(categoryCount);
+		for (const card of await visibleCards.all()) {
+			await expect(card).toHaveAttribute('data-category', categoryId);
+		}
+
+		// 対象カテゴリのフィルタチップがアクティブになる
+		await expect(
+			page
+				.locator('#category-filter')
+				.getByRole('button', { name: categoryName }),
+		).toHaveAttribute('aria-pressed', 'true');
 	});
 
 	test('Footer links are present', async ({ page }) => {

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -53,6 +53,68 @@ test.describe('Layout & Navigation', () => {
 		await expect(searchInput).toBeFocused();
 	});
 
+	test('Breadcrumbs are displayed on tool pages', async ({ page }) => {
+		await page.goto('/csv-editor');
+
+		const nav = page.getByRole('navigation', { name: 'パンくずリスト' });
+		await expect(nav).toBeVisible();
+
+		// ホームリンク
+		const homeLink = nav.getByRole('link', { name: 'ホーム' });
+		await expect(homeLink).toBeVisible();
+		await expect(homeLink).toHaveAttribute('href', '/');
+
+		// カテゴリリンク（/?category=<カテゴリ名> へのリンク）
+		const categoryLink = nav.getByRole('link', { name: 'データ処理' });
+		await expect(categoryLink).toBeVisible();
+		await expect(categoryLink).toHaveAttribute(
+			'href',
+			`/?category=${encodeURIComponent('データ処理')}`,
+		);
+
+		// 現在ページ（リンクなし、aria-current="page"）
+		const current = nav.locator('[aria-current="page"]');
+		await expect(current).toHaveText('CSVビューア/エディタ');
+		await expect(
+			nav.getByRole('link', { name: 'CSVビューア/エディタ' }),
+		).toHaveCount(0);
+	});
+
+	test('BreadcrumbList JSON-LD is present and valid', async ({ page }) => {
+		await page.goto('/csv-editor');
+
+		const jsonLdTexts = await page
+			.locator('script[type="application/ld+json"]')
+			.allTextContents();
+		const breadcrumb = jsonLdTexts
+			.map((text) => JSON.parse(text))
+			.find((schema) => schema['@type'] === 'BreadcrumbList');
+
+		expect(breadcrumb).toBeTruthy();
+		expect(breadcrumb['@context']).toBe('https://schema.org');
+		expect(breadcrumb.itemListElement).toHaveLength(3);
+
+		const [home, category, current] = breadcrumb.itemListElement;
+		expect(home).toMatchObject({
+			'@type': 'ListItem',
+			position: 1,
+			name: 'ホーム',
+			item: 'https://tools.codelife.cafe/',
+		});
+		expect(category).toMatchObject({
+			'@type': 'ListItem',
+			position: 2,
+			name: 'データ処理',
+			item: `https://tools.codelife.cafe/?category=${encodeURIComponent('データ処理')}`,
+		});
+		expect(current).toMatchObject({
+			'@type': 'ListItem',
+			position: 3,
+			name: 'CSVビューア/エディタ',
+		});
+		expect(current.item).toBeUndefined();
+	});
+
 	test('Footer links are present', async ({ page }) => {
 		const footer = page.locator('footer');
 		await expect(footer).toBeVisible();


### PR DESCRIPTION
## 概要

Closes #109

各ツールページのタイトル上部にパンくずリスト（`ホーム > カテゴリ > ツール名`）を追加し、`BreadcrumbList` の JSON-LD 構造化データを自動生成するようにしました。

## 実装内容

- **パンくずリスト表示**（`src/components/common/ToolLayout.astro`）
  - `<nav aria-label="パンくずリスト">` + `<ol>` のセマンティックマークアップ
  - ホームは `/` へ、カテゴリは `/?category=<カテゴリ名>` へリンク（#108 のカテゴリフィルタと連動）
  - 現在ページは `aria-current="page"` のテキスト表示（リンクなし）
  - `text-muted-foreground` ベースの控えめなデザイン（ダークモード対応）
  - カテゴリは `src/lib/tools/catalog.ts` から `path` で解決
- **BreadcrumbList JSON-LD 自動生成**
  - 既存の `ToolJsonLd` と同様に `title`/`path` から生成するため、各ツールページの個別変更は不要
  - 最終要素（現在ページ）は schema.org の推奨どおり `item` を省略

## テスト

- `npm run lint` — エラーなし
- `npm run build` — 33ページ正常ビルド
- `npx playwright test tests/e2e/layout.spec.ts` — **12 passed**（chromium / mobile-chrome）
  - 追加テスト: パンくず表示（ホーム/カテゴリリンクの href・現在ページの非リンク確認）、BreadcrumbList JSON-LD の内容検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)