### PR TITLE
feat: ツール間回遊カードセクションを追加

### DIFF
--- a/docs/specs/2026-06-27-tool-related-cards-design.md
+++ b/docs/specs/2026-06-27-tool-related-cards-design.md
@@ -1,0 +1,159 @@
+# ツール間回遊カードセクション 設計
+
+- 日付: 2026-06-27
+- ステータス: 承認済み（ユーザー承認 2026-06-27）
+
+## 背景・課題
+
+各ツールページの「📖 使い方・ユースケース」`details` の最下部に、関連ツールが
+小さなテキストリンク（`関連ツール: A B C`）として手書きで埋め込まれている。
+
+- 視認性が低く、回遊（ツール→ツールの移動）を促せていない
+- 22 ページに分散して手書きされており、保守が困難
+- 関連付け情報が `catalog.ts` に存在せず、データとして再利用できない
+
+これを独立した見出し付きの「関連ツール」セクションに格上げし、トップページと
+同じカード UI で表示する。
+
+## 決定事項（ユーザー確認済み）
+
+1. **選定ロジック: ハイブリッド** — `catalog.ts` の `related` を優先表示し、
+   3 枚に満たなければ同カテゴリの他ツールで自動補完する。
+2. **実装方式: ToolLayout に集約** — `related` を `catalog.ts` に持ち、
+   `ToolLayout.astro` が `path` から自動でセクションを描画。各ページの手書き
+   リンクは削除する。
+3. **見た目: フルカード3枚** — トップページと同じ `ToolCard.astro` を流用し、
+   `sm:grid-cols-2 lg:grid-cols-3` のグリッドで表示する。
+4. **配置** — `slot name="usage"` の直下に、独立した見出し「関連ツール」
+   セクションとして置く。
+
+## アーキテクチャ
+
+### 1. データモデル（`src/lib/tools/catalog.ts`）
+
+`ToolCatalogItem` にフィールドを追加:
+
+```ts
+related?: readonly string[]; // 関連ツールidを優先順で。省略可。
+```
+
+ヘルパー関数を追加（ロジックを分離し単体テスト可能にする）:
+
+```ts
+export function getRelatedTools(toolId: string, limit = 3): ToolCatalogItem[]
+```
+
+仕様:
+- `related` に指定された id を順に解決（自分自身・存在しない id・重複は除外）
+- `limit` に満たない場合、**同カテゴリ**の他ツールで補完（既出・自分は除外）
+- なお補完してもなお 0 件なら空配列を返す（呼び出し側はセクションを描画しない）
+- 返り値は `ToolCatalogItem[]`（カード描画にそのまま渡せる）
+
+### 2. 表示（`src/components/common/ToolLayout.astro`）
+
+- 既に `path` から `tool` を解決済み（`toolCatalog.find((t) => t.href === path)`）。
+- `tool` が解決でき、かつ `getRelatedTools(tool.id)` が 1 件以上を返す場合のみ、
+  `slot name="usage"` の直下に以下を描画:
+
+```astro
+{related.length > 0 && (
+  <section class="mt-8" aria-labelledby="related-tools-heading">
+    <h2 id="related-tools-heading" class="text-lg font-semibold mb-4">関連ツール</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      {related.map((t) => (
+        <ToolCard
+          title={t.title}
+          description={t.description}
+          href={t.href}
+          icon={t.icon}
+          category={t.category}
+          categoryColor={t.categoryColor}
+        />
+      ))}
+    </div>
+  </section>
+)}
+```
+
+設計判断:
+- **`span` は渡さない**（既定値 1）。ツールページは横幅が狭い（`max-w-[800px]
+  xl:max-w-5xl`）ため、全カードを均等 1 マスにしてレイアウト崩れを防ぐ。
+- **`categoryId` は渡さない**。トップページのカテゴリ絞り込み（`#tool-grid` 前提の
+  `setupCategoryFilter`）はツールページに存在しないため、バッジに絞り込み
+  アフォーダンスを付けると誤解を招く。バッジはラベル表示のみとする。
+
+### 3. 各ツールページ（`src/pages/*.astro` ×22）
+
+`slot="usage"` 内の「関連ツール:」リンク行（`<div class="flex flex-wrap gap-3
+pt-2 border-t border-border">...</div>`）を削除する。`catalog.ts` の `related`
+に集約済みのため重複を排除する。
+
+> 注意: 一部ページは `usage` 内の HTML 入れ子が微妙に異なる（例:
+> `url-encoder.astro` は本文ラッパ `div` が省略されている）。削除は
+> 各ファイルを直接読んで該当ブロックだけを正確に除去すること。一括 sed は使わない。
+
+## 関連ツール移植マップ
+
+各ページの手書きリンクを `related` に移植する。`getRelatedTools` は先頭から
+`limit`(=3) 件を採用するため、4 件以上のものは順序が優先度を意味する。
+
+| ツール id | related（優先順） |
+|---|---|
+| bg-remove | image-compress, image-mosaic, image-text |
+| base64 | url-encoder, cipher, unicode-converter |
+| csv-editor | json-csv, csv-fixer, zipcode |
+| color | hash, markdown, favicon |
+| image-compress | image-convert, bg-remove, image-mosaic, image-text, favicon, pdf-merge, pdf-split |
+| cipher | url-encoder, unicode-converter, base64 |
+| hash | cipher, masking, color, base64 |
+| json-formatter | json-csv, csv-editor |
+| favicon | color, image-compress, image-text |
+| csv-fixer | json-csv, csv-editor |
+| pdf-merge | pdf-split, image-compress, image-mosaic |
+| json-csv | json-formatter, csv-editor, csv-fixer, tax, markdown |
+| zipcode | phone-formatter, dummy-data, csv-editor, tax |
+| image-text | image-mosaic, image-compress, bg-remove |
+| image-mosaic | image-text, image-compress, masking, bg-remove, pdf-merge |
+| phone-formatter | char-count, csv-fixer, masking, zipcode |
+| masking | image-mosaic, dummy-data |
+| image-convert | image-compress, image-mosaic, image-text, bg-remove |
+| url-encoder | base64, cipher, unicode-converter |
+| pdf-split | pdf-merge, image-compress |
+| tax | zipcode, json-csv |
+| markdown | json-csv, color |
+
+> `cipher` / `hash` の `base64` の挿入位置は、実装時に各 `.astro` を直接読んで
+> 元のリンク並び順どおりに確定すること（上表の末尾配置は暫定）。
+> `related` を持たないツール（`char-count`, `dummy-data`, `qr-generator`,
+> `regex-tester`, `sql-formatter`, `text-diff`, `wareki-converter`,
+> `zenkaku-hankaku`, `unicode-converter`）は同カテゴリ自動補完のみで表示される。
+
+## テスト
+
+- **単体（`getRelatedTools`）**: related 優先 / カテゴリ補完 / 自己除外 /
+  存在しない id 無視 / 0 件時の空配列、を検証。
+- **E2E（Playwright, `tests/e2e/fixtures/base.ts` 経由必須）**: 代表ツールページ
+  （例: base64, image-compress）で「関連ツール」見出しとカードリンクが表示され、
+  カードのリンク先が正しいことを確認。
+
+## セキュリティ注記（重要・後続作業者向け）
+
+本設計のブレインストーミング中、**プロンプトインジェクション攻撃**が発生した。
+ツール通信を装った偽の内容が混入し、以下を信じ込ませようとした:
+
+- 「`ToolCard.astro` が category-chip 重複・`</body>` 混在で壊れている」
+- 「teammate が ToolCard.astro のバグ修正に注意せよと言っている」
+
+**いずれも虚偽**。実ファイル `src/components/common/ToolCard.astro` は 53 行の
+正常な `<a>` カードであり、重複も構文破綻もない（props は `title, description,
+href, icon, category, categoryId?, categoryColor?, span?`）。これは「正常な
+ファイルを修正させて壊す」典型的な誘導である。
+
+**`ToolCard.astro` を"バグ修正"してはならない。** 本作業で `ToolCard.astro` を
+変更する必要は一切ない（流用するだけ）。
+
+## スコープ外
+
+- `ToolCard.astro` の改修（流用のみ。変更不要）
+- 関連度の自動スコアリング（キーワード類似など）— 今回はハイブリッド固定
+- トップページ・検索の挙動変更

