### PR TITLE
feat: 画像Base64/Data URI変換ツール（/image-base64）を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@
 | [暗号変換](/cipher) | シーザー暗号・ROT13・モールス信号・逆順等のテキスト変換 |
 | [カラーコード変換](/color) | HEX・RGB・HSL・CMYKの相互変換。カラーピッカー連動・ワンクリックコピー |
 | [ファビコン生成](/favicon) | 画像から favicon.ico・各サイズPNG・apple-touch-icon・site.webmanifest を一括生成。アップロード不要・HTMLタグ出力対応（完全ローカル実行） |
+| [画像Base64変換](/image-base64) | 画像をBase64/Data URIへ相互変換。`<img>`タグ・CSS `url()` スニペット出力。逆変換対応 |
 
 ## 🛡️ セキュリティ
 

--- a/src/components/image-base64/ImageBase64Page.tsx
+++ b/src/components/image-base64/ImageBase64Page.tsx
@@ -1,0 +1,330 @@
+import {
+	AlertTriangle,
+	Download,
+	FileImage,
+	ImageIcon,
+	Loader2,
+} from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import CopyButton from '@/components/common/CopyButton';
+import { FileDropzone } from '@/components/common/FileDropzone';
+import { Button } from '@/components/ui/button';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Textarea } from '@/components/ui/textarea';
+import {
+	buildSnippet,
+	dataUriToBlob,
+	estimateSize,
+	fileToDataUri,
+	formatBytes,
+	type SnippetKind,
+	validateImageFile,
+} from '@/lib/tools/image-base64';
+import { downloadBlob } from '@/lib/tools/image-common';
+
+type Mode = 'encode' | 'decode';
+
+const ACCEPT =
+	'image/png,image/jpeg,image/webp,image/gif,image/svg+xml,.png,.jpg,.jpeg,.webp,.gif,.svg';
+const MAX_SIZE = 10 * 1024 * 1024;
+
+const SNIPPET_KINDS: { kind: SnippetKind; label: string }[] = [
+	{ kind: 'data-uri', label: 'Data URI' },
+	{ kind: 'raw-base64', label: 'Base64' },
+	{ kind: 'img', label: '<img> タグ' },
+	{ kind: 'css-bg', label: 'CSS background' },
+];
+
+const PREVIEW_LENGTH = 120;
+
+function truncate(s: string): string {
+	return s.length > PREVIEW_LENGTH ? `${s.slice(0, PREVIEW_LENGTH)}…` : s;
+}
+
+export function ImageBase64Page() {
+	const [mode, setMode] = useState<Mode>('encode');
+
+	const [file, setFile] = useState<File | null>(null);
+	const [dataUri, setDataUri] = useState<string | null>(null);
+	const [converting, setConverting] = useState(false);
+	const [encodeError, setEncodeError] = useState<string | null>(null);
+
+	const [decodeInput, setDecodeInput] = useState('');
+	const [decodedUrl, setDecodedUrl] = useState<string | null>(null);
+	const [decodedMime, setDecodedMime] = useState<string | null>(null);
+	const [decodedExt, setDecodedExt] = useState<string | null>(null);
+	const [decodedBlob, setDecodedBlob] = useState<Blob | null>(null);
+	const [decodeError, setDecodeError] = useState<string | null>(null);
+
+	const decodedUrlRef = useRef<string | null>(null);
+
+	const handleModeChange = useCallback((v: string) => {
+		setMode(v as Mode);
+		setEncodeError(null);
+		setDecodeError(null);
+	}, []);
+
+	// --- Encode ---
+
+	const handleFileSelect = useCallback(async (f: File) => {
+		const validation = validateImageFile(f);
+		if (!validation.ok) {
+			setEncodeError(validation.message);
+			return;
+		}
+		setFile(f);
+		setEncodeError(null);
+		setConverting(true);
+		try {
+			const uri = await fileToDataUri(f);
+			setDataUri(uri);
+		} catch (err) {
+			setEncodeError(
+				err instanceof Error ? err.message : '変換に失敗しました。',
+			);
+		} finally {
+			setConverting(false);
+		}
+	}, []);
+
+	const handleClearFile = useCallback(() => {
+		setFile(null);
+		setDataUri(null);
+		setEncodeError(null);
+	}, []);
+
+	const snippets = useMemo(() => {
+		if (!dataUri) return null;
+		return SNIPPET_KINDS.map(({ kind, label }) => ({
+			kind,
+			label,
+			full: buildSnippet(dataUri, kind),
+		}));
+	}, [dataUri]);
+
+	const sizeInfo = useMemo(() => {
+		if (!dataUri) return null;
+		return estimateSize(dataUri);
+	}, [dataUri]);
+
+	// --- Decode ---
+
+	useEffect(() => {
+		if (mode !== 'decode' || decodeInput.trim() === '') {
+			if (decodedUrlRef.current) {
+				URL.revokeObjectURL(decodedUrlRef.current);
+				decodedUrlRef.current = null;
+			}
+			setDecodedUrl(null);
+			setDecodedMime(null);
+			setDecodedExt(null);
+			setDecodedBlob(null);
+			setDecodeError(null);
+			return;
+		}
+
+		const timer = setTimeout(() => {
+			try {
+				const { blob, mime, ext } = dataUriToBlob(decodeInput);
+				if (decodedUrlRef.current) {
+					URL.revokeObjectURL(decodedUrlRef.current);
+				}
+				const url = URL.createObjectURL(blob);
+				decodedUrlRef.current = url;
+				setDecodedUrl(url);
+				setDecodedMime(mime);
+				setDecodedExt(ext);
+				setDecodedBlob(blob);
+				setDecodeError(null);
+			} catch (err) {
+				if (decodedUrlRef.current) {
+					URL.revokeObjectURL(decodedUrlRef.current);
+					decodedUrlRef.current = null;
+				}
+				setDecodedUrl(null);
+				setDecodedMime(null);
+				setDecodedExt(null);
+				setDecodedBlob(null);
+				setDecodeError(
+					err instanceof Error ? err.message : 'デコードに失敗しました。',
+				);
+			}
+		}, 300);
+
+		return () => clearTimeout(timer);
+	}, [mode, decodeInput]);
+
+	useEffect(() => {
+		return () => {
+			if (decodedUrlRef.current) {
+				URL.revokeObjectURL(decodedUrlRef.current);
+			}
+		};
+	}, []);
+
+	const handleDownload = useCallback(() => {
+		if (decodedBlob && decodedExt) {
+			downloadBlob(decodedBlob, `decoded.${decodedExt}`);
+		}
+	}, [decodedBlob, decodedExt]);
+
+	return (
+		<Tabs value={mode} onValueChange={handleModeChange}>
+			<TabsList className="w-full grid grid-cols-2">
+				<TabsTrigger value="encode" data-testid="tab-encode">
+					<FileImage className="h-4 w-4 mr-1" />
+					画像 → Base64
+				</TabsTrigger>
+				<TabsTrigger value="decode" data-testid="tab-decode">
+					<ImageIcon className="h-4 w-4 mr-1" />
+					Base64 → 画像
+				</TabsTrigger>
+			</TabsList>
+
+			{/* === Encode Tab === */}
+			<TabsContent value="encode" className="mt-4 space-y-4">
+				<FileDropzone
+					onFileSelect={handleFileSelect}
+					onValidationError={setEncodeError}
+					accept={ACCEPT}
+					maxSizeBytes={MAX_SIZE}
+					validationMessage="ファイルサイズが10MBを超えています。"
+					label="画像をドラッグ＆ドロップ"
+					description="PNG / JPEG / WebP / GIF / SVG（最大10MB）"
+					privacyNote="🔒 画像はサーバーに送信されません。すべてブラウザ内で処理されます。"
+					selectedFileName={file?.name ?? null}
+					onClear={handleClearFile}
+					disabled={converting}
+					inputAriaLabel="Base64変換する画像を選択"
+					data-testid="encode-file-input"
+				/>
+
+				{encodeError && (
+					<div
+						className="rounded-lg border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
+						role="alert"
+					>
+						{encodeError}
+					</div>
+				)}
+
+				{converting && (
+					<div className="flex items-center gap-2 text-sm text-muted-foreground">
+						<Loader2 className="h-4 w-4 animate-spin text-primary" />
+						<span>変換中…</span>
+					</div>
+				)}
+
+				{sizeInfo && (
+					<div className="flex flex-wrap gap-3 text-sm">
+						<span className="rounded-md bg-muted px-2 py-1">
+							元サイズ: {formatBytes(sizeInfo.originalBytes)}
+						</span>
+						<span className="rounded-md bg-muted px-2 py-1">
+							Base64: {formatBytes(sizeInfo.base64TextBytes)}
+						</span>
+						<span className="rounded-md bg-muted px-2 py-1">
+							肥大率: +{sizeInfo.inflationPct}%
+						</span>
+					</div>
+				)}
+
+				{sizeInfo && sizeInfo.inflationPct > 0 && (
+					<div className="flex items-start gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/5 p-3 text-sm text-muted-foreground">
+						<AlertTriangle className="h-4 w-4 mt-0.5 shrink-0 text-yellow-600 dark:text-yellow-400" />
+						<span>
+							Data
+							URIは元サイズより約33%大きくなります。大きな画像のインライン化は非推奨です。
+						</span>
+					</div>
+				)}
+
+				{snippets && (
+					<div className="space-y-3" data-testid="snippet-results">
+						<h2 className="text-sm font-semibold">変換結果</h2>
+						{snippets.map(({ kind, label, full }) => (
+							<div
+								key={kind}
+								className="rounded-lg border border-border p-3"
+								data-testid={`snippet-${kind}`}
+							>
+								<div className="flex items-center justify-between gap-2 mb-2">
+									<span className="text-xs font-semibold text-muted-foreground">
+										{label}
+									</span>
+									<CopyButton text={full} size="sm" variant="ghost" />
+								</div>
+								<p className="font-mono text-xs break-all text-muted-foreground max-h-20 overflow-hidden">
+									{truncate(full)}
+								</p>
+							</div>
+						))}
+					</div>
+				)}
+			</TabsContent>
+
+			{/* === Decode Tab === */}
+			<TabsContent value="decode" className="mt-4 space-y-4">
+				<div className="space-y-2">
+					<label htmlFor="decode-input" className="text-sm font-medium">
+						Base64 / Data URI を貼り付け
+					</label>
+					<Textarea
+						id="decode-input"
+						value={decodeInput}
+						onChange={(e) => setDecodeInput(e.target.value)}
+						placeholder="data:image/png;base64,iVBORw0KGgo... または Base64 文字列"
+						rows={5}
+						className="font-mono text-xs"
+						data-testid="decode-input"
+					/>
+				</div>
+
+				{decodeError && (
+					<div
+						className="rounded-lg border border-destructive/50 bg-destructive/5 p-3 text-sm text-destructive"
+						role="alert"
+						data-testid="decode-error"
+					>
+						{decodeError}
+					</div>
+				)}
+
+				{decodedUrl && (
+					<div className="space-y-3" data-testid="decode-result">
+						<h2 className="text-sm font-semibold">プレビュー</h2>
+						<div className="rounded-lg border border-border p-4 flex items-center justify-center bg-[repeating-conic-gradient(var(--color-muted)_0%_25%,transparent_0%_50%)] bg-[length:16px_16px]">
+							<img
+								src={decodedUrl}
+								alt="デコード結果"
+								className="max-w-full max-h-64 object-contain"
+								data-testid="decode-preview"
+							/>
+						</div>
+						<div className="flex items-center gap-3">
+							{decodedMime && (
+								<span className="text-xs text-muted-foreground rounded-md bg-muted px-2 py-1">
+									{decodedMime}
+								</span>
+							)}
+							{decodedBlob && (
+								<span className="text-xs text-muted-foreground rounded-md bg-muted px-2 py-1">
+									{formatBytes(decodedBlob.size)}
+								</span>
+							)}
+							<Button
+								size="sm"
+								variant="outline"
+								onClick={handleDownload}
+								data-testid="decode-download"
+							>
+								<Download className="h-4 w-4" />
+								<span className="ml-1">ダウンロード</span>
+							</Button>
+						</div>
+					</div>
+				)}
+			</TabsContent>
+		</Tabs>
+	);
+}

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -420,6 +420,25 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 			'PWAアイコン',
 		],
 	},
