### PR TITLE
feat: ツールごとのOGP画像をビルド時に静的生成 (#110)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,9 @@
 				"@biomejs/biome": "2.4.16",
 				"@playwright/test": "^1.60.0",
 				"@types/encoding-japanese": "^2.2.1",
-				"@types/papaparse": "^5.5.2"
+				"@types/papaparse": "^5.5.2",
+				"satori": "^0.26.0",
+				"sharp": "^0.35.1"
 			},
 			"engines": {
 				"node": ">=22.22.2"
@@ -826,9 +828,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.8.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
+			"integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
@@ -1317,16 +1319,7 @@
 				"sharp": "^0.34.5"
 			}
 		},
-		"node_modules/@img/colour": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.0.0.tgz",
-			"integrity": "sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@img/sharp-darwin-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-arm64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
 			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
@@ -1348,7 +1341,7 @@
 				"@img/sharp-libvips-darwin-arm64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-darwin-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-darwin-x64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
 			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
@@ -1370,7 +1363,7 @@
 				"@img/sharp-libvips-darwin-x64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-libvips-darwin-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-arm64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
 			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
@@ -1386,7 +1379,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-darwin-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-darwin-x64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
 			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
@@ -1402,7 +1395,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-arm": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
 			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
@@ -1418,7 +1411,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-arm64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
 			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
@@ -1434,7 +1427,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-ppc64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-ppc64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
 			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
@@ -1450,7 +1443,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-riscv64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-riscv64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
 			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
@@ -1466,7 +1459,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-s390x": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-s390x": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
 			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
@@ -1482,7 +1475,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linux-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linux-x64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
 			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
@@ -1498,7 +1491,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
 			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
@@ -1514,7 +1507,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-libvips-linuxmusl-x64": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
 			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
@@ -1530,7 +1523,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-linux-arm": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
 			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
@@ -1552,7 +1545,7 @@
 				"@img/sharp-libvips-linux-arm": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linux-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-arm64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
 			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
@@ -1574,7 +1567,7 @@
 				"@img/sharp-libvips-linux-arm64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linux-ppc64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-ppc64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
 			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
@@ -1596,7 +1589,7 @@
 				"@img/sharp-libvips-linux-ppc64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linux-riscv64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-riscv64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
 			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
@@ -1618,7 +1611,7 @@
 				"@img/sharp-libvips-linux-riscv64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linux-s390x": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-s390x": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
 			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
@@ -1640,7 +1633,7 @@
 				"@img/sharp-libvips-linux-s390x": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linux-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linux-x64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
 			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
@@ -1662,7 +1655,7 @@
 				"@img/sharp-libvips-linux-x64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linuxmusl-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-arm64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
 			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
@@ -1684,7 +1677,7 @@
 				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-linuxmusl-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-linuxmusl-x64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
 			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
@@ -1706,7 +1699,7 @@
 				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
 			}
 		},
-		"node_modules/@img/sharp-wasm32": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-wasm32": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
 			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
@@ -1725,7 +1718,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-win32-arm64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-arm64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
 			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
@@ -1744,7 +1737,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-win32-ia32": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-ia32": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
 			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
@@ -1763,7 +1756,7 @@
 				"url": "https://opencollective.com/libvips"
 			}
 		},