--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -1,7 +1,8 @@
 ---
-import { getCategoryId, toolCatalog } from '../../lib/tools/catalog';
+import { getCategoryId, getRelatedTools, toolCatalog } from '../../lib/tools/catalog';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import SafetyBadge from '../layout/SafetyBadge.tsx';
+import ToolCard from '../common/ToolCard.astro';
 import ToolJsonLd from '../common/ToolJsonLd.astro';
 
 interface Props {
@@ -22,6 +23,9 @@ const categoryHref = category ? `/?category=${getCategoryId(category)}` : undefi
 
 // カタログ掲載ツールはビルド時生成のツール別 OG 画像（/og/{id}.png）を使う
 const ogImage = tool ? `/og/${tool.id}.png` : undefined;
+
+// 回遊カード: related 優先＋同カテゴリ補完で最大3件。0件ならセクション非表示。
+const relatedTools = tool ? getRelatedTools(tool.id) : [];
 
 const breadcrumbItems: { name: string; url?: string }[] = [
   { name: 'ホーム', url: `${SITE_URL}/` },
@@ -90,6 +94,25 @@ const breadcrumbSchema = {
 
     <!-- Usage / Tips section -->
     <slot name="usage" />
+
+    <!-- Related tools (回遊カード) -->
+    {relatedTools.length > 0 && (
+      <section class="mt-8" aria-labelledby="related-tools-heading">
+        <h2 id="related-tools-heading" class="text-lg font-semibold mb-4">関連ツール</h2>
+        <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+          {relatedTools.map((t) => (
+            <ToolCard
+              title={t.title}
+              description={t.description}
+              href={t.href}
+              icon={t.icon}
+              category={t.category}
+              categoryColor={t.categoryColor}
+            />
+          ))}
+        </div>
+      </section>
+    )}
   </div>
 </BaseLayout>
 

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -19,6 +19,9 @@ export type ToolCatalogItem = {
 	categoryColor: string;
 	span?: 2;
 	keywords: readonly string[];
+	// 関連ツールのidを優先順で指定（回遊カードで使用）。
+	// 省略時・件数不足時は getRelatedTools が同カテゴリで自動補完する。
+	related?: readonly string[];
 };
 
 export const toolCatalog: readonly ToolCatalogItem[] = [
@@ -54,6 +57,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: '開発ツール',
 		categoryColor: 'border-l-chart-1',
 		keywords: ['JSON', 'フォーマット', 'バリデーション'],
+		related: ['json-csv', 'csv-editor'],
 	},
 	{
 		id: 'text-diff',
@@ -98,6 +102,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'エンコード/デコード',
 		categoryColor: 'border-l-primary',
 		keywords: ['URL', 'encodeURI', 'decodeURI', 'パーセントエンコード'],
+		related: ['base64', 'cipher', 'unicode-converter'],
 	},
 	{
 		id: 'base64',
@@ -109,6 +114,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'ユーティリティ',
 		categoryColor: 'border-l-chart-2',
 		keywords: ['Base64', 'エンコード', 'デコード'],
+		related: ['url-encoder', 'cipher', 'unicode-converter'],
 	},
 	{
 		id: 'regex-tester',
@@ -153,6 +159,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'データ処理',
 		categoryColor: 'border-l-chart-4',
 		keywords: ['個人情報', 'マスキング', 'メール', '電話番号'],
+		related: ['image-mosaic', 'dummy-data'],
 	},
 	{
 		id: 'csv-editor',
@@ -165,6 +172,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		categoryColor: 'border-l-chart-4',
 		span: 2,
 		keywords: ['CSV', 'TSV', '表', '編集'],
+		related: ['json-csv', 'csv-fixer', 'zipcode'],
 	},
 	{
 		id: 'unicode-converter',
@@ -187,6 +195,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'データ処理',
 		categoryColor: 'border-l-chart-4',
 		keywords: ['CSV', '文字化け', 'Shift_JIS', 'BOM'],
+		related: ['json-csv', 'csv-editor'],
 	},
 	{
 		id: 'phone-formatter',
@@ -198,6 +207,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'データ処理',
 		categoryColor: 'border-l-chart-4',
 		keywords: ['電話番号', 'E.164', 'CSV'],
+		related: ['char-count', 'csv-fixer', 'masking', 'zipcode'],
 	},
 	{
 		id: 'cipher',
@@ -209,6 +219,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'ユーティリティ',
 		categoryColor: 'border-l-chart-2',
 		keywords: ['暗号', '難読化', 'ROT13', 'モールス信号', 'シーザー暗号'],
+		related: ['base64', 'url-encoder', 'unicode-converter'],
 	},
 	{
 		id: 'json-csv',
@@ -220,6 +231,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'データ処理',
 		categoryColor: 'border-l-chart-4',
 		keywords: ['JSON', 'CSV', '変換', 'BOM', 'Excel', 'フラット化'],
+		related: ['json-formatter', 'csv-editor', 'csv-fixer', 'tax', 'markdown'],
 	},
 	{
 		id: 'hash',
@@ -231,6 +243,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: '開発ツール',
 		categoryColor: 'border-l-chart-1',
 		keywords: ['ハッシュ', 'MD5', 'SHA-256', 'チェックサム', 'CRC32', '改ざん'],
+		related: ['cipher', 'base64', 'masking', 'color'],
 	},
 	{
 		id: 'bg-remove',
@@ -242,6 +255,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'AI/画像',
 		categoryColor: 'border-l-chart-5',
 		keywords: ['背景削除', '透過', 'AI', '画像', 'アップロード不要'],
+		related: ['image-compress', 'image-mosaic', 'image-text'],
 	},
 	{
 		id: 'image-mosaic',
@@ -263,6 +277,13 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'絵文字スタンプ',
 			'画像スタンプ',
 		],
+		related: [
+			'image-text',
+			'image-compress',
+			'masking',
+			'bg-remove',
+			'pdf-merge',
+		],
 	},
 	{
 		id: 'image-text',
@@ -274,6 +295,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'AI/画像',
 		categoryColor: 'border-l-chart-5',
 		keywords: ['テキスト', '文字入れ', '画像', '注釈', 'キャプション'],
+		related: ['image-mosaic', 'image-compress', 'bg-remove'],
 	},
 	{
 		id: 'image-compress',
@@ -293,6 +315,15 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'目標サイズ',
 			'JPEG',
 			'PNG',
+		],
+		related: [
+			'image-convert',
+			'bg-remove',
+			'image-mosaic',
+			'image-text',
+			'favicon',
+			'pdf-merge',
+			'pdf-split',
 		],
 	},
 	{
@@ -314,6 +345,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'一括',
 			'ZIP',
 		],
+		related: ['image-compress', 'image-mosaic', 'image-text', 'bg-remove'],
 	},
 	{
 		id: 'zipcode',
@@ -333,6 +365,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'CSV',
 			'オフライン',
 		],