+	{
+		id: 'image-base64',
+		title: '画像Base64変換',
+		description: '画像をBase64/Data URIへ相互変換。データは外部送信なし。',
+		href: '/image-base64',
+		icon: '🔣',
+		category: '開発ツール',
+		categoryColor: 'border-l-chart-1',
+		keywords: [
+			'Base64',
+			'Data URI',
+			'画像変換',
+			'img',
+			'CSS',
+			'base64',
+			'データURI',
+			'インライン画像',
+		],
+	},
 ];
 
 // カテゴリーサマリーのチップ色（categoryColor の border-l-* と対になる bg/text クラス）

--- a/src/lib/tools/image-base64.ts
+++ b/src/lib/tools/image-base64.ts
@@ -154,7 +154,11 @@ export function dataUriToBlob(input: string): {
 	}
 
 	const ext = MIME_TO_EXT[mime] ?? 'bin';
-	return { blob: new Blob([bytes], { type: mime }), mime, ext };
+	return {
+		blob: new Blob([bytes.buffer as ArrayBuffer], { type: mime }),
+		mime,
+		ext,
+	};
 }
 
 export function estimateSize(dataUri: string): SizeEstimate {

--- a/src/lib/tools/image-base64.ts
+++ b/src/lib/tools/image-base64.ts
@@ -1,0 +1,180 @@
+export type SnippetKind = 'img' | 'css-bg' | 'raw-base64' | 'data-uri';
+
+export type ImageInputValidation =
+	| { ok: true; mime: string }
+	| {
+			ok: false;
+			reason: 'unsupported-type' | 'too-large';
+			message: string;
+	  };
+
+export type SizeEstimate = {
+	originalBytes: number;
+	base64TextBytes: number;
+	inflationPct: number;
+};
+
+const SUPPORTED_MIMES = new Set([
+	'image/png',
+	'image/jpeg',
+	'image/webp',
+	'image/gif',
+	'image/svg+xml',
+]);
+
+const MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+const MIME_TO_EXT: Record<string, string> = {
+	'image/png': 'png',
+	'image/jpeg': 'jpg',
+	'image/webp': 'webp',
+	'image/gif': 'gif',
+	'image/svg+xml': 'svg',
+};
+
+export function validateImageFile(file: File): ImageInputValidation {
+	if (!SUPPORTED_MIMES.has(file.type)) {
+		return {
+			ok: false,
+			reason: 'unsupported-type',
+			message:
+				'対応していない形式です。PNG / JPEG / WebP / GIF / SVG を選択してください。',
+		};
+	}
+	if (file.size > MAX_FILE_SIZE) {
+		return {
+			ok: false,
+			reason: 'too-large',
+			message: 'ファイルサイズが10MBを超えています。',
+		};
+	}
+	return { ok: true, mime: file.type };
+}
+
+export function fileToDataUri(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader();
+		reader.onload = () => resolve(reader.result as string);
+		reader.onerror = () =>
+			reject(new Error('ファイルの読み込みに失敗しました。'));
+		reader.readAsDataURL(file);
+	});
+}
+
+export function toBase64(dataUri: string): string {
+	const idx = dataUri.indexOf(',');
+	if (idx === -1) {
+		throw new Error(
+			'不正な Data URI です。"data:<mime>;base64," 形式で入力してください。',
+		);
+	}
+	return dataUri.slice(idx + 1);
+}
+
+export function buildSnippet(dataUri: string, kind: SnippetKind): string {
+	switch (kind) {
+		case 'data-uri':
+			return dataUri;
+		case 'raw-base64':
+			return toBase64(dataUri);
+		case 'img':
+			return `<img src="${dataUri}" alt="" />`;
+		case 'css-bg':
+			return `background-image: url("${dataUri}");`;
+	}
+}
+
+const MAGIC_BYTES: [string, string][] = [
+	['iVBOR', 'image/png'],
+	['/9j/', 'image/jpeg'],
+	['R0lGO', 'image/gif'],
+	['UklGR', 'image/webp'],
+];
+
+export function detectMimeFromBase64(b64: string): string | null {
+	for (const [prefix, mime] of MAGIC_BYTES) {
+		if (b64.startsWith(prefix)) return mime;
+	}
+	if (b64.startsWith('PD') || b64.startsWith('PHN')) {
+		return 'image/svg+xml';
+	}
+	return null;
+}
+
+function normalizeBase64Input(input: string): string {
+	return input.replace(/[\s\r\n]/g, '');
+}
+
+export function dataUriToBlob(input: string): {
+	blob: Blob;
+	mime: string;
+	ext: string;
+} {
+	const cleaned = normalizeBase64Input(input);
+
+	let mime: string | null = null;
+	let b64: string;
+
+	const dataUriMatch = cleaned.match(/^data:([^;,]+);base64,(.+)$/);
+	if (dataUriMatch) {
+		mime = dataUriMatch[1];
+		b64 = dataUriMatch[2];
+	} else {
+		b64 = cleaned;
+	}
+
+	const detectedMime = detectMimeFromBase64(b64);
+	if (detectedMime) {
+		mime = detectedMime;
+	}
+
+	if (!mime) {
+		throw new Error(
+			'MIMEタイプを判定できません。Data URI形式（data:image/png;base64,...）で入力するか、有効な画像のBase64を入力してください。',
+		);
+	}
+
+	if (!SUPPORTED_MIMES.has(mime)) {
+		throw new Error(
+			`対応していない形式です（${mime}）。画像（PNG / JPEG / WebP / GIF / SVG）のBase64を入力してください。`,
+		);
+	}
+
+	let bytes: Uint8Array;
+	try {
+		const binary = atob(b64);
+		bytes = new Uint8Array(binary.length);
+		for (let i = 0; i < binary.length; i++) {
+			bytes[i] = binary.charCodeAt(i);
+		}
+	} catch {
+		throw new Error(
+			'Base64のデコードに失敗しました。有効なBase64文字列を入力してください。',
+		);
+	}
+
+	const ext = MIME_TO_EXT[mime] ?? 'bin';
+	return { blob: new Blob([bytes], { type: mime }), mime, ext };
+}
+
+export function estimateSize(dataUri: string): SizeEstimate {
+	const b64 = toBase64(dataUri);
+	const base64TextBytes = b64.length;
+	const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0;
+	const originalBytes = Math.floor((b64.length * 3) / 4 - padding);
+	const inflationPct =
+		originalBytes > 0
+			? Math.round(((base64TextBytes - originalBytes) / originalBytes) * 100)
+			: 0;
+	return { originalBytes, base64TextBytes, inflationPct };
+}
+
+export function extensionForMime(mime: string): string {
+	return MIME_TO_EXT[mime] ?? 'bin';
+}
+
+export function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+}

