### PR TITLE
docs: add zipcode data validation steps

### DIFF
--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -53,7 +53,13 @@
    ```bash
    node scripts/generate-zipcode-data.ts
    ```
-4. **コミット:**
+4. **更新後の検証:**
+   - `public/data/zipcode/metadata.json` を開き、`generatedAt`、`dataVersion`、`recordCount`、`chunkCount` が最新の生成結果として妥当であることを確認します。
+   - `public/data/zipcode/{00..99}.json` が生成されていることを確認し、空ファイルや破損した JSON がないことを確認します。
+   - 画面上で代表的な郵便番号（例: `1000001`、`1500001`、`5300001`）を検索し、期待する住所が表示されることを確認します。
+   - `git diff public/data/zipcode/` を実行し、想定外の大量削除や JSON 形式の変更が含まれていないことを確認します。
+   - 日本郵便データのライセンス・出典表記が、`metadata.json` と画面表示の両方で維持されていることを確認します。
+5. **コミット:**
    - `public/data/zipcode/` に生成された差分（各チャンクJSONと `metadata.json`）を Git にコミットします。
 
 ---


### PR DESCRIPTION
### Motivation
- 郵便番号データを更新した際に、生成結果が正しく破損や意図しない差分が含まれていないことを確実にするため、更新後の検証手順をドキュメントに追加しました。

### Description
- `docs/data-management.md` の「1.3 データの更新プロセス」に `更新後の検証` を追加し、`public/data/zipcode/metadata.json` の `generatedAt`/`dataVersion`/`recordCount`/`chunkCount` 確認、`public/data/zipcode/{00..99}.json` の生成と破損チェック、代表郵便番号（例: `1000001`、`1500001`、`5300001`）での画面検索確認、`git diff public/data/zipcode/` による差分チェック、および日本郵便データのライセンス・出典表記を `metadata.json` と画面表示の両方で維持する旨を明記し、コミット手順を検証後に行う流れにしました（変更ファイル: `docs/data-management.md`）。

### Testing
- 実行した自動化手順: `git diff --check` は成功、`npm ci` は Node.js バージョン要件（`>=22.22.2`）および `onnxruntime-node` のダウンロードで `ENETUNREACH` により失敗し、そのため `npm run lint`（`biome` 未検出）と `npm test`（`playwright` 未検出）は実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fde0b3030832fb766537667c9c0ee)