### PR TITLE
fix: 画像形式変換ツールの完了メッセージ残存とファイル名表示を修正

### DIFF
--- a/src/components/image-convert/ConvertResultList.tsx
+++ b/src/components/image-convert/ConvertResultList.tsx
@@ -62,100 +62,107 @@ export function ConvertResultList({
 
 	return (
 		<div className="space-y-2" data-testid="convert-result-list">
-			{items.map((item) => (
-				<div
-					key={item.id}
-					className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-center"
-				>
-					{/* サムネイル（HEIC等は表示できないためフォールバック） */}
-					<div className="flex w-fit shrink-0 items-center gap-2 rounded-lg border border-border bg-muted/20 p-2">
-						<div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded border border-border bg-[repeating-conic-gradient(#0001_0_25%,transparent_0_50%)] bg-[length:10px_10px]">
-							{item.status === 'done' && item.resultUrl ? (
-								<img
-									src={item.resultUrl}
-									alt={`${item.file.name}の変換後プレビュー`}
-									className="h-14 w-14 object-cover"
-								/>
-							) : item.status === 'error' ? (
-								<AlertTriangle className="h-4 w-4 text-destructive" />
-							) : (
-								<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
-							)}
+			{items.map((item) => {
+				// 変換完了後は出力後のファイル名（拡張子置換済み）を表示する
+				const displayName =
+					item.status === 'done' && item.result
+						? item.result.fileName
+						: item.file.name;
+				return (
+					<div
+						key={item.id}
+						className="flex flex-col gap-3 rounded-lg border border-border p-3 sm:flex-row sm:items-center"
+					>
+						{/* サムネイル（HEIC等は表示できないためフォールバック） */}
+						<div className="flex w-fit shrink-0 items-center gap-2 rounded-lg border border-border bg-muted/20 p-2">
+							<div className="flex h-14 w-14 items-center justify-center overflow-hidden rounded border border-border bg-[repeating-conic-gradient(#0001_0_25%,transparent_0_50%)] bg-[length:10px_10px]">
+								{item.status === 'done' && item.resultUrl ? (
+									<img
+										src={item.resultUrl}
+										alt={`${item.file.name}の変換後プレビュー`}
+										className="h-14 w-14 object-cover"
+									/>
+								) : item.status === 'error' ? (
+									<AlertTriangle className="h-4 w-4 text-destructive" />
+								) : (
+									<Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+								)}
+							</div>
 						</div>
-					</div>
 
-					{/* 情報 */}
-					<div className="min-w-0 flex-1">
-						<p className="truncate text-sm font-medium" title={item.file.name}>
-							{item.file.name}
-						</p>
+						{/* 情報 */}
+						<div className="min-w-0 flex-1">
+							<p className="truncate text-sm font-medium" title={displayName}>
+								{displayName}
+							</p>
 
-						<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-							<Badge variant="outline">
-								{SOURCE_LABELS[item.sourceFormat]}
-							</Badge>
-							<MoveRight className="h-3.5 w-3.5" />
-							<Badge className="bg-primary/15 text-primary border-primary/30">
-								{TARGET_LABELS[target]}
-							</Badge>
-							{item.status === 'done' && item.result && (
-								<>
-									<span>{formatBytes(item.file.size)}</span>
-									<span>→</span>
-									<span className="font-medium text-foreground">
-										{formatBytes(item.result.blob.size)}
-									</span>
-								</>
+							<div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+								<Badge variant="outline">
+									{SOURCE_LABELS[item.sourceFormat]}
+								</Badge>
+								<MoveRight className="h-3.5 w-3.5" />
+								<Badge className="bg-primary/15 text-primary border-primary/30">
+									{TARGET_LABELS[target]}
+								</Badge>
+								{item.status === 'done' && item.result && (
+									<>
+										<span>{formatBytes(item.file.size)}</span>
+										<span>→</span>
+										<span className="font-medium text-foreground">
+											{formatBytes(item.result.blob.size)}
+										</span>
+									</>
+								)}
+							</div>
+
+							{item.status === 'pending' && (
+								<p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+									<Loader2 className="h-3.5 w-3.5 animate-spin" />
+									変換中…
+								</p>
 							)}
+
+							{item.status === 'error' && (
+								<p className="mt-1 flex items-center gap-1.5 text-xs text-destructive">
+									<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+									{item.error ?? '変換に失敗しました。'}
+								</p>
+							)}
+
+							{item.status === 'done' &&
+								item.result &&
+								item.result.warnings.map((w) => (
+									<p
+										key={w}
+										className="mt-1 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500"
+									>
+										<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+										{w}
+									</p>
+								))}
 						</div>
+
+						{/* アクション */}
+						{item.status === 'done' && item.result && (
+							<div className="flex shrink-0 flex-col gap-1.5">
+								<Button
+									size="sm"
+									variant="outline"
+									onClick={() => onDownload(item)}
+									aria-label="ダウンロード"
+								>
+									<Download className="h-4 w-4" />
+									<span className="ml-1 hidden sm:inline">ダウンロード</span>
+								</Button>
+							</div>
+						)}
 
 						{item.status === 'pending' && (
-							<p className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
-								<Loader2 className="h-3.5 w-3.5 animate-spin" />
-								変換中…
-							</p>
+							<ImageIcon className="hidden h-4 w-4 shrink-0 text-muted-foreground sm:block" />
 						)}
-
-						{item.status === 'error' && (
-							<p className="mt-1 flex items-center gap-1.5 text-xs text-destructive">
-								<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-								{item.error ?? '変換に失敗しました。'}
-							</p>
-						)}
-
-						{item.status === 'done' &&
-							item.result &&
-							item.result.warnings.map((w) => (
-								<p
-									key={w}
-									className="mt-1 flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-500"
-								>
-									<AlertTriangle className="h-3.5 w-3.5 shrink-0" />
-									{w}
-								</p>
-							))}
 					</div>
-
-					{/* アクション */}
-					{item.status === 'done' && item.result && (
-						<div className="flex shrink-0 flex-col gap-1.5">
-							<Button
-								size="sm"
-								variant="outline"
-								onClick={() => onDownload(item)}
-								aria-label="ダウンロード"
-							>
-								<Download className="h-4 w-4" />
-								<span className="ml-1 hidden sm:inline">ダウンロード</span>
-							</Button>
-						</div>
-					)}
-
-					{item.status === 'pending' && (
-						<ImageIcon className="hidden h-4 w-4 shrink-0 text-muted-foreground sm:block" />
-					)}
-				</div>
-			))}
+				);
+			})}
 		</div>
 	);
 }

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -159,6 +159,12 @@ export function ImageConvertPage() {
 		[options, processAll],
 	);
 
+	// オプション変更時は古い完了メッセージを消す（再変換するまで結果は前回のまま）
+	const handleOptionsChange = useCallback((next: ConvertUiOptions) => {
+		setOptions(next);
+		setCompletion(null);
+	}, []);
+
 	const handleReconvert = useCallback(() => {
 		const reset = itemsRef.current.map((it) => {
 			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
@@ -258,7 +264,7 @@ export function ImageConvertPage() {
 					<ConvertOptionsPanel
 						options={options}
 						disabled={processing}
-						onChange={setOptions}
+						onChange={handleOptionsChange}
 					/>
 
 					<div className="flex flex-wrap items-center gap-2">

--- a/tests/e2e/image-convert.spec.ts
+++ b/tests/e2e/image-convert.spec.ts
@@ -72,10 +72,24 @@ test.describe('画像形式変換', () => {
 		await expect(page.getByTestId('convert-completion')).toContainText(
 			'変換完了',
 		);
+		// 結果リストの表示名は変換後の拡張子（.jpg）になる
+		await expect(page.getByTestId('convert-result-list')).toContainText(
+			'sample-400x300.jpg',
+		);
 		const { name, buf } = await readDownload(page);
 		expect(name).toBe('sample-400x300.jpg');
 		expect(buf[0]).toBe(0xff);
 		expect(buf[1]).toBe(0xd8); // JPEG
+	});
+
+	test('オプション変更で前回の完了メッセージが消える', async ({ page }) => {
+		await input(page).setInputFiles(PNG);
+		await waitConverted(page);
+		await expect(page.getByTestId('convert-completion')).toBeVisible();
+		// 出力形式を変えた時点で（再変換前に）完了メッセージは消える
+		await page.getByRole('combobox', { name: '出力形式' }).click();
+		await page.getByRole('option', { name: 'WebP', exact: true }).click();
+		await expect(page.getByTestId('convert-completion')).toBeHidden();
 	});
 
 	test('WebP→PNG が成功しダウンロードできる', async ({ page }) => {


### PR DESCRIPTION
## 概要

画像形式変換ツール（`/image-convert`）の2つの表示不具合を修正しました。

## 修正内容

### 1. オプション変更後も「変換完了」メッセージが残り続ける
- **原因**: `ConvertOptionsPanel` の `onChange={setOptions}` がオプション変更時に `completion` ステートをクリアしていなかった
- **修正**: `handleOptionsChange` ラッパーを追加し、オプション変更時に `setCompletion(null)` を実行。設定を変えた時点で完了メッセージが消え、「この設定で再変換」を促す自然な挙動になった

### 2. 変換完了後の表示ファイル名の拡張子が元のまま
- **原因**: 結果リストの表示が `item.file.name`（元拡張子）を使う一方、ダウンロードは `item.result.fileName`（変換後拡張子）を使っていたため、画面表示だけ食い違っていた（ダウンロード自体は正しい拡張子）
- **修正**: 変換完了時（`status === 'done'` かつ `result` あり）は `result.fileName` を表示する `displayName` を導入。表示とダウンロードのファイル名が一致

## テスト

E2Eテストを追加・実行（いずれもパス）:
- `PNG→JPEG が成功しダウンロードできる`（結果リストの表示名が `.jpg` になることを検証・追加）
- `オプション変更で前回の完了メッセージが消える`（新規）
- `WebP→PNG が成功しダウンロードできる`（リグレッション確認）

`npm run lint` クリーン。Codex (gpt-5.5) によるコードレビュー済み（重大度つきの指摘なし）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)