--- a/src/pages/image-base64.astro
+++ b/src/pages/image-base64.astro
@@ -1,0 +1,51 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import { ImageBase64Page } from '../components/image-base64/ImageBase64Page';
+---
+
+<ToolLayout
+  title="画像 Base64 / Data URI 変換（相互変換）"
+  description="画像をBase64・Data URIに変換し、imgタグやCSSのurl()スニペットを出力できる無料ツール。Base64から画像への逆変換にも対応。完全クライアントサイド処理で画像はサーバーに送信されません。"
+  path="/image-base64"
+>
+  <ImageBase64Page client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4" open>
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>
+          画像ファイルをBase64エンコードし、Data URI・<code>&lt;img&gt;</code>タグ・CSS <code>background-image: url()</code> のスニペットをワンクリックでコピーできます。Base64文字列から画像への逆変換（デコード）にも対応しています。すべてブラウザ内で処理されるため、画像がサーバーにアップロードされることはありません。
+        </p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>
+            <strong>Data URIの用途:</strong>
+            小さなアイコンやロゴをHTML/CSSにインライン埋め込みすると、HTTPリクエストを削減できます。メールテンプレートへの画像埋め込みにも便利です。
+          </li>
+          <li>
+            <strong>肥大率に注意:</strong>
+            Base64エンコードすると元のファイルサイズより<strong>約33%大きく</strong>なります。数KB以下の小さな画像のインライン化には有効ですが、大きな画像には通常のファイル配信を推奨します。
+          </li>
+          <li>
+            <strong>対応形式:</strong>
+            PNG・JPEG・WebP・GIF・SVGに対応しています。ファイルサイズの上限は10MBです。
+          </li>
+          <li>
+            <strong>逆変換（Base64 → 画像）:</strong>
+            <code>data:image/...;base64,</code> 形式のData URI、または生のBase64文字列を貼り付けると、画像としてプレビュー・ダウンロードできます。マジックバイトから形式を自動判定します。
+          </li>
+        </ul>
+        <div class="flex flex-wrap gap-3 pt-2 border-t border-border">
+          <span class="text-xs font-medium text-muted-foreground">関連ツール:</span>
+          <a href="/hash" class="text-xs text-primary hover:underline">ハッシュ値計算</a>
+          <a href="/base64" class="text-xs text-primary hover:underline">Base64変換（テキスト）</a>
+          <a href="/json-csv" class="text-xs text-primary hover:underline">JSON ↔ CSV変換</a>
+          <a href="/color" class="text-xs text-primary hover:underline">カラーコード変換</a>
+        </div>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/tests/e2e/image-base64.spec.ts
+++ b/tests/e2e/image-base64.spec.ts
@@ -1,0 +1,137 @@
+import path from 'node:path';
+import { expect, test } from './fixtures/base';
+
+const FIX = (name: string) =>
+	path.join(process.cwd(), 'tests', 'e2e', 'fixtures', name);
+
+const PNG = FIX('sample-400x300.png');
+
+test.describe('画像 Base64 / Data URI 変換', () => {
+	test.beforeEach(async ({ createToolPage }) => {
+		const toolPage = createToolPage('image-base64');
+		await toolPage.goto();
+	});
+
+	test('ページ表示とSafetyBadge', async ({ createToolPage }) => {
+		const toolPage = createToolPage('image-base64');
+		await toolPage.expectTitle('画像 Base64 / Data URI 変換');
+		await toolPage.expectSafetyBadge();
+	});
+
+	test('画像投入 → Data URIスニペットが表示される', async ({ page }) => {
+		await page
+			.getByTestId('encode-file-input')
+			.setInputFiles(PNG);
+
+		const results = page.getByTestId('snippet-results');
+		await expect(results).toBeVisible({ timeout: 10_000 });
+
+		const dataUriSnippet = page.getByTestId('snippet-data-uri');
+		await expect(dataUriSnippet).toBeVisible();
+		await expect(dataUriSnippet).toContainText('data:image/png;base64,');
+
+		const imgSnippet = page.getByTestId('snippet-img');
+		await expect(imgSnippet).toBeVisible();
+		await expect(imgSnippet).toContainText('<img src=');
+
+		const cssSnippet = page.getByTestId('snippet-css-bg');
+		await expect(cssSnippet).toBeVisible();
+		await expect(cssSnippet).toContainText('background-image: url(');
+	});
+
+	test('サイズ情報と肥大率が表示される', async ({ page }) => {
+		await page
+			.getByTestId('encode-file-input')
+			.setInputFiles(PNG);
+
+		await expect(page.getByTestId('snippet-results')).toBeVisible({
+			timeout: 10_000,
+		});
+
+		await expect(page.getByText('元サイズ:')).toBeVisible();
+		await expect(page.getByText('Base64:')).toBeVisible();
+		await expect(page.getByText('肥大率:')).toBeVisible();
+	});
+
+	test('コピーボタンで表示が「コピー済み」に変わる', async ({ page }) => {
+		await page
+			.getByTestId('encode-file-input')
+			.setInputFiles(PNG);
+
+		await expect(page.getByTestId('snippet-results')).toBeVisible({
+			timeout: 10_000,
+		});
+
+		const copyBtn = page
+			.getByTestId('snippet-data-uri')
+			.getByRole('button', { name: /コピー/ });
+		await copyBtn.click();
+		await expect(
+			page
+				.getByTestId('snippet-data-uri')
+				.getByRole('button', { name: 'コピーしました' }),
+		).toBeVisible();
+	});
+
+	test('Base64貼り付け → プレビュー表示 → ダウンロード', async ({ page }) => {
+		await page.getByTestId('tab-decode').click();
+
+		const b64 =
+			'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg==';
+		await page.getByTestId('decode-input').fill(b64);
+
+		const preview = page.getByTestId('decode-preview');
+		await expect(preview).toBeVisible({ timeout: 5_000 });
+
+		const downloadBtn = page.getByTestId('decode-download');
+		await expect(downloadBtn).toBeVisible();
+
+		const downloadPromise = page.waitForEvent('download');
+		await downloadBtn.click();
+		const download = await downloadPromise;
+		expect(download.suggestedFilename()).toBe('decoded.png');
+	});
+
+	test('不正なBase64でエラー表示', async ({ page }) => {
+		await page.getByTestId('tab-decode').click();
+		await page.getByTestId('decode-input').fill('this-is-not-valid-base64!!!');
+
+		const error = page.getByTestId('decode-error');
+		await expect(error).toBeVisible({ timeout: 5_000 });
+	});
+
+	test('レスポンシブ表示（375px / 1440px）', async ({ page }) => {
+		await page.setViewportSize({ width: 375, height: 667 });
+		await expect(page.getByTestId('tab-encode')).toBeVisible();
+		await expect(page.getByTestId('tab-decode')).toBeVisible();
+
+		await page.setViewportSize({ width: 1440, height: 900 });
+		await expect(page.getByTestId('tab-encode')).toBeVisible();
+		await expect(page.getByTestId('tab-decode')).toBeVisible();
+	});
+
+	test('画像アップロード時にネットワークリクエストが飛ばない', async ({
+		page,
+	}) => {
+		const requests: string[] = [];
+		page.on('request', (req) => {
+			const url = req.url();
+			if (
+				!url.startsWith('data:') &&
+				!url.includes('localhost') &&
+				!url.includes('127.0.0.1')
+			) {
+				requests.push(url);
+			}
+		});
+
+		await page
+			.getByTestId('encode-file-input')
+			.setInputFiles(PNG);
+		await expect(page.getByTestId('snippet-results')).toBeVisible({
+			timeout: 10_000,
+		});
+
+		expect(requests).toEqual([]);
+	});
+});