-		"node_modules/@img/sharp-win32-x64": {
+		"node_modules/@huggingface/transformers/node_modules/@img/sharp-win32-x64": {
 			"version": "0.34.5",
 			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
 			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
@@ -1777,6 +1770,576 @@
 			],
 			"engines": {
 				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@huggingface/transformers/node_modules/sharp": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"@img/colour": "^1.0.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.34.5",
+				"@img/sharp-darwin-x64": "0.34.5",
+				"@img/sharp-libvips-darwin-arm64": "1.2.4",
+				"@img/sharp-libvips-darwin-x64": "1.2.4",
+				"@img/sharp-libvips-linux-arm": "1.2.4",
+				"@img/sharp-libvips-linux-arm64": "1.2.4",
+				"@img/sharp-libvips-linux-ppc64": "1.2.4",
+				"@img/sharp-libvips-linux-riscv64": "1.2.4",
+				"@img/sharp-libvips-linux-s390x": "1.2.4",
+				"@img/sharp-libvips-linux-x64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+				"@img/sharp-linux-arm": "0.34.5",
+				"@img/sharp-linux-arm64": "0.34.5",
+				"@img/sharp-linux-ppc64": "0.34.5",
+				"@img/sharp-linux-riscv64": "0.34.5",
+				"@img/sharp-linux-s390x": "0.34.5",
+				"@img/sharp-linux-x64": "0.34.5",
+				"@img/sharp-linuxmusl-arm64": "0.34.5",
+				"@img/sharp-linuxmusl-x64": "0.34.5",
+				"@img/sharp-wasm32": "0.34.5",
+				"@img/sharp-win32-arm64": "0.34.5",
+				"@img/sharp-win32-ia32": "0.34.5",
+				"@img/sharp-win32-x64": "0.34.5"
+			}
+		},
+		"node_modules/@img/colour": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+			"integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.1.tgz",
+			"integrity": "sha512-T15JRWOubQ3f5+GxnWeIvo47u5qV0M9HBgJhT+f2gE1e9e6OhR6K73Re52Hm80qWcu1DNb3GweKmpr/MnuP2Ow==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-darwin-x64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.1.tgz",
+			"integrity": "sha512-t1CPD0cr7XCHjwUj6tQ5MC0pCi866I+gUW6zbUX4aFPnKd1DFBtk0M+gWcjX8VeEzgfCNiSiNTVFZ6b7kvdbnQ==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-freebsd-wasm32": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.1.tgz",
+			"integrity": "sha512-MBSQXqNPThW9EcZ905H6N4sEdX5EwZEYzGx5EBq9ncDCGJALMiY1xPFJxNdzuB1iBjLOpIfxajM6YxdvwmQSLA==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"freebsd"
+			],
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.0.tgz",
+			"integrity": "sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.0.tgz",
+			"integrity": "sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.0.tgz",
+			"integrity": "sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.0.tgz",
+			"integrity": "sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.0.tgz",
+			"integrity": "sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.0.tgz",
+			"integrity": "sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.0.tgz",
+			"integrity": "sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.0.tgz",
+			"integrity": "sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.0.tgz",
+			"integrity": "sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.0.tgz",
+			"integrity": "sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.1.tgz",
+			"integrity": "sha512-jygmR02PpCYypt7xB7nst1vqjZp/BpRA/Kf9nK7qRponJ/KrLPaZWEG4G15z1d2FZ6XqI+T0350ha3RSnKx24A==",
+			"cpu": [
+				"arm"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-arm64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.1.tgz",
+			"integrity": "sha512-ErCRyGU7LeoaFBZ0xW8hhLlXzhAg80sc4vxePB86qvtEvW1jEhhmbiNBP4oEzZfPMnu6HwHXfzD2W2kBU+RnCw==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.1.tgz",
+			"integrity": "sha512-LUWZ2+r2UoLCd8j0RLCwQ4gL6w47+Y7igxtVnPIDXOOEjV86LpBkAHq5VpJeg+GHbw0KN/JWlPJOdZjyZnFqFQ==",
+			"cpu": [
+				"ppc64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.1.tgz",
+			"integrity": "sha512-i7x6J3mwF4JgT0sM4V4WlAWdJ0bucPtA9rzO1bTji1n5qgBq/W5nn87RvOQPleuuxahNoLdTngByD8/vDDLArw==",
+			"cpu": [
+				"riscv64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-s390x": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.1.tgz",
+			"integrity": "sha512-0zSaTUjTF0kIWTSYxD4EG/nvCU4jez53+3RdURtoY3HvbXtIQ98W90JnrGz/oLRFuEnfIy9+7xeq883euc0ZWw==",
+			"cpu": [
+				"s390x"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linux-x64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.1.tgz",
+			"integrity": "sha512-NbJD4mWdeyrNQKluO/tR/wBDOelcowSVGNBWxI0e3ZtlXc6F/UOVKDj1MLD4zl3oHTuvKW3s+MA9N54YTldAYw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.1.tgz",
+			"integrity": "sha512-VoW2sQCWI+0YIKQEmWJ8vzaQjTg9wIyfkFpvEfAS2h43X6iHu7GTk1hhOgB4IpSzCHe8UwQZIcx7b81VTaOrJA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.1.tgz",
+			"integrity": "sha512-LjBoSd/c5JU0/K5MwzDMlgsSRP2bPn98JQGFFQAOLQ0bU/1z4ekxUdSKY9BmlwSh/cA+OrvpgsWqfZyYfVHBRw==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.0"
+			}
+		},
+		"node_modules/@img/sharp-wasm32": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.1.tgz",
+			"integrity": "sha512-PCQUoQdZyE8tp3HpbevuihfUmgSP4qWI0FGEPWoeXqaS+cUrFfemabHQiebUmUmlUhCuNnQMxGrQ+CPqK4hnxg==",
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.11.0"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-webcontainers-wasm32": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.1.tgz",
+			"integrity": "sha512-xU2ml2bU2OPxYVvW2A6ae4M1g5QKyhKG06P4FAt+YEaFQQO0919Qx+XxIZEUuWTMoDViLpMws2/dQwoe/VcA6A==",
+			"cpu": [
+				"wasm32"
+			],
+			"dev": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/sharp-wasm32": "0.35.1"
+			},
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-arm64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.1.tgz",
+			"integrity": "sha512-IkmHwuFhYpd3bTsN5SAahjwhiAcyXPooBt8vEUgxY3T0IP70sSJ0nU1xiPzZY8AH/OB1XpV3j8aZSVSOSfTbdA==",
+			"cpu": [
+				"arm64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-ia32": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.1.tgz",
+			"integrity": "sha512-wQahqCi9MD8Yxzg4gVM4fNrZxh+r6vD55PyIg+WJPaM5ZRUyF35iQpwJCuma3r6viU9/8Pxlc+XHV+woVa6nCQ==",
+			"cpu": [
+				"ia32"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^20.9.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/@img/sharp-win32-x64": {
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.1.tgz",
+			"integrity": "sha512-WzBtkYtZHATLPe8XRharxZXxQ9cdLrQWHiwxt+BJ5rBsisQrKeeV86ErxPSVhcG6xCEuNhs0SqLpWr7XDa2k6w==",
+			"cpu": [
+				"x64"
+			],
+			"dev": true,
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
@@ -4123,6 +4686,23 @@
 			"integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
 			"license": "MIT"
 		},
+		"node_modules/@shuding/opentype.js": {
+			"version": "1.4.0-beta.0",
+			"resolved": "https://registry.npmjs.org/@shuding/opentype.js/-/opentype.js-1.4.0-beta.0.tgz",
+			"integrity": "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"fflate": "^0.7.3",
+				"string.prototype.codepointat": "^0.2.1"
+			},
+			"bin": {
+				"ot": "bin/ot"
+			},
+			"engines": {
+				"node": ">= 8.0.0"
+			}
+		},
 		"node_modules/@tailwindcss/node": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -4938,6 +5518,462 @@
 			"integrity": "sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==",
 			"license": "MIT"
 		},