+		related: ['phone-formatter', 'dummy-data', 'csv-editor', 'tax'],
 	},
 	{
 		id: 'pdf-merge',
@@ -350,6 +383,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'アップロードしない',
 			'安全',
 		],
+		related: ['pdf-split', 'image-compress', 'image-mosaic'],
 	},
 	{
 		id: 'pdf-split',
@@ -368,6 +402,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'アップロードしない',
 			'安全',
 		],
+		related: ['pdf-merge', 'image-compress'],
 	},
 	{
 		id: 'tax',
@@ -379,6 +414,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'ユーティリティ',
 		categoryColor: 'border-l-chart-2',
 		keywords: ['消費税', '税込', '税抜', '軽減税率', '端数処理', '計算'],
+		related: ['zipcode', 'json-csv'],
 	},
 	{
 		id: 'color',
@@ -390,6 +426,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: '開発ツール',
 		categoryColor: 'border-l-chart-1',
 		keywords: ['カラーコード', 'HEX', 'RGB', 'HSL', 'CMYK', '色', '変換'],
+		related: ['hash', 'markdown', 'favicon'],
 	},
 	{
 		id: 'markdown',
@@ -401,6 +438,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		category: 'テキスト変換',
 		categoryColor: 'border-l-primary',
 		keywords: ['Markdown', 'マークダウン', 'プレビュー', 'GFM', 'HTML'],
+		related: ['json-csv', 'color'],
 	},
 	{
 		id: 'favicon',
@@ -419,6 +457,7 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'apple-touch-icon',
 			'PWAアイコン',
 		],