--- a/tests/e2e/image-base64.spec.ts
+++ b/tests/e2e/image-base64.spec.ts
@@ -19,9 +19,7 @@ test.describe('画像 Base64 / Data URI 変換', () => {
 	});
 
 	test('画像投入 → Data URIスニペットが表示される', async ({ page }) => {
-		await page
-			.getByTestId('encode-file-input')
-			.setInputFiles(PNG);
+		await page.getByTestId('encode-file-input').setInputFiles(PNG);
 
 		const results = page.getByTestId('snippet-results');
 		await expect(results).toBeVisible({ timeout: 10_000 });
@@ -40,9 +38,7 @@ test.describe('画像 Base64 / Data URI 変換', () => {
 	});
 
 	test('サイズ情報と肥大率が表示される', async ({ page }) => {
-		await page
-			.getByTestId('encode-file-input')
-			.setInputFiles(PNG);
+		await page.getByTestId('encode-file-input').setInputFiles(PNG);
 
 		await expect(page.getByTestId('snippet-results')).toBeVisible({
 			timeout: 10_000,
@@ -54,9 +50,7 @@ test.describe('画像 Base64 / Data URI 変換', () => {
 	});
 
 	test('コピーボタンで表示が「コピー済み」に変わる', async ({ page }) => {
-		await page
-			.getByTestId('encode-file-input')
-			.setInputFiles(PNG);
+		await page.getByTestId('encode-file-input').setInputFiles(PNG);
 
 		await expect(page.getByTestId('snippet-results')).toBeVisible({
 			timeout: 10_000,
@@ -125,9 +119,7 @@ test.describe('画像 Base64 / Data URI 変換', () => {
 			}
 		});
 
-		await page
-			.getByTestId('encode-file-input')
-			.setInputFiles(PNG);
+		await page.getByTestId('encode-file-input').setInputFiles(PNG);
 		await expect(page.getByTestId('snippet-results')).toBeVisible({
 			timeout: 10_000,
 		});

--- a/tests/unit/image-base64.test.ts
+++ b/tests/unit/image-base64.test.ts
@@ -1,0 +1,291 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	buildSnippet,
+	dataUriToBlob,
+	detectMimeFromBase64,
+	estimateSize,
+	extensionForMime,
+	formatBytes,
+	toBase64,
+	validateImageFile,
+} from '../../src/lib/tools/image-base64.ts';
+
+// ---------------------------------------------------------------------------
+// テスト用ヘルパー
+// ---------------------------------------------------------------------------
+
+function pngBase64(): string {
+	const header = new Uint8Array([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	]);
+	let binary = '';
+	for (const b of header) binary += String.fromCharCode(b);
+	return btoa(binary);
+}
+
+function jpegBase64(): string {
+	const header = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]);
+	let binary = '';
+	for (const b of header) binary += String.fromCharCode(b);
+	return btoa(binary);
+}
+
+function gifBase64(): string {
+	const header = new Uint8Array([
+		0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00,
+	]);
+	let binary = '';
+	for (const b of header) binary += String.fromCharCode(b);
+	return btoa(binary);
+}
+
+function webpBase64(): string {
+	const bytes = new Uint8Array([
+		0x52, 0x49, 0x46, 0x46, 0x00, 0x00, 0x00, 0x00, 0x57, 0x45, 0x42, 0x50,
+	]);
+	let binary = '';
+	for (const b of bytes) binary += String.fromCharCode(b);
+	return btoa(binary);
+}
+
+// ---------------------------------------------------------------------------
+// validateImageFile
+// ---------------------------------------------------------------------------
+
+test('validateImageFile: PNG は OK', () => {
+	const file = new File([new Uint8Array(100)], 'test.png', {
+		type: 'image/png',
+	});
+	const result = validateImageFile(file);
+	assert.equal(result.ok, true);
+	if (result.ok) assert.equal(result.mime, 'image/png');
+});
+
+test('validateImageFile: SVG は OK', () => {
+	const file = new File(['<svg></svg>'], 'test.svg', {
+		type: 'image/svg+xml',
+	});
+	const result = validateImageFile(file);
+	assert.equal(result.ok, true);
+	if (result.ok) assert.equal(result.mime, 'image/svg+xml');
+});
+
+test('validateImageFile: 非対応形式は unsupported-type', () => {
+	const file = new File([new Uint8Array(100)], 'test.bmp', {
+		type: 'image/bmp',
+	});
+	const result = validateImageFile(file);
+	assert.equal(result.ok, false);
+	if (!result.ok) assert.equal(result.reason, 'unsupported-type');
+});
+
+test('validateImageFile: 10MB超は too-large', () => {
+	const file = {
+		type: 'image/png',
+		size: 11 * 1024 * 1024,
+	} as unknown as File;
+	const result = validateImageFile(file);
+	assert.equal(result.ok, false);
+	if (!result.ok) assert.equal(result.reason, 'too-large');
+});
+
+// ---------------------------------------------------------------------------
+// toBase64
+// ---------------------------------------------------------------------------
+
+test('toBase64: Data URI から Base64 本体を抽出する', () => {
+	const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+	assert.equal(toBase64(dataUri), 'iVBORw0KGgoAAAANSUhEUg==');
+});
+
+test('toBase64: カンマなしの入力はエラー', () => {
+	assert.throws(() => toBase64('invalid'), {
+		message: /不正な Data URI/,
+	});
+});
+
+// ---------------------------------------------------------------------------
+// buildSnippet
+// ---------------------------------------------------------------------------
+
+test('buildSnippet: data-uri はそのまま返す', () => {
+	const uri = 'data:image/png;base64,abc123';
+	assert.equal(buildSnippet(uri, 'data-uri'), uri);
+});
+
+test('buildSnippet: raw-base64 は Base64 本体のみ', () => {
+	assert.equal(
+		buildSnippet('data:image/png;base64,abc123', 'raw-base64'),
+		'abc123',
+	);
+});
+
+test('buildSnippet: img タグ', () => {
+	const result = buildSnippet('data:image/png;base64,abc', 'img');
+	assert.equal(result, '<img src="data:image/png;base64,abc" alt="" />');
+});
+
+test('buildSnippet: css-bg', () => {
+	const result = buildSnippet('data:image/png;base64,abc', 'css-bg');
+	assert.equal(result, 'background-image: url("data:image/png;base64,abc");');
+});
+
+// ---------------------------------------------------------------------------
+// detectMimeFromBase64
+// ---------------------------------------------------------------------------
+
+test('detectMimeFromBase64: PNG', () => {
+	assert.equal(detectMimeFromBase64(pngBase64()), 'image/png');
+});
+
+test('detectMimeFromBase64: JPEG', () => {
+	assert.equal(detectMimeFromBase64(jpegBase64()), 'image/jpeg');
+});
+
+test('detectMimeFromBase64: GIF', () => {
+	assert.equal(detectMimeFromBase64(gifBase64()), 'image/gif');
+});
+
+test('detectMimeFromBase64: WebP', () => {
+	assert.equal(detectMimeFromBase64(webpBase64()), 'image/webp');
+});
+
+test('detectMimeFromBase64: SVG（PD...）', () => {
+	const b64 = btoa('<?xml version="1.0"?><svg></svg>');
+	assert.equal(detectMimeFromBase64(b64), 'image/svg+xml');
+});
+
+test('detectMimeFromBase64: SVG（PHN...）', () => {
+	const b64 = btoa('<svg></svg>');
+	assert.equal(detectMimeFromBase64(b64), 'image/svg+xml');
+});
+
+test('detectMimeFromBase64: 不明なデータは null', () => {
+	assert.equal(detectMimeFromBase64('AAAA'), null);
+});
+
+// ---------------------------------------------------------------------------
+// dataUriToBlob
+// ---------------------------------------------------------------------------
+
+test('dataUriToBlob: Data URI 付き PNG のデコード', () => {
+	const b64 = pngBase64();
+	const dataUri = `data:image/png;base64,${b64}`;
+	const { blob, mime, ext } = dataUriToBlob(dataUri);
+	assert.equal(mime, 'image/png');
+	assert.equal(ext, 'png');
+	assert.equal(blob.type, 'image/png');
+	assert.equal(blob.size, 8);
+});
+
+test('dataUriToBlob: data: プレフィックスなし（マジックバイト判定）', () => {
+	const b64 = jpegBase64();
+	const { mime, ext } = dataUriToBlob(b64);
+	assert.equal(mime, 'image/jpeg');
+	assert.equal(ext, 'jpg');
+});
+
+test('dataUriToBlob: 改行・空白を含む入力', () => {
+	const b64 = pngBase64();
+	const withWhitespace = `data:image/png;base64,${b64.slice(0, 4)}\n  ${b64.slice(4)}`;
+	const { mime } = dataUriToBlob(withWhitespace);
+	assert.equal(mime, 'image/png');
+});
+
+test('dataUriToBlob: 空文字列はエラー', () => {
+	assert.throws(() => dataUriToBlob(''), {
+		message: /MIMEタイプを判定できません/,
+	});
+});
+
+test('dataUriToBlob: 不正な Base64 はエラー', () => {
+	assert.throws(() => dataUriToBlob('data:image/png;base64,!!!invalid!!!'), {
+		message: /Base64のデコードに失敗しました/,
+	});
+});
+
+test('dataUriToBlob: data:text/html は拒否', () => {
+	const b64 = btoa('<html></html>');
+	assert.throws(() => dataUriToBlob(`data:text/html;base64,${b64}`), {
+		message: /対応していない形式です/,
+	});
+});
+
+test('dataUriToBlob: MIMEヘッダのみ（Base64なし）はエラー', () => {
+	assert.throws(() => dataUriToBlob('data:image/png;base64,'), {
+		message: /MIMEタイプを判定できません/,
+	});
+});
+
+test('dataUriToBlob: マジックバイト判定不能 + data: なしはエラー', () => {
+	const b64 = btoa('random binary content');
+	assert.throws(() => dataUriToBlob(b64), {
+		message: /MIMEタイプを判定できません/,
+	});
+});
+
+// ---------------------------------------------------------------------------
+// ラウンドトリップ
+// ---------------------------------------------------------------------------
+
+test('ラウンドトリップ: encode → decode が元バイト列と一致', async () => {
+	const original = new Uint8Array([
+		0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d,
+	]);
+	let binary = '';
+	for (const b of original) binary += String.fromCharCode(b);
+	const b64 = btoa(binary);
+	const dataUri = `data:image/png;base64,${b64}`;
+
+	const { blob } = dataUriToBlob(dataUri);
+	const decoded = new Uint8Array(await blob.arrayBuffer());
+	assert.deepEqual(Array.from(decoded), Array.from(original));
+});
+
+// ---------------------------------------------------------------------------
+// estimateSize
+// ---------------------------------------------------------------------------
+
+test('estimateSize: サイズと肥大率を計算する', () => {
+	const original = new Uint8Array(100);
+	let binary = '';
+	for (const b of original) binary += String.fromCharCode(b);
+	const b64 = btoa(binary);
+	const dataUri = `data:image/png;base64,${b64}`;
+
+	const { originalBytes, base64TextBytes, inflationPct } =
+		estimateSize(dataUri);
+	assert.equal(originalBytes, 100);
+	assert.equal(base64TextBytes, b64.length);
+	assert.ok(inflationPct > 30 && inflationPct < 40);
+});
+
+test('estimateSize: パディング付きの入力でも正確', () => {
+	const b64 = btoa('ab');
+	const dataUri = `data:image/png;base64,${b64}`;
+	const { originalBytes } = estimateSize(dataUri);
+	assert.equal(originalBytes, 2);
+});
+
+// ---------------------------------------------------------------------------
+// extensionForMime / formatBytes
+// ---------------------------------------------------------------------------
+
+test('extensionForMime: 各 MIME → 拡張子', () => {
+	assert.equal(extensionForMime('image/png'), 'png');
+	assert.equal(extensionForMime('image/jpeg'), 'jpg');
+	assert.equal(extensionForMime('image/webp'), 'webp');
+	assert.equal(extensionForMime('image/gif'), 'gif');
+	assert.equal(extensionForMime('image/svg+xml'), 'svg');
+	assert.equal(extensionForMime('application/octet-stream'), 'bin');
+});
+
+test('formatBytes: 人が読める形式', () => {
+	assert.equal(formatBytes(0), '0 B');
+	assert.equal(formatBytes(512), '512 B');
+	assert.equal(formatBytes(1024), '1.0 KB');
+	assert.equal(formatBytes(1536), '1.5 KB');
+	assert.equal(formatBytes(1048576), '1.00 MB');
+	assert.equal(formatBytes(2621440), '2.50 MB');
+});


### PR DESCRIPTION
## Summary
- 画像をBase64/Data URIに変換し、`<img>` / CSS `url()` スニペットをワンクリックコピーできるツールを追加
- Base64→画像の逆変換（プレビュー＋ダウンロード）にも対応
- 全処理ブラウザ完結・新規npm依存ゼロ・画像はサーバーに送信されない

## Changes
### Core Logic (`src/lib/tools/image-base64.ts`)
- `validateImageFile` — PNG/JPEG/WebP/GIF/SVG + 10MB上限の検証
- `fileToDataUri` / `toBase64` / `buildSnippet` — Data URI生成 + 4種スニペット（data-uri / raw-base64 / img / css-bg）
- `dataUriToBlob` — 逆変換。マジックバイト判定でMIME自動推定、`data:` プレフィックス有無どちらも許容
- `estimateSize` — 元サイズ・Base64サイズ・肥大率（約33%）の算出

### UI (`src/components/image-base64/ImageBase64Page.tsx`)
- タブ切替: 「画像→Base64」「Base64→画像」
- エンコード: FileDropzone → 省略プレビュー + CopyButton × 4スニペット + サイズ情報 + 肥大率注意表示
- デコード: Textarea入力 → 300ms debounce → `<img src>` プレビュー + ダウンロード
- メモリ管理: `useEffect` cleanup + `decodedUrlRef` で Object URL リーク防止
- `useMemo` でスニペット生成最適化

### Astro Page + SEO (`src/pages/image-base64.astro`)
- ToolLayout + SEO meta + usage セクション + 関連ツールリンク（/hash, /base64, /json-csv, /color）
- Catalog登録（開発ツール、🔣アイコン）→ Navigation / SearchModal / ホーム自動連動

## Test plan
- [x] Unit tests: 30件 all pass（`node --test tests/unit/image-base64.test.ts`）
- [x] E2E tests: 16件 all pass（chromium 8 + mobile-chrome 8）
  - ページ表示 + SafetyBadge
  - 画像投入 → スニペット表示・コピー動作
  - Base64貼り付け → プレビュー → ダウンロード
  - 不正Base64エラー / レスポンシブ / ネットワーク送信なし確認
- [x] `npm run build` — 37 pages, zero errors
- [x] `npx biome check` — 202 files, zero issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)