+		"node_modules/astro/node_modules/@img/sharp-darwin-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+			"integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-arm64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-darwin-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+			"integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-darwin-x64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-darwin-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+			"integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-darwin-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+			"integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-arm": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+			"integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+			"cpu": [
+				"arm"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+			"integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-ppc64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+			"integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-riscv64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+			"integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-s390x": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+			"integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linux-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+			"integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+			"integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-libvips-linuxmusl-x64": {
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+			"integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+			"cpu": [
+				"x64"
+			],
+			"license": "LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-arm": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+			"integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+			"cpu": [
+				"arm"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+			"integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-arm64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-ppc64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+			"integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+			"cpu": [
+				"ppc64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-ppc64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-riscv64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+			"integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+			"cpu": [
+				"riscv64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-riscv64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-s390x": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+			"integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+			"cpu": [
+				"s390x"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-s390x": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linux-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+			"integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linux-x64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linuxmusl-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+			"integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-linuxmusl-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+			"integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0",
+			"optional": true,
+			"os": [
+				"linux"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-wasm32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+			"integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+			"cpu": [
+				"wasm32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+			"optional": true,
+			"dependencies": {
+				"@emnapi/runtime": "^1.7.0"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-win32-arm64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+			"integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+			"cpu": [
+				"arm64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-win32-ia32": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+			"integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+			"cpu": [
+				"ia32"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
+		"node_modules/astro/node_modules/@img/sharp-win32-x64": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+			"integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+			"cpu": [
+				"x64"
+			],
+			"license": "Apache-2.0 AND LGPL-3.0-or-later",
+			"optional": true,
+			"os": [
+				"win32"
+			],
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			}
+		},
 		"node_modules/astro/node_modules/diff": {
 			"version": "8.0.4",
 			"resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
@@ -4945,6 +5981,51 @@
 			"license": "BSD-3-Clause",
 			"engines": {
 				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/astro/node_modules/sharp": {
+			"version": "0.34.5",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+			"hasInstallScript": true,
+			"license": "Apache-2.0",
+			"optional": true,
+			"dependencies": {
+				"@img/colour": "^1.0.0",
+				"detect-libc": "^2.1.2",
+				"semver": "^7.7.3"
+			},
+			"engines": {
+				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/libvips"
+			},
+			"optionalDependencies": {
+				"@img/sharp-darwin-arm64": "0.34.5",
+				"@img/sharp-darwin-x64": "0.34.5",
+				"@img/sharp-libvips-darwin-arm64": "1.2.4",
+				"@img/sharp-libvips-darwin-x64": "1.2.4",
+				"@img/sharp-libvips-linux-arm": "1.2.4",
+				"@img/sharp-libvips-linux-arm64": "1.2.4",
+				"@img/sharp-libvips-linux-ppc64": "1.2.4",
+				"@img/sharp-libvips-linux-riscv64": "1.2.4",
+				"@img/sharp-libvips-linux-s390x": "1.2.4",
+				"@img/sharp-libvips-linux-x64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+				"@img/sharp-linux-arm": "0.34.5",
+				"@img/sharp-linux-arm64": "0.34.5",
+				"@img/sharp-linux-ppc64": "0.34.5",
+				"@img/sharp-linux-riscv64": "0.34.5",
+				"@img/sharp-linux-s390x": "0.34.5",
+				"@img/sharp-linux-x64": "0.34.5",
+				"@img/sharp-linuxmusl-arm64": "0.34.5",
+				"@img/sharp-linuxmusl-x64": "0.34.5",
+				"@img/sharp-wasm32": "0.34.5",
+				"@img/sharp-win32-arm64": "0.34.5",
+				"@img/sharp-win32-ia32": "0.34.5",
+				"@img/sharp-win32-x64": "0.34.5"
 			}
 		},
 		"node_modules/astro/node_modules/yargs-parser": {
@@ -4987,6 +6068,16 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/base64-js": {
+			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.8.tgz",
+			"integrity": "sha512-3XSA2cR/h/73EzlXXdU6YNycmYI7+kicTxks4eJg2g39biHR84slg2+des+p7iHYhbRg/udIS4TD53WabcOUkw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.4"
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
@@ -5045,6 +6136,16 @@
 			},
 			"engines": {
 				"node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+			}
+		},
+		"node_modules/camelize": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
+			"integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/caniuse-lite": {
@@ -5332,6 +6433,40 @@
 				"uncrypto": "^0.1.3"
 			}
 		},
+		"node_modules/css-background-parser": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/css-background-parser/-/css-background-parser-0.1.0.tgz",
+			"integrity": "sha512-2EZLisiZQ+7m4wwur/qiYJRniHX4K5Tc9w93MT3AS0WS1u5kaZ4FKXlOTBhOjc+CgEgPiGY+fX1yWD8UwpEqUA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/css-box-shadow": {
+			"version": "1.0.0-3",
+			"resolved": "https://registry.npmjs.org/css-box-shadow/-/css-box-shadow-1.0.0-3.tgz",
+			"integrity": "sha512-9jaqR6e7Ohds+aWwmhe6wILJ99xYQbfmK9QQB9CcMjDbTxPZjwEmUQpU91OG05Xgm8BahT5fW+svbsQGjS/zPg==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/css-color-keywords": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
+			"integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/css-gradient-parser": {
+			"version": "0.0.17",
+			"resolved": "https://registry.npmjs.org/css-gradient-parser/-/css-gradient-parser-0.0.17.tgz",
+			"integrity": "sha512-w2Xy9UMMwlKtou0vlRnXvWglPAceXCTtcmVSo8ZBUvqCV5aXEFP/PC6d+I464810I9FT++UACwTD5511bmGPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/css-select": {
 			"version": "5.2.2",
 			"resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
@@ -5346,6 +6481,18 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
+			}
+		},
+		"node_modules/css-to-react-native": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
+			"integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"camelize": "^1.0.0",
+				"css-color-keywords": "^1.0.0",
+				"postcss-value-parser": "^4.0.2"
 			}
 		},
 		"node_modules/css-tree": {
@@ -5675,6 +6822,16 @@
 				"@emmetio/css-abbreviation": "^2.1.8"
 			}
 		},
