### PR TITLE
AI表データプロンプト生成ツールを追加

### DIFF
--- a/src/components/tools/AiSpreadsheetPrompt.tsx
+++ b/src/components/tools/AiSpreadsheetPrompt.tsx
@@ -1,0 +1,178 @@
+import { Copy, Sparkles } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { Textarea } from '@/components/ui/textarea';
+import {
+	generateSpreadsheetPrompt,
+	type PromptTask,
+	type SpreadsheetInputFormat,
+} from '@/lib/tools/ai-spreadsheet-prompt';
+
+const SAMPLE_DATA = `商品名\tカテゴリ\t売上\t粗利率\nコーヒー豆A\t食品\t128000\t32%\nマグカップ\t雑貨\t54000\t45%\nギフトセット\t食品\t212000\t38%`;
+
+export function AiSpreadsheetPrompt() {
+	const [input, setInput] = useState(SAMPLE_DATA);
+	const [format, setFormat] = useState<SpreadsheetInputFormat>('auto');
+	const [task, setTask] = useState<PromptTask>('analyze');
+	const [customInstruction, setCustomInstruction] = useState(
+		'売上が高い順に特徴を整理し、次に取るべき施策を3つ提案してください。',
+	);
+	const [maxRows, setMaxRows] = useState(30);
+	const [copied, setCopied] = useState(false);
+
+	const result = useMemo(
+		() =>
+			generateSpreadsheetPrompt({
+				input,
+				format,
+				task,
+				customInstruction,
+				maxRows,
+			}),
+		[input, format, task, customInstruction, maxRows],
+	);
+
+	const copyPrompt = async () => {
+		if (!result.prompt) return;
+		await navigator.clipboard.writeText(result.prompt);
+		setCopied(true);
+		window.setTimeout(() => setCopied(false), 1600);
+	};
+
+	return (
+		<div className="space-y-6">
+			<div className="rounded-xl border border-border bg-card p-4 shadow-sm">
+				<div className="mb-4 flex items-center gap-2">
+					<Sparkles className="size-5 text-primary" />
+					<h2 className="font-semibold">表データからAI用プロンプトを作成</h2>
+				</div>
+
+				<div className="grid gap-4 md:grid-cols-3">
+					<div className="space-y-2">
+						<Label htmlFor="format">入力形式</Label>
+						<Select
+							value={format}
+							onValueChange={(value) =>
+								setFormat(value as SpreadsheetInputFormat)
+							}
+						>
+							<SelectTrigger id="format" className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="auto">自動判定</SelectItem>
+								<SelectItem value="csv">CSV</SelectItem>
+								<SelectItem value="tsv">TSV / Excel貼り付け</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="task">AIに依頼する内容</Label>
+						<Select
+							value={task}
+							onValueChange={(value) => setTask(value as PromptTask)}
+						>
+							<SelectTrigger id="task" className="w-full">
+								<SelectValue />
+							</SelectTrigger>
+							<SelectContent>
+								<SelectItem value="analyze">分析してほしい</SelectItem>
+								<SelectItem value="summarize">要約してほしい</SelectItem>
+								<SelectItem value="clean">データ品質を確認したい</SelectItem>
+								<SelectItem value="transform">JSONに変換したい</SelectItem>
+								<SelectItem value="custom">自由に指定する</SelectItem>
+							</SelectContent>
+						</Select>
+					</div>
+
+					<div className="space-y-2">
+						<Label htmlFor="maxRows">プロンプトに含める最大行数</Label>
+						<input
+							id="maxRows"
+							type="number"
+							min="2"
+							max="200"
+							value={maxRows}
+							onChange={(event) => setMaxRows(Number(event.target.value))}
+							className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
+						/>
+					</div>
+				</div>
+
+				{task === 'custom' && (
+					<div className="mt-4 space-y-2">
+						<Label htmlFor="customInstruction">自由指示</Label>
+						<Textarea
+							id="customInstruction"
+							value={customInstruction}
+							onChange={(event) => setCustomInstruction(event.target.value)}
+							placeholder="AIに依頼したい内容を日本語で入力してください。"
+							className="min-h-20"
+						/>
+					</div>
+				)}
+			</div>
+
+			<div className="grid gap-4 lg:grid-cols-2">
+				<div className="space-y-2">
+					<Label htmlFor="spreadsheetInput">
+						CSV / TSV / Excel貼り付けデータ
+					</Label>
+					<Textarea
+						id="spreadsheetInput"
+						value={input}
+						onChange={(event) => setInput(event.target.value)}
+						placeholder="Excelやスプレッドシートからコピーした表、CSV、TSVを貼り付けてください。"
+						className="min-h-80 font-mono text-sm"
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<div className="flex items-center justify-between gap-2">
+						<Label htmlFor="promptOutput">生成されたプロンプト</Label>
+						<Button
+							type="button"
+							variant="outline"
+							size="sm"
+							onClick={copyPrompt}
+							disabled={!result.prompt}
+						>
+							<Copy className="size-4" />
+							{copied ? 'コピーしました' : 'コピー'}
+						</Button>
+					</div>
+					<Textarea
+						id="promptOutput"
+						value={result.prompt}
+						readOnly
+						placeholder="左側に表データを入力すると、AIに貼り付けやすいプロンプトが生成されます。"
+						className="min-h-80 font-mono text-sm"
+					/>
+				</div>
+			</div>
+
+			<div className="rounded-xl border border-border bg-muted/30 p-4 text-sm text-muted-foreground">
+				<p>
+					検出結果: {result.rowCount}行 / {result.columnCount}列 / 区切り文字 「
+					{result.detectedDelimiter === '\t' ? 'タブ' : 'カンマ'}」
+				</p>
+				{result.warnings.length > 0 && (
+					<ul className="mt-2 list-disc space-y-1 pl-5">
+						{result.warnings.map((warning) => (
+							<li key={warning}>{warning}</li>
+						))}
+					</ul>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/lib/tools/ai-spreadsheet-prompt.ts
+++ b/src/lib/tools/ai-spreadsheet-prompt.ts
@@ -59,8 +59,12 @@ function detectDelimiter(
 	return tabCount > commaCount ? '\t' : ',';
 }
 
-function parseDelimited(input: string, delimiter: ',' | '\t'): string[][] {
+function parseDelimited(
+	input: string,
+	delimiter: ',' | '\t',
+): { rows: string[][]; warnings: string[] } {
 	const rows: string[][] = [];
+	const warnings: string[] = [];
 	let row: string[] = [];
 	let cell = '';
 	let inQuotes = false;
@@ -102,7 +106,18 @@ function parseDelimited(input: string, delimiter: ',' | '\t'): string[][] {
 		rows.push(row);
 	}
 
-	return rows.filter((cells) => cells.some((value) => value.trim().length > 0));
+	if (inQuotes) {
+		warnings.push(
+			'ダブルクォートが閉じられていない可能性があります。元データのCSV形式を確認してください。',
+		);
+	}
+
+	return {
+		rows: rows.filter((cells) =>
+			cells.some((value) => value.trim().length > 0),
+		),
+		warnings,
+	};
 }
 
 function escapeMarkdownCell(value: string): string {
@@ -146,7 +161,8 @@ export function generateSpreadsheetPrompt({
 	}
 
 	const detectedDelimiter = detectDelimiter(trimmedInput, format);
-	const rows = parseDelimited(trimmedInput, detectedDelimiter);
+	const parsed = parseDelimited(trimmedInput, detectedDelimiter);
+	const rows = parsed.rows;
 	const rowCount = rows.length;
 	const columnCount =
 		rows.length > 0 ? Math.max(...rows.map((row) => row.length)) : 0;
@@ -154,7 +170,7 @@ export function generateSpreadsheetPrompt({
 	const includedRows = Math.min(rowCount, safeMaxRows);
 	const includedRowsData = rows.slice(0, includedRows);
 	const truncated = rowCount > includedRows;
-	const warnings: string[] = [];
+	const warnings: string[] = [...parsed.warnings];
 
 	if (truncated) {
 		warnings.push(

--- a/src/lib/tools/ai-spreadsheet-prompt.ts
+++ b/src/lib/tools/ai-spreadsheet-prompt.ts
@@ -1,0 +1,190 @@
+export type SpreadsheetInputFormat = 'auto' | 'csv' | 'tsv';
+export type PromptTask =
+	| 'analyze'
+	| 'summarize'
+	| 'clean'
+	| 'transform'
+	| 'custom';
+
+export interface SpreadsheetPromptOptions {
+	input: string;
+	format: SpreadsheetInputFormat;
+	task: PromptTask;
+	customInstruction?: string;
+	maxRows: number;
+}
+
+export interface SpreadsheetPromptResult {
+	prompt: string;
+	detectedDelimiter: ',' | '\t';
+	rowCount: number;
+	columnCount: number;
+	includedRows: number;
+	truncated: boolean;
+	warnings: string[];
+}
+
+const TASK_INSTRUCTIONS: Record<PromptTask, string> = {
+	analyze:
+		'以下の表データを分析し、重要な傾向・外れ値・確認すべきポイントを日本語で箇条書きにしてください。',
+	summarize:
+		'以下の表データの内容を、意思決定に使いやすい日本語の要約にしてください。',
+	clean:
+		'以下の表データを確認し、表記ゆれ・欠損値・重複・形式不備の可能性を指摘してください。修正案も示してください。',
+	transform:
+		'以下の表データを、扱いやすいJSON配列に変換してください。値の意味を保ち、列名をキーにしてください。',
+	custom: '',
+};
+
+function detectDelimiter(
+	input: string,
+	format: SpreadsheetInputFormat,
+): ',' | '\t' {
+	if (format === 'csv') return ',';
+	if (format === 'tsv') return '\t';
+
+	const firstLines = input
+		.split(/\r?\n/)
+		.filter((line) => line.trim().length > 0)
+		.slice(0, 10);
+	const tabCount = firstLines.reduce(
+		(count, line) => count + (line.match(/\t/g)?.length ?? 0),
+		0,
+	);
+	const commaCount = firstLines.reduce(
+		(count, line) => count + (line.match(/,/g)?.length ?? 0),
+		0,
+	);
+
+	return tabCount > commaCount ? '\t' : ',';
+}
+
+function parseDelimited(input: string, delimiter: ',' | '\t'): string[][] {
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let cell = '';
+	let inQuotes = false;
+
+	for (let index = 0; index < input.length; index += 1) {
+		const char = input[index];
+		const next = input[index + 1];
+
+		if (char === '"') {
+			if (inQuotes && next === '"') {
+				cell += '"';
+				index += 1;
+			} else {
+				inQuotes = !inQuotes;
+			}
+			continue;
+		}
+
+		if (!inQuotes && char === delimiter) {
+			row.push(cell);
+			cell = '';
+			continue;
+		}
+
+		if (!inQuotes && (char === '\n' || char === '\r')) {
+			row.push(cell);
+			rows.push(row);
+			row = [];
+			cell = '';
+			if (char === '\r' && next === '\n') index += 1;
+			continue;
+		}
+
+		cell += char;
+	}
+
+	if (cell.length > 0 || row.length > 0) {
+		row.push(cell);
+		rows.push(row);
+	}
+
+	return rows.filter((cells) => cells.some((value) => value.trim().length > 0));
+}
+
+function escapeMarkdownCell(value: string): string {
+	return value.replace(/\|/g, '\\|').replace(/\r?\n/g, '<br>').trim();
+}
+
+function toMarkdownTable(rows: string[][]): string {
+	if (rows.length === 0) return '';
+	const columnCount = Math.max(...rows.map((row) => row.length));
+	const normalized = rows.map((row) =>
+		Array.from({ length: columnCount }, (_, index) =>
+			escapeMarkdownCell(row[index] ?? ''),
+		),
+	);
+	const header = normalized[0].map((value, index) => value || `列${index + 1}`);
+	const separator = Array.from({ length: columnCount }, () => '---');
+	const body = normalized.slice(1);
+	return [header, separator, ...body]
+		.map((row) => `| ${row.join(' | ')} |`)
+		.join('\n');
+}
+
+export function generateSpreadsheetPrompt({
+	input,
+	format,
+	task,
+	customInstruction,
+	maxRows,
+}: SpreadsheetPromptOptions): SpreadsheetPromptResult {
+	const trimmedInput = input.trim();
+	if (!trimmedInput) {
+		return {
+			prompt: '',
+			detectedDelimiter: format === 'tsv' ? '\t' : ',',
+			rowCount: 0,
+			columnCount: 0,
+			includedRows: 0,
+			truncated: false,
+			warnings: ['表データを入力してください。'],
+		};
+	}
+
+	const detectedDelimiter = detectDelimiter(trimmedInput, format);
+	const rows = parseDelimited(trimmedInput, detectedDelimiter);
+	const rowCount = rows.length;
+	const columnCount =
+		rows.length > 0 ? Math.max(...rows.map((row) => row.length)) : 0;
+	const safeMaxRows = Math.max(2, Math.min(maxRows, 200));
+	const includedRows = Math.min(rowCount, safeMaxRows);
+	const includedRowsData = rows.slice(0, includedRows);
+	const truncated = rowCount > includedRows;
+	const warnings: string[] = [];
+
+	if (truncated) {
+		warnings.push(
+			`入力は${rowCount}行あります。プロンプトには先頭${includedRows}行のみ含めています。`,
+		);
+	}
+	if (columnCount >= 12) {
+		warnings.push(
+			'列数が多いため、AIには分析観点を具体的に指定すると精度が上がります。',
+		);
+	}
+
+	const instruction =
+		task === 'custom'
+			? customInstruction?.trim() ||
+				'以下の表データを確認し、必要な処理を日本語で実行してください。'
+			: TASK_INSTRUCTIONS[task];
+	const delimiterLabel =
+		detectedDelimiter === '\t' ? 'TSV/Excel貼り付け' : 'CSV';
+	const omittedLine = truncated
+		? `\n※元データは${rowCount}行です。長すぎるため、ここでは先頭${includedRows}行のみ共有します。必要なら追加行を分割して送ります。`
+		: '';
+
+	return {
+		prompt: `${instruction}\n\n# 前提\n- データ形式: ${delimiterLabel}\n- 行数: ${rowCount}行\n- 列数: ${columnCount}列${omittedLine}\n\n# 表データ\n${toMarkdownTable(includedRowsData)}\n\n# 出力条件\n- 日本語で回答してください。\n- 推測した点は「推測」と明記してください。\n- 不明点や追加で必要な列があれば最後に確認事項として列挙してください。`,
+		detectedDelimiter,
+		rowCount,
+		columnCount,
+		includedRows,
+		truncated,
+		warnings,
+	};
+}

--- a/src/lib/tools/catalog.ts
+++ b/src/lib/tools/catalog.ts
@@ -272,6 +272,26 @@ export const toolCatalog: readonly ToolCatalogItem[] = [
 		},
 	},
 	{
+		id: 'ai-spreadsheet-prompt',
+		title: 'AI表データプロンプト生成',
+		description:
+			'CSV・TSV・Excel貼り付けデータを、AIに渡しやすい分析プロンプトへ変換。',
+		href: '/ai-spreadsheet-prompt',
+		icon: '🤖',
+		category: 'データ処理',
+		categoryColor: 'border-l-chart-4',
+		span: 2,
+		keywords: ['AI', 'CSV', 'TSV', 'Excel', 'プロンプト'],
+		related: ['csv-editor', 'json-csv', 'csv-fixer'],
+		llmsFull: {
+			useCase:
+				'CSV、TSV、Excel貼り付け表データからAIチャット向けの分析・要約・変換プロンプトを生成',
+			inputs: 'tableText（CSV/TSV/Excel貼り付けデータ）, task（依頼内容）',
+			outputs: 'Markdown表と出力条件を含むAI向けプロンプト',
+			options: '入力形式の自動判定、依頼内容、最大行数、自由指示',
+		},
+	},
+	{
 		id: 'csv-editor',
 		title: 'CSVビューア/エディタ',
 		description:

--- a/src/pages/ai-spreadsheet-prompt.astro
+++ b/src/pages/ai-spreadsheet-prompt.astro
@@ -1,0 +1,33 @@
+---
+import ToolLayout from '../components/common/ToolLayout.astro';
+import { AiSpreadsheetPrompt } from '../components/tools/AiSpreadsheetPrompt';
+---
+
+<ToolLayout
+  title="AI表データプロンプト生成"
+  description="CSV・TSV・Excel貼り付けデータを、AIに分析や要約を依頼しやすいプロンプトへ変換します。"
+  path="/ai-spreadsheet-prompt"
+>
+  <AiSpreadsheetPrompt client:load />
+
+  <div slot="usage" class="mt-8">
+    <details class="group rounded-xl border border-border p-4" open>
+      <summary class="cursor-pointer text-sm font-semibold flex items-center gap-2">
+        📖 使い方・ユースケース
+        <span class="ml-auto text-muted-foreground group-open:rotate-180 transition-transform">▼</span>
+      </summary>
+      <div class="mt-4 space-y-3 text-sm text-muted-foreground">
+        <p>Excelやスプレッドシートからコピーした表データ、CSV、TSVを貼り付けるだけで、AIチャットにそのまま渡しやすいMarkdown表付きプロンプトを作成できます。</p>
+        <ul class="list-disc pl-5 space-y-1">
+          <li>売上表やアンケート結果をAIに分析してもらう</li>
+          <li>CSVの表記ゆれ、欠損値、重複の確認観点をまとめる</li>
+          <li>表データをJSON化するための指示文を素早く作る</li>
+          <li>長い表は先頭行だけを共有し、追加行を分割して依頼する</li>
+        </ul>
+        <div class="mt-2 text-xs bg-muted/50 p-2 rounded">
+          ⚠️ 入力データはブラウザ内だけで処理されます。AIサービスへ送信する前に、個人情報や機密情報が含まれていないか必ず確認してください。
+        </div>
+      </div>
+    </details>
+  </div>
+</ToolLayout>

--- a/tests/e2e/ai-spreadsheet-prompt.spec.ts
+++ b/tests/e2e/ai-spreadsheet-prompt.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from './fixtures/base';
+
+test('AI表データプロンプト生成ツールが表データからプロンプトを生成できること', async ({
+	page,
+	createToolPage,
+}) => {
+	const toolPage = createToolPage('ai-spreadsheet-prompt');
+	await toolPage.goto();
+
+	await toolPage.expectSafetyBadge();
+	await toolPage.expectTitle('AI表データプロンプト生成');
+
+	await page
+		.locator('#spreadsheetInput')
+		.fill('名前,売上\n商品A,1000\n商品B,2500');
+
+	const output = page.locator('#promptOutput');
+	await expect(output).toContainText('以下の表データを分析');
+	await expect(output).toContainText('| 名前 | 売上 |');
+	await expect(output).toContainText('| 商品B | 2500 |');
+	await expect(page.getByText('検出結果: 3行 / 2列')).toBeVisible();
+});

--- a/tests/unit/ai-spreadsheet-prompt.test.ts
+++ b/tests/unit/ai-spreadsheet-prompt.test.ts
@@ -1,0 +1,65 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/ai-spreadsheet-prompt.test.ts
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { generateSpreadsheetPrompt } from '../../src/lib/tools/ai-spreadsheet-prompt.ts';
+
+test('TSV/Excel貼り付けデータを自動判定してMarkdown表付きプロンプトを生成する', () => {
+	const result = generateSpreadsheetPrompt({
+		input: '商品名\t売上\nコーヒー豆\t128000\nマグカップ\t54000',
+		format: 'auto',
+		task: 'analyze',
+		maxRows: 30,
+	});
+
+	assert.equal(result.detectedDelimiter, '\t');
+	assert.equal(result.rowCount, 3);
+	assert.equal(result.columnCount, 2);
+	assert.match(result.prompt, /以下の表データを分析/);
+	assert.match(result.prompt, /\| 商品名 \| 売上 \|/);
+	assert.match(result.prompt, /\| コーヒー豆 \| 128000 \|/);
+});
+
+test('CSVクォート、カンマ、改行、パイプをMarkdown向けに処理する', () => {
+	const result = generateSpreadsheetPrompt({
+		input: '名前,メモ\n"商品, A","1行目\n2行目"\n"A|B","引用""符"',
+		format: 'csv',
+		task: 'summarize',
+		maxRows: 10,
+	});
+
+	assert.equal(result.detectedDelimiter, ',');
+	assert.equal(result.rowCount, 3);
+	assert.match(result.prompt, /商品, A/);
+	assert.match(result.prompt, /1行目<br>2行目/);
+	assert.match(result.prompt, /A\\\|B/);
+	assert.match(result.prompt, /引用"符/);
+});
+
+test('最大行数を超える入力は先頭行に制限して警告する', () => {
+	const result = generateSpreadsheetPrompt({
+		input: '名前,売上\nA,100\nB,200\nC,300',
+		format: 'csv',
+		task: 'clean',
+		maxRows: 2,
+	});
+
+	assert.equal(result.rowCount, 4);
+	assert.equal(result.includedRows, 2);
+	assert.equal(result.truncated, true);
+	assert.match(result.warnings.join('\n'), /先頭2行のみ/);
+	assert.doesNotMatch(result.prompt, /\| B \| 200 \|/);
+});
+
+test('自由指示と未クローズクォートの警告を扱う', () => {
+	const result = generateSpreadsheetPrompt({
+		input: '名前,メモ\nA,"未完了',
+		format: 'csv',
+		task: 'custom',
+		customInstruction: '改善案だけを出してください。',
+		maxRows: 10,
+	});
+
+	assert.match(result.prompt, /^改善案だけを出してください。/);
+	assert.match(result.warnings.join('\n'), /ダブルクォート/);
+});


### PR DESCRIPTION
### Motivation
- ExcelやCSV/TSVの貼り付けデータを、そのままAIチャットに渡しやすいMarkdown表付きプロンプトへ自動変換する機能を追加するため。 
- クライアントサイドで完結する純粋関数と日本語UIで、プロンプト生成の効率化と安全性（外部送信無し）を担保するため。

### Description
- 純粋ロジック `src/lib/tools/ai-spreadsheet-prompt.ts` を追加し、区切り文字の自動判定、CSVクォート対応、行/列カウント、Markdown表変換、行数トリミングと警告生成を実装しました。 
- Reactコンポーネント `src/components/tools/AiSpreadsheetPrompt.tsx` を追加し、入力形式/依頼タスク/最大行数/自由指示のUIとコピー機能を実装しました。 
- ページ `src/pages/ai-spreadsheet-prompt.astro` を追加してサイト上にツールを公開し、`src/lib/tools/catalog.ts` にカタログ登録を行いました。 
- E2Eテスト `tests/e2e/ai-spreadsheet-prompt.spec.ts` を追加して、入力から生成プロンプト・検出結果表示までの動作を検証するシナリオを用意しました。 

### Testing
- `npm run lint:fix` を実行し自動整形を適用してエラーを修正しました（成功）。
- `npm run lint` を実行して静的解析チェックが通ることを確認しました（成功）。
- `npm run build` を実行してビルドが正常完了することを確認しました（成功）。
- `npm test -- tests/e2e/ai-spreadsheet-prompt.spec.ts` を試行しましたが、Playwright用のブラウザが未インストールでテストが失敗し、`npx playwright install chromium` がCDNの403（Domain forbidden）によりブラウザ取得に失敗したためE2Eは実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fbf25bba8832fa468cdefc0409df9)