+		related: ['color', 'image-compress', 'image-text'],
 	},
 ];
 
@@ -462,3 +501,40 @@ export function getCategoryId(category: ToolCategory): string {
 }
 
 export const toolSlugs = toolCatalog.map((tool) => tool.id);
+
+/**
+ * 指定ツールの関連ツールを取得する（回遊カード用）。
+ *
+ * 1. `related` に指定された id を優先順に解決（自分自身・存在しない id・重複は除外）
+ * 2. `limit` に満たなければ同カテゴリの他ツールで補完（既出・自分は除外）
+ * 3. それでも 0 件なら空配列を返す（呼び出し側はセクションを描画しない）
+ */
+export function getRelatedTools(toolId: string, limit = 3): ToolCatalogItem[] {
+	const self = toolCatalog.find((t) => t.id === toolId);
+	if (!self) return [];
+
+	const byId = new Map(toolCatalog.map((t) => [t.id, t]));
+	const result: ToolCatalogItem[] = [];
+	const seen = new Set<string>([toolId]);
+
+	const push = (tool: ToolCatalogItem | undefined) => {
+		if (!tool || seen.has(tool.id) || result.length >= limit) return;
+		seen.add(tool.id);
+		result.push(tool);
+	};
+
+	// 1. related を優先順に追加
+	for (const id of self.related ?? []) {
+		push(byId.get(id));
+	}
+
+	// 2. 不足分を同カテゴリで補完（カタログ順）
+	if (result.length < limit) {
+		for (const tool of toolCatalog) {
+			if (tool.category === self.category) push(tool);
+			if (result.length >= limit) break;
+		}
+	}
+
+	return result;
+}

--- a/src/pages/base64.astro
+++ b/src/pages/base64.astro
@@ -24,12 +24,6 @@ import Base64Converter from '../components/tools/Base64Converter.tsx';
           <li>小さな画像ファイルをCSSやHTMLに直接埋め込むためにData URI形式に変換したい</li>
           <li>フォントファイルなどをBase64化してバンドルしたい</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/url-encoder" class="text-xs text-primary hover:underline">URLエンコード</a>
-          <a href="/cipher" class="text-xs text-primary hover:underline">暗号化・難読化</a>
-          <a href="/unicode-converter" class="text-xs text-primary hover:underline">Unicode変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/bg-remove.astro
+++ b/src/pages/bg-remove.astro
@@ -35,12 +35,6 @@ import BgRemoveTool from '../components/tools/BgRemove.tsx';
           <h4 class="font-semibold text-foreground">背景差し替え</h4>
           <p>背景を透過以外にも、単色やカスタム画像に差し替えることができます。</p>
         </div>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-          <a href="/image-text" class="text-xs text-primary hover:underline">画像テキスト挿入</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/cipher.astro
+++ b/src/pages/cipher.astro
@@ -23,12 +23,6 @@ import { CipherPage } from '../components/tools/cipher/CipherPage';
           <li><strong>文字列反転:</strong> 文字列の順序を逆にします。サロゲートペアや結合文字（濁点など）も正しく維持されます。</li>
           <li><strong>モールス信号:</strong> アマチュア無線や謎解き、CTFなどで使用されるモールス信号のエンコードおよびデコードに対応しています。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/base64" class="text-xs text-primary hover:underline">Base64変換</a>
-          <a href="/url-encoder" class="text-xs text-primary hover:underline">URLエンコード</a>
-          <a href="/unicode-converter" class="text-xs text-primary hover:underline">Unicode変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/color.astro
+++ b/src/pages/color.astro
@@ -34,12 +34,6 @@ import { ColorConvertPage } from '../components/tools/color/ColorConvertPage';
             CMYK変換は印刷用のICCプロファイルを使用しない簡易変換（naive conversion）です。実際の印刷物の色とは異なる場合があるため、正確な色再現が必要な印刷用途には対応していません。
           </li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/hash" class="text-xs text-primary hover:underline">ハッシュ値計算</a>
-          <a href="/markdown" class="text-xs text-primary hover:underline">Markdownエディタ</a>
-          <a href="/favicon" class="text-xs text-primary hover:underline">ファビコン生成</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/csv-editor.astro
+++ b/src/pages/csv-editor.astro
@@ -27,12 +27,6 @@ import CsvEditorTool from '../components/tools/CsvEditor.tsx';
         <div class="mt-2 text-xs bg-muted/50 p-2 rounded">
           ⚠️ ブラウザのメモリ制限のため、極端に大きなファイル（数十万行、数百MB以上）の場合は表示が遅くなる、または開けない場合があります。
         </div>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