+		"node_modules/emoji-regex-xs": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-2.0.1.tgz",
+			"integrity": "sha512-1QFuh8l7LqUcKe24LsPUNzjrzJQ7pgRwp1QMcZ5MX6mFplk2zQ08NVCM84++1cveaUUYtcCYHmeFEuNg16sU4g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			}
+		},
 		"node_modules/encoding-japanese": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/encoding-japanese/-/encoding-japanese-2.2.0.tgz",
@@ -5789,6 +6946,13 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/escape-html": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/escape-string-regexp": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -5877,6 +7041,13 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/fflate": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/fflate/-/fflate-0.7.4.tgz",
+			"integrity": "sha512-5u2V/CDW15QM1XbbgS+0DfPxVB+jUKhWEKuuFuHncbk3tEEqzmoXL+2KyOFuKGqOnmdIy0/davWF1CkuwtibCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/find-up": {
 			"version": "4.1.0",
@@ -6250,6 +7421,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/hex-rgb": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/hex-rgb/-/hex-rgb-4.3.0.tgz",
+			"integrity": "sha512-Ox1pJVrDCyGHMG9CFg1tmrRUMRPRsAWYc/PinY0XzJU4K7y7vjNoLKIQ7BR5UJMCxNN8EM1MNDmHWA/B3aZUuw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/html-escaper": {
@@ -6684,6 +7868,17 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/linebreak": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
+			"integrity": "sha512-MHp03UImeVhB7XZtjd0E4n6+3xr5Dq/9xI/5FptGk5FrbDR3zagPa2DS6U8ks/3HjbKWG9Q1M2ufOzxV2qLYSQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "0.0.8",
+				"unicode-trie": "^2.0.0"
 			}
 		},
 		"node_modules/locate-path": {
@@ -7920,6 +9115,17 @@
 			"integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
 			"license": "MIT"
 		},
+		"node_modules/parse-css-color": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/parse-css-color/-/parse-css-color-0.2.1.tgz",
+			"integrity": "sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"color-name": "^1.1.4",
+				"hex-rgb": "^4.1.0"
+			}
+		},
 		"node_modules/parse-latin": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/parse-latin/-/parse-latin-7.0.0.tgz",
@@ -8097,6 +9303,13 @@
 			"engines": {
 				"node": "^10 || ^12 || >=14"
 			}
+		},
+		"node_modules/postcss-value-parser": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+			"integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prettier": {
 			"version": "3.8.3",
@@ -8921,6 +10134,29 @@
 				"fsevents": "~2.3.2"
 			}
 		},
