### PR TITLE
feat: JWTデコーダーツールを追加

### DIFF
--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -6,7 +6,7 @@
 //   scripts/.cache/fonts/ にキャッシュする（.gitignore 済み）
 // - 生成画像はコミットせず、デプロイ成果物（dist/）にのみ含まれる
 
-import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import satori from 'satori';
@@ -37,40 +37,51 @@ const LEGACY_UA =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30';
 const FONT_CSS_URL =
 	'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap';
-const FALLBACK_FONT_PAIRS = [
-	{
-		name: 'DejaVu Sans',
-		regular: '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
-		bold: '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
-	},
-];
+
+const LOCAL_FONT_CANDIDATES = {
+	regular: [
+		'/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc',
+		'/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc',
+		'/usr/share/fonts/truetype/noto/NotoSansJP-Regular.otf',
+		'/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+	],
+	bold: [
+		'/usr/share/fonts/opentype/noto/NotoSansCJK-Bold.ttc',
+		'/usr/share/fonts/truetype/noto/NotoSansCJK-Bold.ttc',
+		'/usr/share/fonts/truetype/noto/NotoSansJP-Bold.otf',
+		'/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+	],
+};
+
+async function readFirstAvailable(paths) {
+	for (const path of paths) {
+		try {
+			return await readFile(path);
+		} catch {
+			// 次の候補を試す
+		}
+	}
+	return null;
+}
+
+async function loadLocalFallbackFonts() {
+	const [regular, bold] = await Promise.all([
+		readFirstAvailable(LOCAL_FONT_CANDIDATES.regular),
+		readFirstAvailable(LOCAL_FONT_CANDIDATES.bold),
+	]);
+	if (regular && bold) {
+		console.warn(
+			'[generate-og] フォント: Google Fonts 取得に失敗したためローカルフォントを使用します',
+		);
+		return { regular, bold };
+	}
+	return null;
+}
 
 /**
  * Noto Sans JP の TTF を取得する（キャッシュ優先、なければ Google Fonts からダウンロード）
  * @returns {Promise<{regular: Buffer, bold: Buffer}>}
  */
-async function loadFallbackFonts() {
-	for (const pair of FALLBACK_FONT_PAIRS) {
-		try {
-			await Promise.all([access(pair.regular), access(pair.bold)]);
-			const [regular, bold] = await Promise.all([
-				readFile(pair.regular),
-				readFile(pair.bold),
-			]);
-			console.warn(
-				`[generate-og] フォント: Google Fonts を取得できないため ${pair.name} にフォールバックします`,
-			);
-			return { regular, bold };
-		} catch {
-			// 次の候補へ
-		}
-	}
-
-	throw new Error(
-		'[generate-og] 利用可能なフォールバックフォントが見つかりません',
-	);
-}
-
 async function loadFonts() {
 	await mkdir(FONT_CACHE_DIR, { recursive: true });
 	const cachePaths = {
@@ -89,8 +100,10 @@ async function loadFonts() {
 		// キャッシュなし → ダウンロードへ
 	}
 
+	console.log('[generate-og] フォント: Google Fonts からダウンロード中...');
+	let regular;
+	let bold;
 	try {
-		console.log('[generate-og] フォント: Google Fonts からダウンロード中...');
 		const cssRes = await fetch(FONT_CSS_URL, {
 			headers: { 'User-Agent': LEGACY_UA },
 		});
@@ -123,22 +136,21 @@ async function loadFonts() {
 			}
 			return Buffer.from(await res.arrayBuffer());
 		};
-		const [regular, bold] = await Promise.all([
+		[regular, bold] = await Promise.all([
 			download(urls['400']),
 			download(urls['700']),
 		]);
-
-		await Promise.all([
-			writeFile(cachePaths.regular, regular),
-			writeFile(cachePaths.bold, bold),
-		]);
-		return { regular, bold };
 	} catch (error) {
-		console.warn(
-			`[generate-og] フォント: Google Fonts の取得に失敗しました (${error instanceof Error ? error.message : String(error)})`,
-		);
-		return loadFallbackFonts();
+		const fallback = await loadLocalFallbackFonts();
+		if (!fallback) throw error;
+		return fallback;
 	}
+
+	await Promise.all([
+		writeFile(cachePaths.regular, regular),
+		writeFile(cachePaths.bold, bold),
+	]);
+	return { regular, bold };
 }
 
 // satori 用の要素ツリーを生成するヘルパー（JSX なしで構築）

--- a/scripts/generate-og-images.mjs
+++ b/scripts/generate-og-images.mjs
@@ -6,7 +6,7 @@
 //   scripts/.cache/fonts/ にキャッシュする（.gitignore 済み）
 // - 生成画像はコミットせず、デプロイ成果物（dist/）にのみ含まれる
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import satori from 'satori';
@@ -37,11 +37,40 @@ const LEGACY_UA =
 	'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_6_8) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.112 Safari/534.30';
 const FONT_CSS_URL =
 	'https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;700&display=swap';
+const FALLBACK_FONT_PAIRS = [
+	{
+		name: 'DejaVu Sans',
+		regular: '/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf',
+		bold: '/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf',
+	},
+];
 
 /**
  * Noto Sans JP の TTF を取得する（キャッシュ優先、なければ Google Fonts からダウンロード）
  * @returns {Promise<{regular: Buffer, bold: Buffer}>}
  */
+async function loadFallbackFonts() {
+	for (const pair of FALLBACK_FONT_PAIRS) {
+		try {
+			await Promise.all([access(pair.regular), access(pair.bold)]);
+			const [regular, bold] = await Promise.all([
+				readFile(pair.regular),
+				readFile(pair.bold),
+			]);
+			console.warn(
+				`[generate-og] フォント: Google Fonts を取得できないため ${pair.name} にフォールバックします`,
+			);
+			return { regular, bold };
+		} catch {
+			// 次の候補へ
+		}
+	}
+
+	throw new Error(
+		'[generate-og] 利用可能なフォールバックフォントが見つかりません',
+	);
+}
+
 async function loadFonts() {
 	await mkdir(FONT_CACHE_DIR, { recursive: true });
 	const cachePaths = {
@@ -60,52 +89,66 @@ async function loadFonts() {
 		// キャッシュなし → ダウンロードへ
 	}
 
-	console.log('[generate-og] フォント: Google Fonts からダウンロード中...');
-	const cssRes = await fetch(FONT_CSS_URL, {
-		headers: { 'User-Agent': LEGACY_UA },
-	});
-	if (!cssRes.ok) {
-		throw new Error(`[generate-og] フォントCSSの取得に失敗: HTTP ${cssRes.status}`);
-	}
-	const css = await cssRes.text();
-
-	// @font-face ブロックから weight ごとの TTF URL を抽出
-	const urls = {};
-	for (const block of css.match(/@font-face\s*\{[^}]*\}/g) ?? []) {
-		const weight = block.match(/font-weight:\s*(\d+)/)?.[1];
-		const url = block.match(/src:\s*url\((https:[^)]+)\)/)?.[1];
-		if (weight && url) urls[weight] = url;
-	}
-	if (!urls['400'] || !urls['700']) {
-		throw new Error(
-			'[generate-og] フォントURLの抽出に失敗（Google Fonts のレスポンス形式が変わった可能性）',
-		);
-	}
-
-	const download = async (url) => {
-		const res = await fetch(url);
-		if (!res.ok) {
-			throw new Error(`[generate-og] フォントのダウンロードに失敗: HTTP ${res.status} ${url}`);
+	try {
+		console.log('[generate-og] フォント: Google Fonts からダウンロード中...');
+		const cssRes = await fetch(FONT_CSS_URL, {
+			headers: { 'User-Agent': LEGACY_UA },
+		});
+		if (!cssRes.ok) {
+			throw new Error(
+				`[generate-og] フォントCSSの取得に失敗: HTTP ${cssRes.status}`,
+			);
 		}
-		return Buffer.from(await res.arrayBuffer());
-	};
-	const [regular, bold] = await Promise.all([
-		download(urls['400']),
-		download(urls['700']),
-	]);
+		const css = await cssRes.text();
 
-	await Promise.all([
-		writeFile(cachePaths.regular, regular),
-		writeFile(cachePaths.bold, bold),
-	]);
-	return { regular, bold };
+		// @font-face ブロックから weight ごとの TTF URL を抽出
+		const urls = {};
+		for (const block of css.match(/@font-face\s*\{[^}]*\}/g) ?? []) {
+			const weight = block.match(/font-weight:\s*(\d+)/)?.[1];
+			const url = block.match(/src:\s*url\((https:[^)]+)\)/)?.[1];
+			if (weight && url) urls[weight] = url;
+		}
+		if (!urls['400'] || !urls['700']) {
+			throw new Error(
+				'[generate-og] フォントURLの抽出に失敗（Google Fonts のレスポンス形式が変わった可能性）',
+			);
+		}
+
+		const download = async (url) => {
+			const res = await fetch(url);
+			if (!res.ok) {
+				throw new Error(
+					`[generate-og] フォントのダウンロードに失敗: HTTP ${res.status} ${url}`,
+				);
+			}
+			return Buffer.from(await res.arrayBuffer());
+		};
+		const [regular, bold] = await Promise.all([
+			download(urls['400']),
+			download(urls['700']),
+		]);
+
+		await Promise.all([
+			writeFile(cachePaths.regular, regular),
+			writeFile(cachePaths.bold, bold),
+		]);
+		return { regular, bold };
+	} catch (error) {
+		console.warn(
+			`[generate-og] フォント: Google Fonts の取得に失敗しました (${error instanceof Error ? error.message : String(error)})`,
+		);
+		return loadFallbackFonts();
+	}
 }
 
 // satori 用の要素ツリーを生成するヘルパー（JSX なしで構築）
 function h(type, props, ...children) {
 	return {
 		type,
-		props: { ...props, children: children.length === 1 ? children[0] : children },
+		props: {
+			...props,
+			children: children.length === 1 ? children[0] : children,
+		},
 	};
 }
 

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -1,0 +1,92 @@
+import { AlertTriangle, KeyRound, Trash2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import CopyButton from '@/components/common/CopyButton';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { decodeJwt } from '@/lib/tools/jwt-decoder';
+
+const SAMPLE_JWT =
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IuWxseeUsOWkqumDjiIsInJvbGUiOiLnrqHnkIbogIUiLCJpYXQiOjE3MDQwNjcyMDAsImV4cCI6NDEwMjQ0NDgwMH0.dummy-signature';
+
+function ResultCard({ title, value }: { title: string; value: string }) {
+	return (
+		<Card>
+			<CardHeader className="flex flex-row items-center justify-between gap-3 pb-3">
+				<CardTitle className="text-base">{title}</CardTitle>
+				<CopyButton text={value} />
+			</CardHeader>
+			<CardContent>
+				<pre className="min-h-40 overflow-auto rounded-lg bg-muted p-4 font-mono-tool text-sm whitespace-pre-wrap">
+					{value || 'デコード結果がここに表示されます。'}
+				</pre>
+			</CardContent>
+		</Card>
+	);
+}
+
+export function JwtDecoder() {
+	const [input, setInput] = useState(SAMPLE_JWT);
+	const result = useMemo(() => decodeJwt(input), [input]);
+
+	return (
+		<div className="space-y-6">
+			<Alert>
+				<KeyRound className="h-4 w-4" />
+				<AlertTitle>署名検証は行いません</AlertTitle>
+				<AlertDescription>
+					JWTのヘッダーとペイロードをブラウザ内でデコードします。秘密鍵や外部サーバーは使用しません。
+				</AlertDescription>
+			</Alert>
+
+			<div className="space-y-2">
+				<div className="flex items-center justify-between gap-3">
+					<Label htmlFor="jwt-input">JWT</Label>
+					<Button
+						variant="outline"
+						size="sm"
+						onClick={() => setInput('')}
+						disabled={!input}
+					>
+						<Trash2 className="mr-1 h-4 w-4" />
+						クリア
+					</Button>
+				</div>
+				<Textarea
+					id="jwt-input"
+					value={input}
+					onChange={(event) => setInput(event.target.value)}
+					placeholder="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+					className="min-h-36 font-mono-tool"
+				/>
+			</div>
+
+			{result.error && (
+				<Alert variant="destructive">
+					<AlertTriangle className="h-4 w-4" />
+					<AlertTitle>デコードできません</AlertTitle>
+					<AlertDescription>{result.error}</AlertDescription>
+				</Alert>
+			)}
+
+			{result.warnings.length > 0 && (
+				<Alert>
+					<AlertTriangle className="h-4 w-4" />
+					<AlertTitle>注意</AlertTitle>
+					<AlertDescription>{result.warnings.join(' / ')}</AlertDescription>
+				</Alert>
+			)}
+
+			<div className="grid gap-4 lg:grid-cols-2">
+				<ResultCard title="ヘッダー" value={result.header?.formatted ?? ''} />
+				<ResultCard
+					title="ペイロード"
+					value={result.payload?.formatted ?? ''}
+				/>
+			</div>
+			<ResultCard title="署名（未検証）" value={result.signature} />
+		</div>
+	);
+}

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -56,6 +56,17 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		keywords: ['JSON', 'フォーマット', 'バリデーション'],
 	},
 	{
+		id: 'jwt-decoder',
+		title: 'JWTデコーダー',
+		description:
+			'JWTのヘッダー・ペイロードをブラウザ内でデコード。署名検証なしで内容確認に使えます。',
+		href: '/jwt-decoder',
+		icon: '🎫',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: ['JWT', 'JSON Web Token', 'デコード', '認証', 'トークン'],
+	},
+	{
 		id: 'text-diff',
 		title: 'テキスト差分比較',
 		description:

--- a/src/lib/tools/jwt-decoder.ts
+++ b/src/lib/tools/jwt-decoder.ts
@@ -70,7 +70,7 @@ export function decodeJwt(input: string, now = Date.now()): JwtDecodeResult {
 	}
 
 	const parts = token.split('.');
-	if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+	if (parts.length !== 3 || parts[0].length === 0 || parts[1].length === 0) {
 		return {
 			valid: false,
 			header: null,

--- a/src/lib/tools/jwt-decoder.ts
+++ b/src/lib/tools/jwt-decoder.ts
@@ -1,0 +1,118 @@
+export interface JwtDecodedPart {
+	json: unknown | null;
+	text: string;
+	formatted: string;
+}
+
+export interface JwtDecodeResult {
+	valid: boolean;
+	header: JwtDecodedPart | null;
+	payload: JwtDecodedPart | null;
+	signature: string;
+	error: string | null;
+	warnings: string[];
+}
+
+function decodeBase64Url(segment: string): string {
+	const normalized = segment.replace(/-/g, '+').replace(/_/g, '/');
+	const padded = normalized.padEnd(
+		normalized.length + ((4 - (normalized.length % 4)) % 4),
+		'=',
+	);
+	const binary = atob(padded);
+	const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+}
+
+function decodeJwtPart(segment: string): JwtDecodedPart {
+	const text = decodeBase64Url(segment);
+
+	try {
+		const json = JSON.parse(text) as unknown;
+		return {
+			json,
+			text,
+			formatted: JSON.stringify(json, null, 2),
+		};
+	} catch {
+		return {
+			json: null,
+			text,
+			formatted: text,
+		};
+	}
+}
+
+function readNumericDate(payload: unknown, key: string): number | null {
+	if (!payload || typeof payload !== 'object') return null;
+	const value = (payload as Record<string, unknown>)[key];
+	return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+export function formatUnixSeconds(seconds: number): string {
+	return new Intl.DateTimeFormat('ja-JP', {
+		dateStyle: 'medium',
+		timeStyle: 'medium',
+	}).format(new Date(seconds * 1000));
+}
+
+export function decodeJwt(input: string, now = Date.now()): JwtDecodeResult {
+	const token = input.trim();
+	if (!token) {
+		return {
+			valid: false,
+			header: null,
+			payload: null,
+			signature: '',
+			error: 'JWTを入力してください。',
+			warnings: [],
+		};
+	}
+
+	const parts = token.split('.');
+	if (parts.length !== 3 || parts.some((part) => part.length === 0)) {
+		return {
+			valid: false,
+			header: null,
+			payload: null,
+			signature: '',
+			error:
+				'JWTは「ヘッダー.ペイロード.署名」の3つの部分で構成されている必要があります。',
+			warnings: [],
+		};
+	}
+
+	try {
+		const header = decodeJwtPart(parts[0]);
+		const payload = decodeJwtPart(parts[1]);
+		const warnings: string[] = [];
+		const exp = readNumericDate(payload.json, 'exp');
+		const nbf = readNumericDate(payload.json, 'nbf');
+		const nowSeconds = Math.floor(now / 1000);
+
+		if (exp !== null && exp < nowSeconds) {
+			warnings.push(`有効期限（exp）を過ぎています: ${formatUnixSeconds(exp)}`);
+		}
+		if (nbf !== null && nbf > nowSeconds) {
+			warnings.push(`有効開始時刻（nbf）が未来です: ${formatUnixSeconds(nbf)}`);
+		}
+
+		return {
+			valid: true,
+			header,
+			payload,
+			signature: parts[2],
+			error: null,
+			warnings,
+		};
+	} catch {
+		return {
+			valid: false,
+			header: null,
+			payload: null,
+			signature: '',
+			error: 'Base64URLのデコードに失敗しました。JWTの形式を確認してください。',
+			warnings: [],
+		};
+	}
+}

--- a/src/pages/jwt-decoder.astro
+++ b/src/pages/jwt-decoder.astro
@@ -1,0 +1,30 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import { JwtDecoder } from '../components/tools/JwtDecoder';
+---
+
+<ToolLayout
+  title="JWTデコーダー"
+  description="JWTのヘッダー・ペイロードをブラウザ内でデコード。署名検証なしで内容確認に使えます。"
+  path="/jwt-decoder"
+>
+  <JwtDecoder client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4" open>
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>JWTを貼り付けると、ヘッダーとペイロードをJSONとして整形表示します。</p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>ログや開発環境で取得したJWTのclaimを素早く確認したい</li>
+          <li>exp・nbfなどの時刻claimが有効範囲内か確認したい</li>
+          <li>外部サービスにトークンを貼り付けず、ローカルだけで内容を確認したい</li>
+        </ul>
+        <p class="text-xs">※このツールは署名検証を行いません。認証・認可の判定には使用しないでください。</p>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/tests/e2e/jwt-decoder.spec.ts
+++ b/tests/e2e/jwt-decoder.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from './fixtures/base';
 
 const SAMPLE_JWT =
 	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoi5bGx55Sw5aSq6YOOIiwicm9sZSI6IueuoeeQhuiAhSJ9.signature';
+const UNSIGNED_JWT =
+	'eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.eyJuYW1lIjoi5bGx55Sw5aSq6YOOIiwicm9sZSI6IueuoeeQhuiAhSJ9.';
 
 test.describe('JWT Decoder Tool', () => {
 	test('should decode JWT header and payload locally', async ({
@@ -17,7 +19,21 @@ test.describe('JWT Decoder Tool', () => {
 
 		await expect(page.getByText('"alg": "HS256"')).toBeVisible();
 		await expect(page.getByText('"name": "山田太郎"')).toBeVisible();
-		await expect(page.getByText('signature')).toBeVisible();
+		await expect(page.getByText('signature', { exact: true })).toBeVisible();
+	});
+
+	test('should allow JWTs with alg none and an empty signature', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('jwt-decoder');
+		await toolPage.goto();
+
+		await page.getByLabel('JWT').fill(UNSIGNED_JWT);
+
+		await expect(page.getByText('デコードできません')).toHaveCount(0);
+		await expect(page.getByText('"alg": "none"')).toBeVisible();
+		await expect(page.getByText('"name": "山田太郎"')).toBeVisible();
 	});
 
 	test('should show validation error for invalid token shape', async ({

--- a/tests/e2e/jwt-decoder.spec.ts
+++ b/tests/e2e/jwt-decoder.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from './fixtures/base';
+
+const SAMPLE_JWT =
+	'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoi5bGx55Sw5aSq6YOOIiwicm9sZSI6IueuoeeQhuiAhSJ9.signature';
+
+test.describe('JWT Decoder Tool', () => {
+	test('should decode JWT header and payload locally', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('jwt-decoder');
+		await toolPage.goto();
+		await toolPage.expectTitle('JWTデコーダー | CODE:LIFE Tools');
+		await toolPage.expectSafetyBadge();
+
+		await page.getByLabel('JWT').fill(SAMPLE_JWT);
+
+		await expect(page.getByText('"alg": "HS256"')).toBeVisible();
+		await expect(page.getByText('"name": "山田太郎"')).toBeVisible();
+		await expect(page.getByText('signature')).toBeVisible();
+	});
+
+	test('should show validation error for invalid token shape', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('jwt-decoder');
+		await toolPage.goto();
+
+		await page.getByLabel('JWT').fill('invalid-token');
+
+		await expect(page.getByText('デコードできません')).toBeVisible();
+		await expect(page.getByText('3つの部分で構成')).toBeVisible();
+	});
+});


### PR DESCRIPTION
### Motivation
- ブラウザ内だけでJWTのヘッダー・ペイロードを確認できる開発支援ツールを追加するため、署名検証を行わずにBase64URLデコードとJSON整形を提供します。 
- `exp`/`nbf`等の時刻クレームに対する簡易警告を表示してデバッグをしやすくします。 

### Description
- 新規ロジックを追加し、JWTのBase64URLデコード・整形・警告を行う純粋関数を `src/lib/tools/jwt-decoder.ts` に実装しました。 
- React UIコンポーネント `src/components/tools/JwtDecoder.tsx` を追加し、ヘッダー・ペイロード・署名をコピー可能なカードで表示するUIを実装しました。 
- ツールページ `src/pages/jwt-decoder.astro` を追加し、使い方スロットと注意書きを掲載しました。 
- ツールカタログ `src/lib/tools/catalog.ts` に `jwt-decoder` エントリを追加してトップページ等から参照可能にしました。 
- E2Eテスト `tests/e2e/jwt-decoder.spec.ts` を追加し、ヘッダー/ペイロードのデコードと不正トークンのエラー表示を検証するテストを用意しました。 

### Testing
- `npm run lint` を実行し、`biome` の指摘に対して `npm run lint:fix` を実行してフォーマット上の問題を修正しチェックは通過しました（2ファイル自動修正）。 
- 依存インストールは `npm ci --ignore-scripts` を実行して行いましたが、環境の Node.js が v20.20.2 のため `npm run build` は失敗し、Astro の要件（`>=22.12.0`）によりビルドは実行できませんでした。 
- Playwright の E2E実行（`npm test -- jwt-decoder.spec.ts`）は同じ Node.js バージョン制約で `webServer` が起動できず実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f5d845e6c832fb4b2b2774ad06146)