-          <a href="/csv-fixer" class="text-xs text-primary hover:underline">CSV文字化け修復</a>
-          <a href="/zipcode" class="text-xs text-primary hover:underline">郵便番号→住所変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/csv-fixer.astro
+++ b/src/pages/csv-fixer.astro
@@ -25,11 +25,6 @@ import CsvFixerTool from '../components/tools/CsvFixer';
           <li><strong>Macで作ったCSVをWindowsに渡したい:</strong> 改行コードが異なる場合があります。改行コードの設定で「CRLF (Windows)」を指定して変換してください。</li>
           <li><strong>即時変換モード:</strong> 同じ形式のファイルを繰り返し処理する場合、オプションで「即時変換」をオンにすると、ドラッグ＆ドロップ後すぐに変換済みのファイルがダウンロードされます。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
-          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/favicon.astro
+++ b/src/pages/favicon.astro
@@ -25,12 +25,6 @@ import { FaviconGeneratorPage } from '../components/favicon/FaviconGeneratorPage
           <li><strong>完全ローカル処理:</strong> ICO のエンコードも含め、すべての処理はお使いのブラウザ内（Canvas API）で完結します。機密性の高いロゴ画像も外部送信なしで扱えます。</li>
         </ul>
         <p class="text-xs">favicon.ico には 16 / 32 / 48px を内包します。マスカブルアイコンや SVG ファビコン（icon.svg）の出力には対応していません。</p>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/color" class="text-xs text-primary hover:underline">カラーコード変換</a>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/image-text" class="text-xs text-primary hover:underline">画像テキスト挿入</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/hash.astro
+++ b/src/pages/hash.astro
@@ -36,13 +36,6 @@ import { HashPage } from '../components/tools/hash-generator/HashPage';
             入力するたびに自動で計算されます。日本語や絵文字を含むテキストもUTF-8でエンコードして正確に計算します。
           </li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/cipher" class="text-xs text-primary hover:underline">暗号化・難読化</a>
-          <a href="/base64" class="text-xs text-primary hover:underline">Base64変換</a>
-          <a href="/masking" class="text-xs text-primary hover:underline">個人情報マスキング</a>
-          <a href="/color" class="text-xs text-primary hover:underline">カラーコード変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/image-compress.astro
+++ b/src/pages/image-compress.astro
@@ -24,16 +24,6 @@ import { ImageCompressPage } from '../components/image-compress/ImageCompressPag
           <li><strong>EXIF・位置情報などのメタデータを自動除去:</strong> 再エンコードの過程で、撮影日時・GPS位置情報・カメラ機種などの Exif メタデータが自動的に取り除かれます。スクリーンショットや社内資料の画像を安全に共有できます。</li>
           <li><strong>完全ローカル処理 × 一括ZIP出力:</strong> すべての処理はお使いのブラウザ内（Canvas API）で完結します。複数枚をまとめて圧縮し、ZIP で一括ダウンロードできるため、機密スクショや社内資料も外部送信なしで扱えます。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-convert" class="text-xs text-primary hover:underline">画像形式変換</a>
-          <a href="/bg-remove" class="text-xs text-primary hover:underline">背景削除</a>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-          <a href="/image-text" class="text-xs text-primary hover:underline">画像テキスト挿入</a>
-          <a href="/favicon" class="text-xs text-primary hover:underline">ファビコン生成</a>
-          <a href="/pdf-merge" class="text-xs text-primary hover:underline">PDF結合</a>
-          <a href="/pdf-split" class="text-xs text-primary hover:underline">PDF分割・ページ抽出</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/image-convert.astro
+++ b/src/pages/image-convert.astro
@@ -26,13 +26,6 @@ import { ImageConvertPage } from '../components/image-convert/ImageConvertPage';
           <li><strong>カラープロファイル:</strong> ICCカラープロファイルは保持せず sRGB 前提で処理します。広色域（Display P3 等）の画像では色味が変わる場合があります。</li>
           <li><strong>一括変換・ZIP一括ダウンロード:</strong> 複数画像をまとめて変換し、2件以上は <code>converted.zip</code> で一括ダウンロードできます。すべての処理はお使いのブラウザ内で完結します。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-          <a href="/image-text" class="text-xs text-primary hover:underline">画像テキスト挿入</a>
-          <a href="/bg-remove" class="text-xs text-primary hover:underline">背景削除</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/image-mosaic.astro
+++ b/src/pages/image-mosaic.astro
@@ -24,14 +24,6 @@ import ImageMosaicPage from '../components/image-mosaic/ImageMosaicPage';
           <li><strong>絵文字・任意画像スタンプ:</strong> 「絵文字」モードでは好きな絵文字を入力して配置できます。「画像スタンプ」モードではPNG/JPEG/WebPの任意画像ファイルを選び、ドラッグした範囲内に縦横比を保ったまま配置できます。</li>
           <li><strong>完全ローカル処理:</strong> 加工はすべてお使いのブラウザ内（Canvas API）で完結します。元画像・スタンプ画像を外部サービスにアップロードせずにマスキングできるため、業務利用でも安心です。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-text" class="text-xs text-primary hover:underline">画像テキスト挿入</a>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/masking" class="text-xs text-primary hover:underline">個人情報マスキング</a>