+		"node_modules/satori": {
+			"version": "0.26.0",
+			"resolved": "https://registry.npmjs.org/satori/-/satori-0.26.0.tgz",
+			"integrity": "sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==",
+			"dev": true,
+			"license": "MPL-2.0",
+			"dependencies": {
+				"@shuding/opentype.js": "1.4.0-beta.0",
+				"css-background-parser": "^0.1.0",
+				"css-box-shadow": "1.0.0-3",
+				"css-gradient-parser": "^0.0.17",
+				"css-to-react-native": "^3.0.0",
+				"emoji-regex-xs": "^2.0.1",
+				"escape-html": "^1.0.3",
+				"linebreak": "^1.1.0",
+				"parse-css-color": "^0.2.1",
+				"postcss-value-parser": "^4.2.0",
+				"yoga-layout": "^3.2.1"
+			},
+			"engines": {
+				"node": ">=16"
+			}
+		},
 		"node_modules/sax": {
 			"version": "1.6.0",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -8937,9 +10173,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+			"integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
@@ -8976,47 +10212,48 @@
 			"license": "ISC"
 		},
 		"node_modules/sharp": {
-			"version": "0.34.5",
-			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-			"integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-			"hasInstallScript": true,
+			"version": "0.35.1",
+			"resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.1.tgz",
+			"integrity": "sha512-lW979AMi+ESidzMv/Lnv+F9bknzLyxLqFI05Sm433vOeRcltgxQmXpnfOOFIAlKtwXU/ksupm2srQoFCkR214g==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@img/colour": "^1.0.0",
+				"@img/colour": "^1.1.0",
 				"detect-libc": "^2.1.2",
-				"semver": "^7.7.3"
+				"semver": "^7.8.4"
 			},
 			"engines": {
-				"node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+				"node": ">=20.9.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/libvips"
 			},
 			"optionalDependencies": {
-				"@img/sharp-darwin-arm64": "0.34.5",
-				"@img/sharp-darwin-x64": "0.34.5",
-				"@img/sharp-libvips-darwin-arm64": "1.2.4",
-				"@img/sharp-libvips-darwin-x64": "1.2.4",
-				"@img/sharp-libvips-linux-arm": "1.2.4",
-				"@img/sharp-libvips-linux-arm64": "1.2.4",
-				"@img/sharp-libvips-linux-ppc64": "1.2.4",
-				"@img/sharp-libvips-linux-riscv64": "1.2.4",
-				"@img/sharp-libvips-linux-s390x": "1.2.4",
-				"@img/sharp-libvips-linux-x64": "1.2.4",
-				"@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-				"@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-				"@img/sharp-linux-arm": "0.34.5",
-				"@img/sharp-linux-arm64": "0.34.5",
-				"@img/sharp-linux-ppc64": "0.34.5",
-				"@img/sharp-linux-riscv64": "0.34.5",
-				"@img/sharp-linux-s390x": "0.34.5",
-				"@img/sharp-linux-x64": "0.34.5",
-				"@img/sharp-linuxmusl-arm64": "0.34.5",
-				"@img/sharp-linuxmusl-x64": "0.34.5",
-				"@img/sharp-wasm32": "0.34.5",
-				"@img/sharp-win32-arm64": "0.34.5",
-				"@img/sharp-win32-ia32": "0.34.5",
-				"@img/sharp-win32-x64": "0.34.5"
+				"@img/sharp-darwin-arm64": "0.35.1",
+				"@img/sharp-darwin-x64": "0.35.1",
+				"@img/sharp-freebsd-wasm32": "0.35.1",
+				"@img/sharp-libvips-darwin-arm64": "1.3.0",
+				"@img/sharp-libvips-darwin-x64": "1.3.0",
+				"@img/sharp-libvips-linux-arm": "1.3.0",
+				"@img/sharp-libvips-linux-arm64": "1.3.0",
+				"@img/sharp-libvips-linux-ppc64": "1.3.0",
+				"@img/sharp-libvips-linux-riscv64": "1.3.0",
+				"@img/sharp-libvips-linux-s390x": "1.3.0",
+				"@img/sharp-libvips-linux-x64": "1.3.0",
+				"@img/sharp-libvips-linuxmusl-arm64": "1.3.0",
+				"@img/sharp-libvips-linuxmusl-x64": "1.3.0",
+				"@img/sharp-linux-arm": "0.35.1",
+				"@img/sharp-linux-arm64": "0.35.1",
+				"@img/sharp-linux-ppc64": "0.35.1",
+				"@img/sharp-linux-riscv64": "0.35.1",
+				"@img/sharp-linux-s390x": "0.35.1",
+				"@img/sharp-linux-x64": "0.35.1",
+				"@img/sharp-linuxmusl-arm64": "0.35.1",
+				"@img/sharp-linuxmusl-x64": "0.35.1",
+				"@img/sharp-webcontainers-wasm32": "0.35.1",
+				"@img/sharp-win32-arm64": "0.35.1",
+				"@img/sharp-win32-ia32": "0.35.1",
+				"@img/sharp-win32-x64": "0.35.1"
 			}
 		},
 		"node_modules/shiki": {
@@ -9132,6 +10369,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
 			"integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
+			"license": "MIT"
+		},
+		"node_modules/string.prototype.codepointat": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.codepointat/-/string.prototype.codepointat-0.2.1.tgz",
+			"integrity": "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/stringify-entities": {
@@ -9341,6 +10585,24 @@
 			"version": "7.18.2",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
 			"integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+			"license": "MIT"
+		},
+		"node_modules/unicode-trie": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/unicode-trie/-/unicode-trie-2.0.0.tgz",
+			"integrity": "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"pako": "^0.2.5",
+				"tiny-inflate": "^1.0.0"
+			}
+		},
+		"node_modules/unicode-trie/node_modules/pako": {
+			"version": "0.2.9",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+			"integrity": "sha512-NUcwaKxUxWrZLpDG+z/xZaCgQITkA/Dv4V/T6bw7VON6l1Xz/VnrBqrYjZQ12TamKHzITTfOEIYUj48y2KXImA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unified": {
@@ -10235,6 +11497,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
+		},
+		"node_modules/yoga-layout": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/yoga-layout/-/yoga-layout-3.2.1.tgz",
+			"integrity": "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/zod": {
 			"version": "4.3.6",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	},
 	"scripts": {
 		"dev": "astro dev",
-		"build": "astro build && node scripts/generate-sw.mjs",
+		"build": "astro build && node scripts/generate-og-images.mjs && node scripts/generate-sw.mjs",
 		"test": "playwright test",
 		"test:unit": "node --test \"tests/unit/*.test.ts\"",
 		"preview": "astro preview --host",
@@ -61,7 +61,9 @@
 		"@biomejs/biome": "2.4.16",
 		"@playwright/test": "^1.60.0",
 		"@types/encoding-japanese": "^2.2.1",
-		"@types/papaparse": "^5.5.2"
+		"@types/papaparse": "^5.5.2",
+		"satori": "^0.26.0",
+		"sharp": "^0.35.1"
 	},
 	"overrides": {
 		"esbuild": "^0.28.1",

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -1,0 +1,271 @@
+// ビルド後（astro build の後、generate-sw.mjs の前）に実行し、
+// ツールごとの OGP 画像（1200x630 PNG）を dist/og/ に静的生成する。
+//
+// - ツール一覧は src/lib/tools/catalog.ts から取得（Node の型ストリッピングで直接 import）
+// - 日本語フォント（Noto Sans JP）は Google Fonts からビルド時にダウンロードし、
+//   scripts/.cache/fonts/ にキャッシュする（.gitignore 済み）
+// - 生成画像はコミットせず、デプロイ成果物（dist/）にのみ含まれる
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import satori from 'satori';
+import sharp from 'sharp';
+import { toolCatalog } from '../src/lib/tools/catalog.ts';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const FONT_CACHE_DIR = join(ROOT, 'scripts', '.cache', 'fonts');
+const OUT_DIR = join(ROOT, 'dist', 'og');
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+// サイトのデザイントークン（src/styles/global.css のダークモード配色に準拠）
+const COLORS = {
+	background: '#0C0A09',
+	backgroundEnd: '#1C1917',
+	foreground: '#FAFAF9',
+	muted: '#A8A29E',
+	accent: '#2DD4BF',
+	primary: '#1E40AF',
+	safety: '#34D399',
+	border: '#292524',
+};
+
+// 旧ブラウザの UA を指定すると unicode-range 分割のないフル TTF の URL が返る
+const LEGACY_UA =
+	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30';
+const FONT_CSS_URL =
+	'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap';
+
+/**
+ * Noto Sans JP の TTF を取得する（キャッシュ優先、なければ Google Fonts からダウンロード）
+ * @returns {Promise<{regular: Buffer, bold: Buffer}>}
+ */
+async function loadFonts() {
+	await mkdir(FONT_CACHE_DIR, { recursive: true });
+	const cachePaths = {
+		regular: join(FONT_CACHE_DIR, 'noto-sans-jp-400.ttf'),
+		bold: join(FONT_CACHE_DIR, 'noto-sans-jp-700.ttf'),
+	};
+
+	try {
+		const [regular, bold] = await Promise.all([
+			readFile(cachePaths.regular),
+			readFile(cachePaths.bold),
+		]);
+		console.log('[generate-og] フォント: キャッシュを使用');
+		return { regular, bold };
+	} catch {
+		// キャッシュなし → ダウンロードへ
+	}
+
+	console.log('[generate-og] フォント: Google Fonts からダウンロード中...');
+	const cssRes = await fetch(FONT_CSS_URL, {
+		headers: { 'User-Agent': LEGACY_UA },
+	});
+	if (!cssRes.ok) {
+		throw new Error(`[generate-og] フォントCSSの取得に失敗: HTTP ${cssRes.status}`);
+	}
+	const css = await cssRes.text();
+
+	// @font-face ブロックから weight ごとの TTF URL を抽出
+	const urls = {};
+	for (const block of css.match(/@font-face\s*\{[^}]*\}/g) ?? []) {
+		const weight = block.match(/font-weight:\s*(\d+)/)?.[1];
+		const url = block.match(/src:\s*url\((https:[^)]+)\)/)?.[1];
+		if (weight && url) urls[weight] = url;
+	}
+	if (!urls['400'] || !urls['700']) {
+		throw new Error(
+			'[generate-og] フォントURLの抽出に失敗（Google Fonts のレスポンス形式が変わった可能性）',
+		);
+	}
+
+	const download = async (url) => {
+		const res = await fetch(url);
+		if (!res.ok) {
+			throw new Error(`[generate-og] フォントのダウンロードに失敗: HTTP ${res.status} ${url}`);
+		}
+		return Buffer.from(await res.arrayBuffer());
+	};
+	const [regular, bold] = await Promise.all([
+		download(urls['400']),
+		download(urls['700']),
+	]);
+
+	await Promise.all([
+		writeFile(cachePaths.regular, regular),
+		writeFile(cachePaths.bold, bold),
+	]);
+	return { regular, bold };
+}
+
+// satori 用の要素ツリーを生成するヘルパー（JSX なしで構築）
+function h(type, props, ...children) {
+	return {
+		type,
+		props: { ...props, children: children.length === 1 ? children[0] : children },
+	};
+}
+
+/** タイトル文字数に応じてフォントサイズを調整（はみ出し防止） */
+function titleFontSize(title) {
+	if (title.length <= 10) return 80;
+	if (title.length <= 14) return 68;
+	return 56;
+}
+
+/** ツール1件分の OG 画像レイアウト */
+function toolTemplate(tool) {
+	return h(
+		'div',
+		{
+			style: {
+				width: '100%',
+				height: '100%',
+				display: 'flex',
+				flexDirection: 'column',
+				backgroundImage: `linear-gradient(135deg, ${COLORS.background} 0%, ${COLORS.backgroundEnd} 100%)`,
+				padding: '56px 72px 0',
+				fontFamily: 'Noto Sans JP',
+			},
+		},
+		// ヘッダー: サイト名
+		h(
+			'div',
+			{ style: { display: 'flex', alignItems: 'center', gap: '16px' } },
+			h('div', {
+				style: {
+					display: 'flex',
+					width: '20px',
+					height: '20px',
+					borderRadius: '6px',
+					backgroundImage: `linear-gradient(135deg, ${COLORS.accent} 0%, ${COLORS.primary} 100%)`,
+				},
+			}),
+			h(
+				'div',
+				{
+					style: {
+						display: 'flex',
+						fontSize: '34px',
+						fontWeight: 700,
+						color: COLORS.foreground,
+					},
+				},
+				h('span', { style: { color: COLORS.accent } }, 'CODE:LIFE'),
+				h('span', { style: { marginLeft: '12px' } }, 'Tools'),
+			),
+		),
+		// 中央: カテゴリ + ツール名 + 説明
+		h(
+			'div',
+			{
+				style: {
+					display: 'flex',
+					flexDirection: 'column',
+					flexGrow: 1,
+					justifyContent: 'center',
+				},
+			},
+			h(
+				'div',
+				{
+					style: {
+						display: 'flex',
+						alignSelf: 'flex-start',
+						fontSize: '24px',
+						color: COLORS.accent,
+						border: `2px solid ${COLORS.border}`,
+						borderRadius: '9999px',
+						padding: '6px 24px',
+						marginBottom: '28px',
+					},
+				},
+				tool.category,
+			),
+			h(
+				'div',
+				{
+					style: {
+						display: 'flex',
+						fontSize: `${titleFontSize(tool.title)}px`,
+						fontWeight: 700,
+						color: COLORS.foreground,
+						lineHeight: 1.25,
+						marginBottom: '24px',
+					},
+				},
+				tool.title,
+			),
+			h(
+				'div',
+				{
+					style: {
+						display: 'flex',
+						fontSize: '30px',
+						color: COLORS.muted,
+						lineHeight: 1.6,
+					},
+				},
+				tool.description,
+			),
+		),
+		// フッター: URL + 安全性の訴求
+		h(
+			'div',
+			{
+				style: {
+					display: 'flex',
+					alignItems: 'center',
+					justifyContent: 'space-between',
+					paddingBottom: '40px',
+				},
+			},
+			h(
+				'div',
+				{ style: { display: 'flex', fontSize: '26px', color: COLORS.muted } },
+				'tools.codelife.cafe',
+			),
+			h(
+				'div',
+				{ style: { display: 'flex', fontSize: '24px', color: COLORS.safety } },
+				'✓ データは外部送信されません',
+			),
+		),
+		// 最下部: ブランドカラーのグラデーションバー
+		h('div', {
+			style: {
+				display: 'flex',
+				height: '14px',
+				margin: '0 -72px',
+				backgroundImage: `linear-gradient(90deg, ${COLORS.primary} 0%, ${COLORS.accent} 100%)`,
+			},
+		}),
+	);
+}
+
+const { regular, bold } = await loadFonts();
+const fonts = [
+	{ name: 'Noto Sans JP', data: regular, weight: 400, style: 'normal' },
+	{ name: 'Noto Sans JP', data: bold, weight: 700, style: 'normal' },
+];
+
+await mkdir(OUT_DIR, { recursive: true });
+
+const started = Date.now();
+for (const tool of toolCatalog) {
+	const svg = await satori(toolTemplate(tool), {
+		width: WIDTH,
+		height: HEIGHT,
+		fonts,
+	});
+	await sharp(Buffer.from(svg))
+		.png({ compressionLevel: 9 })
+		.toFile(join(OUT_DIR, `${tool.id}.png`));
+}
+
+console.log(
+	`[generate-og] ${toolCatalog.length} 枚の OG 画像を dist/og/ に生成（${((Date.now() - started) / 1000).toFixed(1)}s）`,
+);

