### PR TITLE
fix: ファビコンツールのアプリ名入力が1文字ごとに中断する不具合を修正

### DIFF
--- a/src/components/favicon/FaviconGeneratorPage.tsx
+++ b/src/components/favicon/FaviconGeneratorPage.tsx
@@ -207,11 +207,7 @@ export function FaviconGeneratorPage() {
 
 			{source && (
 				<>
-					<FaviconOptionsPanel
-						options={options}
-						disabled={generating}
-						onChange={setOptions}
-					/>
+					<FaviconOptionsPanel options={options} onChange={setOptions} />
 
 					<FaviconPreview
 						urls={previewUrls}

--- a/src/components/favicon/FaviconOptionsPanel.tsx
+++ b/src/components/favicon/FaviconOptionsPanel.tsx
@@ -32,11 +32,10 @@ export const DEFAULT_FAVICON_OPTIONS: FaviconUiOptions = {
 
 type Props = {
 	options: FaviconUiOptions;
-	disabled?: boolean;
 	onChange: (next: FaviconUiOptions) => void;
 };
 
-export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
+export function FaviconOptionsPanel({ options, onChange }: Props) {
 	const update = (patch: Partial<FaviconUiOptions>) =>
 		onChange({ ...options, ...patch });
 
@@ -50,12 +49,8 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 					onValueChange={(value) => update({ fit: value as FitMode })}
 				>
 					<TabsList>
-						<TabsTrigger value="contain" disabled={disabled}>
-							余白をつける
-						</TabsTrigger>
-						<TabsTrigger value="cover" disabled={disabled}>
-							中央をクロップ
-						</TabsTrigger>
+						<TabsTrigger value="contain">余白をつける</TabsTrigger>
+						<TabsTrigger value="cover">中央をクロップ</TabsTrigger>
 					</TabsList>
 				</Tabs>
 				<p className="text-xs text-muted-foreground">
@@ -70,7 +65,6 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 					<Switch
 						id="favicon-transparent"
 						checked={options.transparent}
-						disabled={disabled}
 						onCheckedChange={(checked) => update({ transparent: checked })}
 						aria-label="アイコン背景を透過にする"
 					/>
@@ -79,7 +73,6 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 					<ColorField
 						label="アイコン背景色"
 						value={options.background}
-						disabled={disabled}
 						onChange={(background) => update({ background })}
 					/>
 				)}
@@ -94,7 +87,6 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 				<Input
 					id="favicon-appname"
 					value={options.appName}
-					disabled={disabled}
 					maxLength={60}
 					onChange={(e) => update({ appName: e.target.value })}
 					placeholder="My App"
@@ -106,13 +98,11 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 				<ColorField
 					label="テーマカラー（theme_color）"
 					value={options.themeColor}
-					disabled={disabled}
 					onChange={(themeColor) => update({ themeColor })}
 				/>
 				<ColorField
 					label="背景色（background_color）"
 					value={options.backgroundColor}
-					disabled={disabled}
 					onChange={(backgroundColor) => update({ backgroundColor })}
 				/>
 			</div>
@@ -123,12 +113,10 @@ export function FaviconOptionsPanel({ options, disabled, onChange }: Props) {
 function ColorField({
 	label,
 	value,
-	disabled,
 	onChange,
 }: {
 	label: string;
 	value: string;
-	disabled?: boolean;
 	onChange: (value: string) => void;
 }) {
 	const inputId = useId();
@@ -143,7 +131,6 @@ function ColorField({
 				<input
 					type="color"
 					value={pickerValue}
-					disabled={disabled}
 					onChange={handleText}
 					className="h-9 w-12 shrink-0 cursor-pointer rounded-md border border-input bg-transparent p-1"
 					aria-label={label}
@@ -151,7 +138,6 @@ function ColorField({
 				<Input
 					id={inputId}
 					value={value}
-					disabled={disabled}
 					onChange={handleText}
 					className="font-mono"
 					placeholder="#1e40af"

--- a/tests/e2e/favicon.spec.ts
+++ b/tests/e2e/favicon.spec.ts
@@ -94,6 +94,19 @@ test.describe('ファビコン生成', () => {
 		await expect(homeIcon).toHaveAttribute('src', /^blob:/);
 	});
 
+	test('アプリ名を連続入力してもフォーカスが外れない', async ({ page }) => {
+		await uploadAndWait(page, PNG_512);
+
+		const appName = page.getByLabel('アプリ名（site.webmanifest）');
+		await appName.click();
+		// 既定値 "My App" に続けて連続入力する。生成のたびに input が
+		// disabled 化されると blur され、以降の文字が落ちる／フォーカスを失う。
+		await appName.pressSequentially(' Pro', { delay: 20 });
+
+		await expect(appName).toBeFocused();
+		await expect(appName).toHaveValue('My App Pro');
+	});
+
 	test('HTMLスニペットが表示されコピーできる', async ({ page }) => {
 		await uploadAndWait(page, PNG_512);
 


### PR DESCRIPTION
## 概要
ファビコン生成ツールでアプリ名（や色のHEX値）を入力する際、1文字打つたびに入力欄が無効化されてフォーカスが外れ、スムーズに入力できない不具合を修正します。

## 原因
`FaviconGeneratorPage` の `useEffect` で `options` 変更のたびに **`setGenerating(true)` が即座に（150msデバウンスの外で）** 実行され、その `generating` が `<FaviconOptionsPanel disabled={generating}>` 経由でアプリ名 `<Input>` に渡っていました。

input が `disabled` 化されるとブラウザがフォーカスを外す（blur）ため、1文字ごとに入力が中断していました。色のHEX入力欄も同じ問題を抱えていました。

## 修正
ライブプレビュー生成は既にデバウンス（150ms）と `runIdRef` の競合ガードで保護されており、入力欄を `disabled` にする必要はありません。busy状態は「生成中…」スピナーとダウンロードボタン自身の `disabled` で十分伝わるため、`FaviconOptionsPanel` から `disabled` の配線を全面的に削除しました。

- `FaviconGeneratorPage.tsx` — `disabled={generating}` を撤去
- `FaviconOptionsPanel.tsx` — `disabled` プロップと全使用箇所を削除

## 検証
- 新規E2Eテスト「アプリ名を連続入力してもフォーカスが外れない」を追加（修正前は失敗 → 修正後は成功を確認）
- favicon E2E **18件すべてパス**
- Biome lint クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)