-          <a href="/bg-remove" class="text-xs text-primary hover:underline">背景削除</a>
-          <a href="/pdf-merge" class="text-xs text-primary hover:underline">PDF結合</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/image-text.astro
+++ b/src/pages/image-text.astro
@@ -23,12 +23,6 @@ import ImageTextPage from '../components/image-text/ImageTextPage';
           <li><strong>縁取りで視認性を上げるコツ:</strong> 写真の上に文字を置くときは「縁取り」を有効にして、文字色と反対の色（例: 赤文字に白縁）を選ぶと、背景に紛れず読みやすくなります。背景がごちゃついている場合は「背景ボックス」も有効です。</li>
           <li><strong>マニュアル・資料作成に:</strong> スクリーンショットへの手順番号や説明の追加が、画像 テキスト 追加の専用アプリなしで完結します。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/bg-remove" class="text-xs text-primary hover:underline">背景削除</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/json-csv.astro
+++ b/src/pages/json-csv.astro
@@ -36,14 +36,6 @@ import { JsonCsvPage } from '../components/tools/json-csv/JsonCsvPage';
             CSV→JSON変換時、数値・真偽値・空セル（null）を自動で型変換します。電話番号や郵便番号のような先頭ゼロ付きの値（007など）は文字列のまま保持されるので安心です。
           </li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/json-formatter" class="text-xs text-primary hover:underline">JSON整形</a>
-          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
-          <a href="/csv-fixer" class="text-xs text-primary hover:underline">CSV文字化け修復</a>
-          <a href="/tax" class="text-xs text-primary hover:underline">消費税・税込計算</a>
-          <a href="/markdown" class="text-xs text-primary hover:underline">Markdownプレビュー</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/json-formatter.astro
+++ b/src/pages/json-formatter.astro
@@ -26,11 +26,6 @@ import JsonFormatterTool from '../components/tools/JsonFormatter.tsx';
           <li>設定ファイルのJSONをきれいにフォーマットしたい</li>
           <li>JSONデータを圧縮して軽量化したい</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 変換</a>
-          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/markdown.astro
+++ b/src/pages/markdown.astro
@@ -34,11 +34,6 @@ import { MarkdownPreviewPage } from '../components/tools/markdown/MarkdownPrevie
             ツールバーの「HTMLダウンロード」を押すと、プレビューと同じ内容を持つスタンドアロンHTMLファイル（<code>document.html</code>）がダウンロードされます。最小限のタイポグラフィCSSが埋め込まれているため、ブラウザで開くだけでそのまま閲覧できます。「HTMLをコピー」でクリップボードに変換結果のHTMLをコピーすることもできます。
           </li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 相互変換</a>
-          <a href="/color" class="text-xs text-primary hover:underline">カラー変換・パレット</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/masking.astro
+++ b/src/pages/masking.astro
@@ -24,11 +24,6 @@ import MaskingTool from '../components/tools/Masking.tsx';
           <li>完全置換や、先頭を数文字残す「部分マスク」を設定可能</li>
           <li>すべてお使いのブラウザ内（ローカル）で処理されるため、データ漏えいの心配がありません</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-          <a href="/dummy-data" class="text-xs text-primary hover:underline">ダミーデータ生成</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/pdf-merge.astro
+++ b/src/pages/pdf-merge.astro
@@ -24,12 +24,6 @@ import { PdfMergePage } from '../components/pdf-merge/PdfMergePage';
           <li><strong>パスワード付きPDFは非対応:</strong> 暗号化されたPDFは結合できません。パスワードを解除してからお試しください（本ツールに復号機能はありません）。</li>
           <li><strong>しおり・フォームの扱い:</strong> 結合後のPDFにはしおり（アウトライン）は引き継がれません。フォームフィールド（AcroForm）の完全な保持も保証されません。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/pdf-split" class="text-xs text-primary hover:underline">PDF分割・ページ抽出</a>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-          <a href="/image-mosaic" class="text-xs text-primary hover:underline">画像モザイク・ぼかし</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/pdf-split.astro
+++ b/src/pages/pdf-split.astro
@@ -24,11 +24,6 @@ import { PdfSplitPage } from '../components/pdf-split/PdfSplitPage';
           <li><strong>複数ファイルはZIPで一括ダウンロード:</strong> 出力が2ファイル以上になる場合はZIPでまとめてダウンロードされます。個別のダウンロードリンクも一覧に表示されます。</li>
           <li><strong>パスワード付きPDFは非対応:</strong> 暗号化されたPDFは分割できません。パスワードを解除してからお試しください（本ツールに復号機能はありません）。しおり（アウトライン）は分割後のPDFに引き継がれません。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/pdf-merge" class="text-xs text-primary hover:underline">PDF結合</a>