--- a/scripts/generate-sw.mjs
+++ b/scripts/generate-sw.mjs
@@ -7,14 +7,19 @@ import { join } from 'path';
 const DIST = './dist';
 
 // dist/ 直下のディレクトリ（各ルートページ）を収集
-// `data` は静的データ配信用（/data/zipcode/*.json 等）でページではないため除外。
+// `data` は静的データ配信用（/data/zipcode/*.json 等）、`og` は OGP 画像
+// （generate-og-images.mjs が生成）でページではないため除外。
 // これらはプリキャッシュせず、Service Worker のランタイム cache-first で扱う。
 const entries = await readdir(DIST, { withFileTypes: true });
 const pageURLs = [
 	'/',
 	...entries
 		.filter(
-			(d) => d.isDirectory() && !d.name.startsWith('_') && d.name !== 'data',
+			(d) =>
+				d.isDirectory() &&
+				!d.name.startsWith('_') &&
+				d.name !== 'data' &&
+				d.name !== 'og',
 		)
 		.map((d) => `/${d.name}/`),
 ];

--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -20,6 +20,9 @@ const category = tool?.category;
 // #108 のカテゴリフィルタと整合させるため、英語のカテゴリID（?category=<id>）でリンクする
 const categoryHref = category ? `/?category=${getCategoryId(category)}` : undefined;
 
