### PR TITLE
feat: トップページにカテゴリ絞り込み機能を追加

### DIFF
--- a/src/components/common/ToolCard.astro
+++ b/src/components/common/ToolCard.astro
@@ -5,6 +5,7 @@ interface Props {
   href: string;
   icon: string;
   category: string;
+  categoryId?: string;
   categoryColor?: string;
   span?: number;
 }
@@ -15,6 +16,7 @@ const {
   href,
   icon,
   category,
+  categoryId,
   categoryColor = 'border-l-primary',
   span = 1,
 } = Astro.props;
@@ -22,6 +24,7 @@ const {
 
 <a
   href={href}
+  data-category={categoryId}
   class:list={[
     'group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border bg-card p-5 shadow-sm transition-all duration-200 hover:scale-[1.02] hover:shadow-lg hover:border-primary/30',
     categoryColor,
@@ -32,7 +35,14 @@ const {
   <div>
     <div class="mb-3 flex items-center gap-2">
       <span class="text-2xl">{icon}</span>
-      <span class="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full">{category}</span>
+      <span
+        data-category-badge={categoryId}
+        title={categoryId ? `「${category}」で絞り込む` : undefined}
+        class:list={[
+          'text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full',
+          categoryId ? 'cursor-pointer transition-colors hover:bg-primary/10 hover:text-primary' : '',
+        ]}
+      >{category}</span>
     </div>
     <h3 class="text-lg font-semibold mb-1 group-hover:text-primary transition-colors">{title}</h3>
     <p class="text-sm text-muted-foreground leading-relaxed">{description}</p>

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -398,8 +398,29 @@ const categoryChipColor: Record<ToolCategory, string> = {
 	PDF: 'bg-destructive/10 text-destructive',
 };
 
+// カテゴリID（URLクエリ `?category=<id>` で使用。#109 のパンくずリンク先にもなる）
+const categoryIds: Record<ToolCategory, string> = {
+	テキスト変換: 'text-conversion',
+	テキスト解析: 'text-analysis',
+	開発ツール: 'development',
+	生成ツール: 'generator',
+	ユーティリティ: 'utility',
+	'エンコード/デコード': 'encoding',
+	データ処理: 'data-processing',
+	'AI/画像': 'ai-image',
+	PDF: 'pdf',
+};
+
 export const toolCategories = [
 	...new Set(toolCatalog.map((t) => t.category)),
-].map((name) => ({ name, color: categoryChipColor[name] }));
+].map((name) => ({
+	id: categoryIds[name],
+	name,
+	color: categoryChipColor[name],
+}));
+
+export function getCategoryId(category: ToolCategory): string {
+	return categoryIds[category];
+}
 
 export const toolSlugs = toolCatalog.map((tool) => tool.id);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import ToolCard from '../components/common/ToolCard.astro';
 import { ShieldCheck } from 'lucide-react';
-import { toolCatalog, toolCategories } from '../lib/tools/catalog';
+import { getCategoryId, toolCatalog, toolCategories } from '../lib/tools/catalog';
 const schema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
@@ -41,8 +41,35 @@ const schema = {
       </div>
     </div>
 
+    <!-- Category filter chips -->
+    <div
+      id="category-filter"
+      class="mb-8 flex flex-wrap justify-center gap-2"
+      role="group"
+      aria-label="カテゴリで絞り込み"
+    >
+      <button
+        type="button"
+        data-filter-chip=""
+        aria-pressed="true"
+        class="rounded-full border border-border bg-card px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+      >
+        すべて
+      </button>
+      {toolCategories.map((category) => (
+        <button
+          type="button"
+          data-filter-chip={category.id}
+          aria-pressed="false"
+          class="rounded-full border border-border bg-card px-3 py-1.5 text-sm font-medium text-muted-foreground transition-colors hover:bg-muted aria-pressed:border-primary aria-pressed:bg-primary aria-pressed:text-primary-foreground"
+        >
+          {category.name}
+        </button>
+      ))}
+    </div>
+
     <!-- Bento Grid -->
-    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+    <div id="tool-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
       {toolCatalog.map((tool) => (
         <ToolCard
           title={tool.title}
@@ -50,6 +77,7 @@ const schema = {
           href={tool.href}
           icon={tool.icon}
           category={tool.category}
+          categoryId={getCategoryId(tool.category)}
           categoryColor={tool.categoryColor}
           span={tool.span}
         />
@@ -61,9 +89,13 @@ const schema = {
         <p class="text-sm text-muted-foreground mb-3">ツールを公開中</p>
         <div class="flex flex-wrap justify-center gap-1.5">
           {toolCategories.map((category) => (
-            <span class={`text-xs rounded-full px-2 py-0.5 ${category.color}`}>
+            <button
+              type="button"
+              data-category-badge={category.id}
+              class={`text-xs rounded-full px-2 py-0.5 cursor-pointer transition-opacity hover:opacity-75 ${category.color}`}
+            >
               {category.name}
-            </span>
+            </button>
           ))}
         </div>
       </div>
@@ -91,3 +123,74 @@ const schema = {
     </div>
   </section>
 </BaseLayout>
+
+<script>
+  function setupCategoryFilter() {
+    const filterContainer = document.getElementById('category-filter');
+    const toolGrid = document.getElementById('tool-grid');
+    // トップページ以外では何もしない
+    if (!filterContainer || !toolGrid) return;
+    // View Transitions 遷移ごとに DOM が再生成されるため、同一 DOM への二重バインドのみ防ぐ
+    if (filterContainer.dataset.bound === 'true') return;
+    filterContainer.dataset.bound = 'true';
+
+    const chips = Array.from(
+      filterContainer.querySelectorAll<HTMLButtonElement>('[data-filter-chip]'),
+    );
+    const validIds = new Set(
+      chips
+        .map((chip) => chip.getAttribute('data-filter-chip'))
+        .filter((id) => id !== '' && id !== null),
+    );
+
+    /** カテゴリID（空文字 = すべて）でカード表示・チップ状態・URLを更新する */
+    function applyFilter(categoryId: string, updateUrl: boolean) {
+      for (const chip of chips) {
+        const isActive = chip.getAttribute('data-filter-chip') === categoryId;
+        chip.setAttribute('aria-pressed', String(isActive));
+      }
+      const cards = toolGrid?.querySelectorAll<HTMLElement>('[data-category]') ?? [];
+      for (const card of cards) {
+        card.classList.toggle(
+          'hidden',
+          categoryId !== '' && card.dataset.category !== categoryId,
+        );
+      }
+      if (updateUrl) {
+        const url = new URL(window.location.href);
+        if (categoryId === '') {
+          url.searchParams.delete('category');
+        } else {
+          url.searchParams.set('category', categoryId);
+        }
+        history.replaceState(null, '', url);
+      }
+    }
+
+    filterContainer.addEventListener('click', (event) => {
+      const chip = (event.target as Element).closest('[data-filter-chip]');
+      if (!chip) return;
+      applyFilter(chip.getAttribute('data-filter-chip') ?? '', true);
+    });
+
+    // カード内・サマリーカード内のカテゴリバッジクリックでも絞り込む
+    toolGrid.addEventListener('click', (event) => {
+      const badge = (event.target as Element).closest('[data-category-badge]');
+      if (!badge) return;
+      const categoryId = badge.getAttribute('data-category-badge');
+      if (!categoryId || !validIds.has(categoryId)) return;
+      event.preventDefault();
+      applyFilter(categoryId, true);
+    });
+
+    // `?category=<id>` での直アクセス・遷移時に初期フィルタを適用（不正値は「すべて」扱い）
+    const initialId = new URL(window.location.href).searchParams.get('category') ?? '';
+    if (initialId !== '') {
+      applyFilter(validIds.has(initialId) ? initialId : '', false);
+    }
+  }
+
+  // 初回ロード時とView Transitionsによるページ遷移時の両方で実行
+  setupCategoryFilter();
+  document.addEventListener('astro:page-load', setupCategoryFilter);
+</script>

--- a/tests/e2e/category-filter.spec.ts
+++ b/tests/e2e/category-filter.spec.ts
@@ -104,11 +104,9 @@ test.describe('トップページ カテゴリフィルタ', () => {
 		// 別ページへ遷移して戻る
 		await page.getByRole('link', { name: /文字数カウント/ }).click();
 		await expect(page).toHaveURL(/char-count/);
-		await page
-			.getByRole('link', { name: /CODE:LIFE/i })
-			.first()
-			.click();
-		await expect(page).toHaveURL(/\/$/);
+		// ヘッダーロゴ（href="/"）でトップへ戻る
+		await page.locator('header a[href="/"]').click();
+		await expect(page).toHaveURL('/');
 
 		await page
 			.locator('#category-filter')

--- a/tests/e2e/category-filter.spec.ts
+++ b/tests/e2e/category-filter.spec.ts
@@ -1,0 +1,119 @@
+import { toolCatalog, toolCategories } from '../../src/lib/tools/catalog';
+import { expect, test } from './fixtures/base';
+
+const devCategory = toolCategories.find((c) => c.name === '開発ツール');
+if (!devCategory) throw new Error('開発ツール カテゴリが見つかりません');
+
+const totalCount = toolCatalog.length;
+const devCount = toolCatalog.filter((t) => t.category === '開発ツール').length;
+
+const visibleCards = (page: import('@playwright/test').Page) =>
+	page.locator('#tool-grid [data-category]:visible');
+
+test.describe('トップページ カテゴリフィルタ', () => {
+	test('カテゴリチップをクリックすると該当カテゴリのカードのみ表示される', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		// 初期状態: 全カード表示、「すべて」チップがアクティブ
+		await expect(visibleCards(page)).toHaveCount(totalCount);
+		await expect(
+			page.getByRole('button', { name: 'すべて', exact: true }),
+		).toHaveAttribute('aria-pressed', 'true');
+
+		// 「開発ツール」チップをクリック
+		await page
+			.locator('#category-filter')
+			.getByRole('button', { name: '開発ツール' })
+			.click();
+
+		await expect(visibleCards(page)).toHaveCount(devCount);
+		for (const card of await visibleCards(page).all()) {
+			await expect(card).toHaveAttribute('data-category', devCategory.id);
+		}
+
+		// URL が ?category=<id> に更新される
+		await expect(page).toHaveURL(new RegExp(`category=${devCategory.id}`));
+	});
+
+	test('「すべて」チップで全件表示に戻り、URLからパラメータが消える', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		await page
+			.locator('#category-filter')
+			.getByRole('button', { name: '開発ツール' })
+			.click();
+		await expect(visibleCards(page)).toHaveCount(devCount);
+
+		await page.getByRole('button', { name: 'すべて', exact: true }).click();
+
+		await expect(visibleCards(page)).toHaveCount(totalCount);
+		await expect(page).not.toHaveURL(/category=/);
+		await expect(
+			page.getByRole('button', { name: 'すべて', exact: true }),
+		).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('?category=<id> の直アクセスで初期フィルタが適用される', async ({
+		page,
+	}) => {
+		await page.goto(`/?category=${devCategory.id}`);
+
+		await expect(visibleCards(page)).toHaveCount(devCount);
+		await expect(
+			page
+				.locator('#category-filter')
+				.getByRole('button', { name: '開発ツール' }),
+		).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('不正な category パラメータでは全件表示のままになる', async ({
+		page,
+	}) => {
+		await page.goto('/?category=unknown-category');
+
+		await expect(visibleCards(page)).toHaveCount(totalCount);
+		await expect(
+			page.getByRole('button', { name: 'すべて', exact: true }),
+		).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('ツールカードのカテゴリバッジクリックで同カテゴリに絞り込まれる', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		// JSON整形カードのカテゴリバッジ（開発ツール）をクリック
+		await page
+			.locator(`#tool-grid a[href="/json-formatter"] [data-category-badge]`)
+			.click();
+
+		// 遷移せずトップページのままフィルタが適用される
+		await expect(page).toHaveURL(new RegExp(`category=${devCategory.id}`));
+		await expect(visibleCards(page)).toHaveCount(devCount);
+	});
+
+	test('ページ遷移して戻ってもフィルタが動作する（View Transitions対応）', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		// 別ページへ遷移して戻る
+		await page.getByRole('link', { name: /文字数カウント/ }).click();
+		await expect(page).toHaveURL(/char-count/);
+		await page
+			.getByRole('link', { name: /CODE:LIFE/i })
+			.first()
+			.click();
+		await expect(page).toHaveURL(/\/$/);
+
+		await page
+			.locator('#category-filter')
+			.getByRole('button', { name: '開発ツール' })
+			.click();
+		await expect(visibleCards(page)).toHaveCount(devCount);
+	});
+});


### PR DESCRIPTION
## 概要

Closes #108

トップページにカテゴリによるツール絞り込み機能を追加しました。

## UI方式

- **フィルタチップ**: ヒーロー直下に「すべて」+ 全カテゴリ（現在9種）のチップを配置。クリックで該当カテゴリのカードのみ表示し、「すべて」で解除。アクティブ状態は `aria-pressed` + Tailwind の `aria-pressed:` バリアントで表現（ダークモード対応）
- **カードのカテゴリバッジ連動**: 各ツールカード内のカテゴリバッジ、およびサマリーカード（「N ツールを公開中」）内のバッジクリックでも同カテゴリに絞り込み（カードへの遷移は `preventDefault` で抑止）
- **実装方式**: React Island は使わず、`index.astro` 内の小さな client-side script で実装（外部ライブラリ追加なし）。`astro:page-load` イベントで View Transitions 遷移後も再初期化されます

## URL同期仕様（#109 パンくず連携用）

- カテゴリIDは `src/lib/tools/catalog.ts` の `categoryIds`（例: 開発ツール → `development`）で定義し、`toolCategories` の各要素に `id` を追加
- `?category=<id>` 直アクセスで初期フィルタを適用（不正値は「すべて」扱い、URLはそのまま）
- チップ・バッジ選択時は `history.replaceState` で `?category=<id>` を更新、「すべて」選択でパラメータ削除

## 変更ファイル

- `src/lib/tools/catalog.ts` — カテゴリID定義・`getCategoryId()` 追加
- `src/components/common/ToolCard.astro` — `categoryId` prop、`data-category` / `data-category-badge` 属性追加
- `src/pages/index.astro` — フィルタチップUI + フィルタスクリプト
- `tests/e2e/category-filter.spec.ts` — E2Eテスト新規追加（6ケース）

## テスト結果

- `npm run lint` — エラーなし
- `npm run build` — 成功（33ページ）
- `npx playwright test tests/e2e/category-filter.spec.ts tests/e2e/smoke.spec.ts tests/e2e/layout.spec.ts` — **80 passed**（chromium / mobile-chrome）
  - チップでの絞り込み・解除、URL同期、`?category` 直アクセス、不正値フォールバック、バッジクリック連動、View Transitions 遷移後の動作を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)