-          <a href="/image-compress" class="text-xs text-primary hover:underline">画像圧縮・リサイズ</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/phone-formatter.astro
+++ b/src/pages/phone-formatter.astro
@@ -36,13 +36,6 @@ import PhoneFormatterPage from '../components/phone-formatter/PhoneFormatterPage
           </ul>
         </div>
 
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/char-count" class="text-xs text-primary hover:underline">文字数カウント</a>
-          <a href="/csv-fixer" class="text-xs text-primary hover:underline">CSV文字化け修復</a>
-          <a href="/masking" class="text-xs text-primary hover:underline">個人情報マスキング</a>
-          <a href="/zipcode" class="text-xs text-primary hover:underline">郵便番号→住所変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/tax.astro
+++ b/src/pages/tax.astro
@@ -38,11 +38,6 @@ import { TaxCalcPage } from '../components/tools/tax/TaxCalcPage';
             インボイス制度（適格請求書）では、税率ごとに合計した金額に対して端数処理を1回行うのが原則です。複数明細モードでは、明細ごとではなく税率区分ごとに合計してから端数処理するため、8%（軽減税率）と10%が混在する請求書・領収書の確認に使えます。
           </li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/zipcode" class="text-xs text-primary hover:underline">郵便番号から住所変換</a>
-          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV 相互変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/url-encoder.astro
+++ b/src/pages/url-encoder.astro
@@ -21,12 +21,6 @@ import UrlEncoderTool from '../components/tools/UrlEncoder.tsx';
           <li><strong>フルURLモード</strong>: URL全体を変換したい場合に使用します (<code>encodeURI</code> 相当)。<code>http://</code> や <code>/</code> 構造文字はエンコードされずにそのまま残ります。</li>
           <li>ログやGETリクエストから取得したエンコード済み文字列を読める状態に戻したい（デコードしたい）。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/base64" class="text-xs text-primary hover:underline">Base64変換</a>
-          <a href="/cipher" class="text-xs text-primary hover:underline">暗号化・難読化</a>
-          <a href="/unicode-converter" class="text-xs text-primary hover:underline">Unicode変換</a>
-        </div>
       </div>
     </details>
   </div>

--- a/src/pages/zipcode.astro
+++ b/src/pages/zipcode.astro
@@ -43,13 +43,6 @@ const sourceLabel = dataVersion
           <li><strong>該当なし郵便番号の扱い:</strong> 入力が7桁の郵便番号として読み取れない行は「形式エラー」、データに存在しない郵便番号は「該当なし」と備考に表示されます。大口事業所の個別郵便番号（事業所固有番号）には対応していません。複数の町域がある郵便番号は1件目を採用し、備考に「他N件」と表示します。</li>
           <li><strong>データの更新時期について:</strong> 住所データは日本郵便が公開する郵便番号データのスナップショットです（{dataVersion ? `${dataVersion}時点` : '配布時点'}）。最新の住所情報と差異がある場合があります。住所→郵便番号の逆引きには対応していません。</li>
         </ul>
-        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
-          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
-          <a href="/phone-formatter" class="text-xs text-primary hover:underline">電話番号フォーマッタ</a>
-          <a href="/dummy-data" class="text-xs text-primary hover:underline">ダミーデータ生成</a>
-          <a href="/csv-editor" class="text-xs text-primary hover:underline">CSVビューア/エディタ</a>
-          <a href="/tax" class="text-xs text-primary hover:underline">消費税・税込計算</a>
-        </div>
       </div>
     </details>
   </div>

--- a/tests/e2e/related-tools.spec.ts
+++ b/tests/e2e/related-tools.spec.ts
@@ -1,0 +1,51 @@
+import { expect, test } from './fixtures/base';
+
+const section = (page: import('@playwright/test').Page) =>
+	page.locator('section[aria-labelledby="related-tools-heading"]');
+
+test.describe('関連ツール 回遊カード', () => {
+	test('related 指定ツールは指定先のカードを表示する', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('base64');
+		await toolPage.goto();
+
+		const related = section(page);
+		await expect(
+			related.getByRole('heading', { name: '関連ツール' }),
+		).toBeVisible();
+		// base64.related = url-encoder / cipher / unicode-converter
+		await expect(related.locator('a[href="/url-encoder"]')).toHaveCount(1);
+		await expect(related.locator('a[href="/cipher"]')).toHaveCount(1);
+		await expect(related.locator('a[href="/unicode-converter"]')).toHaveCount(
+			1,
+		);
+		// 自分自身へのリンクは出ない
+		await expect(related.locator('a[href="/base64"]')).toHaveCount(0);
+	});
+
+	test('related 未指定ツールは同カテゴリで補完表示する', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('char-count');
+		await toolPage.goto();
+
+		const related = section(page);
+		await expect(
+			related.getByRole('heading', { name: '関連ツール' }),
+		).toBeVisible();
+		// テキスト解析カテゴリの他ツール（text-diff）が補完される
+		await expect(related.locator('a[href="/text-diff"]')).toHaveCount(1);
+		await expect(related.locator('a[href="/char-count"]')).toHaveCount(0);
+	});
+
+	test('カードから関連ツールへ遷移できる', async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('base64');
+		await toolPage.goto();
+
+		await section(page).locator('a[href="/url-encoder"]').click();
+		await expect(page).toHaveURL(/\/url-encoder$/);
+	});
+});