+// カタログ掲載ツールはビルド時生成のツール別 OG 画像（/og/{id}.png）を使う
+const ogImage = tool ? `/og/${tool.id}.png` : undefined;
+
 const breadcrumbItems: { name: string; url?: string }[] = [
   { name: 'ホーム', url: `${SITE_URL}/` },
   ...(category && categoryHref ? [{ name: category, url: `${SITE_URL}${categoryHref}` }] : []),
@@ -38,7 +41,7 @@ const breadcrumbSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} path={path}>
+<BaseLayout title={title} description={description} path={path} ogImage={ogImage}>
   <Fragment slot="head">
     <ToolJsonLd name={title} description={description} url={`https://tools.codelife.cafe${path}`} />
     <script type="application/ld+json" set:html={JSON.stringify(breadcrumbSchema)} />

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -8,9 +8,11 @@ interface Props {
   title: string;
   description: string;
   path: string;
+  /** og:image のパス（省略時はサイト共通画像） */
+  ogImage?: string;
 }
 
-const { title, description, path } = Astro.props;
+const { title, description, path, ogImage = '/og-image.png' } = Astro.props;
 const siteName = "CODE:LIFE Tools";
 const siteUrl = "https://tools.codelife.cafe";
 const fullTitle = `${title} | ${siteName}`;
@@ -27,7 +29,7 @@ const fullTitle = `${title} | ${siteName}`;
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
   <meta property="og:url" content={`${siteUrl}${path}`} />
-  <meta property="og:image" content={`${siteUrl}/og-image.png`} />
+  <meta property="og:image" content={`${siteUrl}${ogImage}`} />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:site_name" content={siteName} />
   <meta name="twitter:card" content="summary_large_image" />

--- a/tests/e2e/og-image.spec.ts
+++ b/tests/e2e/og-image.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from './fixtures/base';
+
+test.describe('OGP画像', () => {
+	test('ツールページの og:image がツール別画像を指し、画像が配信される', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-formatter');
+		await toolPage.goto();
+
+		await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+			'content',
+			'https://tools.codelife.cafe/og/json-formatter.png',
+		);
+
+		// 画像が実際に 200 / PNG で取得できること
+		const res = await page.request.get('/og/json-formatter.png');
+		expect(res.status()).toBe(200);
+		expect(res.headers()['content-type']).toContain('image/png');
+	});
+
+	test('トップページの og:image はサイト共通画像のまま', async ({ page }) => {
+		await page.goto('/');
+		await expect(page.locator('meta[property="og:image"]')).toHaveAttribute(
+			'content',
+			'https://tools.codelife.cafe/og-image.png',
+		);
+	});
+});


### PR DESCRIPTION
## 概要

各ツールページの OGP 画像（1200x630 PNG）を **ビルド時に静的生成** します。SNS シェア時にツールごとに適切なカードが表示されるようになります。ランタイムコストはゼロ（Cloudflare Workers/Functions は不使用、`dist/og/*.png` を静的配信するだけ）。

Closes #110

## 生成方式

- ライブラリ: **satori**（要素ツリー → SVG）+ **sharp**（SVG → PNG）。いずれも `devDependencies` に追加
- スクリプト: `scripts/generate-og-images.mjs`
  - ツール一覧は `src/lib/tools/catalog.ts` を直接 import（Node 22 の型ストリッピング）
  - 全 29 ツール分の `dist/og/{id}.png` を生成
  - レイアウト: サイト名「CODE:LIFE Tools」+ カテゴリ + ツール名（大）+ 説明文 + ブランドカラーのグラデーションバー
- フォント: **Noto Sans JP（400 / 700）** を Google Fonts からビルド時に取得し `scripts/.cache/`（gitignore 済み）にキャッシュ。フォントファイルはリポジトリに同梱しません

## パイプライン組み込み

```
astro build && node scripts/generate-og-images.mjs && node scripts/generate-sw.mjs
```

- OG 生成を `generate-sw.mjs` の **前段** に配置
- `generate-sw.mjs` は `dist/og/` を SW プリキャッシュ対象から **除外**（`data` と同様）。OG 画像29枚がプリキャッシュに混入してバンドルが肥大化するのを防止

## og:image の切り替え

- `BaseLayout.astro` に `ogImage` prop を追加（省略時はサイト共通 `/og-image.png`）
- `ToolLayout.astro` はカタログ掲載ツールのみ `og:image` を `/og/{id}.png` に切替
- トップページ・プライバシー等の非ツールページは従来どおり `/og-image.png`

> #114 のパンくず・BreadcrumbList 実装と競合したため、最新 main を取り込んだ上で、既存の `toolCatalog.find(t => t.href === path)` のツール解決ロジックを再利用する形で OG 画像パスを導出するようにマージしました（`toolSlugs` の重複 import は削除）。

## ビルド時間への影響

- OG 画像29枚の生成: **約1.2秒**（フォントキャッシュ利用時）。初回のみフォントダウンロードで数秒追加
- 既存の Astro ビルド（約11秒）への影響は軽微

## テスト結果

- `tests/e2e/og-image.spec.ts` を追加（ツールページの `og:image` がツール別パスを指し 200 / `image/png` で取得できること、トップは共通画像のままであること）
- `npm run lint`: パス
- `npm run build`: 成功（OG 29枚生成 → SW 生成）
- E2E（og-image + layout 回帰）: **18件すべてパス**。#114 のパンくず・BreadcrumbList テストの回帰なし
- 生成画像を目視確認: 日本語フォント・`↔` 記号・レイアウトとも崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