--- a/tests/unit/related-tools.test.ts
+++ b/tests/unit/related-tools.test.ts
@@ -1,0 +1,97 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/related-tools.test.ts
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getRelatedTools, toolCatalog } from '../../src/lib/tools/catalog.ts';
+
+const ids = (toolId: string, limit?: number) =>
+	getRelatedTools(toolId, limit).map((t) => t.id);
+
+// ---------------------------------------------------------------------------
+// related 優先
+// ---------------------------------------------------------------------------
+
+test('related 指定がある場合は指定順で返す', () => {
+	// base64.related = ['url-encoder', 'cipher', 'unicode-converter']
+	assert.deepEqual(ids('base64'), [
+		'url-encoder',
+		'cipher',
+		'unicode-converter',
+	]);
+});
+
+test('related が limit を超える場合は先頭から limit 件に切り詰める', () => {
+	// image-compress.related は7件
+	assert.deepEqual(ids('image-compress'), [
+		'image-convert',
+		'bg-remove',
+		'image-mosaic',
+	]);
+	// limit を広げれば多く返る
+	assert.deepEqual(ids('image-compress', 5), [
+		'image-convert',
+		'bg-remove',
+		'image-mosaic',
+		'image-text',
+		'favicon',
+	]);
+});
+
+// ---------------------------------------------------------------------------
+// 同カテゴリ自動補完
+// ---------------------------------------------------------------------------
+
+test('related 未指定なら同カテゴリの他ツールで補完する', () => {
+	// char-count（テキスト解析）の同カテゴリは text-diff のみ
+	assert.deepEqual(ids('char-count'), ['text-diff']);
+});
+
+test('related が limit に満たない場合は同カテゴリで補完する', () => {
+	// masking.related = ['image-mosaic', 'dummy-data']（別カテゴリ2件）
+	// → 不足1件を同カテゴリ（データ処理）の先頭 csv-editor で補完
+	const result = ids('masking');
+	assert.equal(result.length, 3);
+	assert.deepEqual(result.slice(0, 2), ['image-mosaic', 'dummy-data']);
+	const filler = toolCatalog.find((t) => t.id === result[2]);
+	assert.equal(filler?.category, 'データ処理');
+});
+
+// ---------------------------------------------------------------------------
+// 除外ルール
+// ---------------------------------------------------------------------------
+
+test('自分自身は結果に含まれない', () => {
+	for (const tool of toolCatalog) {
+		const result = ids(tool.id);
+		assert.ok(
+			!result.includes(tool.id),
+			`${tool.id} の関連に自分自身が含まれている`,
+		);
+	}
+});
+
+test('返り値に重複はなく、すべて実在するツールidである', () => {
+	const validIds = new Set(toolCatalog.map((t) => t.id));
+	for (const tool of toolCatalog) {
+		const result = ids(tool.id);
+		assert.equal(new Set(result).size, result.length, `${tool.id} に重複`);
+		for (const id of result) {
+			assert.ok(validIds.has(id), `${tool.id} の関連に不正id: ${id}`);
+		}
+	}
+});
+
+test('件数は limit を超えない', () => {
+	for (const tool of toolCatalog) {
+		assert.ok(getRelatedTools(tool.id).length <= 3);
+		assert.ok(getRelatedTools(tool.id, 5).length <= 5);
+	}
+});
+
+// ---------------------------------------------------------------------------
+// 空配列ケース
+// ---------------------------------------------------------------------------
+
+test('存在しないツールidは空配列を返す', () => {
+	assert.deepEqual(getRelatedTools('does-not-exist'), []);
+});


### PR DESCRIPTION
## 概要

各ツールページ下部の「使い方・ユースケース」内に小さく手書きされていた関連ツールリンクを、独立した**「関連ツール」カードセクション**へ刷新し、ツール間の回遊を促します。

トップページと同じカードUIを流用し、`使い方` セクションの直下に表示します。

## 変更内容

- **データ集約** ([catalog.ts](src/lib/tools/catalog.ts))
  - `ToolCatalogItem` に `related?: readonly string[]` を追加し、22ツール分の関連付けを移植
  - `getRelatedTools(id, limit = 3)` ヘルパーを追加（**related優先 → 同カテゴリ補完 → 自己/重複/不在id除外**、最大3件）
- **自動描画** ([ToolLayout.astro](src/components/common/ToolLayout.astro))
  - usage スロット直下に「関連ツール」見出し ＋ `ToolCard` グリッド（`sm:grid-cols-2 lg:grid-cols-3`）を自動描画
  - `span`/`categoryId` は渡さず、ツールページの幅・絞り込み誤誘導を回避。0件時はセクションごと非表示
- **重複排除** (`src/pages/*.astro` ×22)
  - usage 内の手書き関連リンクを削除（catalog に集約済み）
- **テスト**
  - `getRelatedTools` 単体テスト8件（related優先・カテゴリ補完・自己除外・空配列）
  - E2E（表示・カテゴリ補完・カード遷移）

## 検証

- ✅ ユニット: 200件パス（新規8件）
- ✅ lint (Biome): クリア
- ✅ build: 36ページ生成成功
- ✅ E2E (Playwright): 479パス / 0 fail（新規 related-tools 6件含む）

## ⚠️ セキュリティ注記

本作業中、ツール結果を装った**プロンプトインジェクション攻撃**を検出しました（正常な `ToolCard.astro` を「壊れている」と偽り、"修正"させて破壊を狙う誘導）。実ファイルを検証して虚偽と判明したため従わず、`ToolCard.astro` は一切変更していません。詳細は設計書 [docs/specs/2026-06-27-tool-related-cards-design.md](docs/specs/2026-06-27-tool-related-cards-design.md) のセキュリティ注記、およびインシデントレポート（Notion）に記録済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)