### PR TITLE
feat: WebMCP基盤を横展開可能な共通ファクトリ構造へ移行

### DIFF
--- a/src/components/tools/hash-generator/HashPage.tsx
+++ b/src/components/tools/hash-generator/HashPage.tsx
@@ -25,7 +25,8 @@ import {
 	MAX_FILE_SIZE,
 	validateHashFile,
 } from '@/lib/tools/hash';
-import { provideTools } from '@/lib/webmcp';
+import { provideToolsFromFactory } from '@/lib/webmcp';
+import { hashTool } from '@/lib/webmcp/tools/hash.webmcp';
 import { HashResultTable } from './HashResultTable';
 import { HashVerifier } from './HashVerifier';
 
@@ -53,65 +54,7 @@ export function HashPage() {
 
 	// --- WebMCP Tool Registration ---
 	useEffect(() => {
-		const hashAlgorithms = ['md5', 'sha-256', 'sha-512'] as const;
-		const cleanup = provideTools([
-			{
-				name: 'generate_hash',
-				description:
-					'文字列のハッシュ値を計算する（MD5 / SHA-256 / SHA-512）。処理はすべてブラウザ内で完結し、外部送信は行わない。',
-				inputSchema: {
-					type: 'object',
-					properties: {
-						text: { type: 'string', description: 'ハッシュ化する文字列' },
-						algorithm: { type: 'string', enum: hashAlgorithms },
-					},
-					required: ['text', 'algorithm'],
-				},
-				execute: async (input) => {
-					try {
-						if (
-							typeof input !== 'object' ||
-							input === null ||
-							typeof (input as { text?: unknown }).text !== 'string' ||
-							!hashAlgorithms.includes(
-								(input as { algorithm?: unknown })
-									.algorithm as (typeof hashAlgorithms)[number],
-							)
-						) {
-							return { error: '入力値が不正です' };
-						}
-
-						const { text: inputText, algorithm } = input as {
-							text: string;
-							algorithm: (typeof hashAlgorithms)[number];
-						};
-
-						const algoMap: Record<
-							(typeof hashAlgorithms)[number],
-							HashAlgorithm
-						> = {
-							md5: 'md5',
-							'sha-256': 'sha256',
-							'sha-512': 'sha512',
-						};
-
-						const targetAlgo = algoMap[algorithm];
-						const res = await hashText(inputText, [targetAlgo]);
-						const computedHash = res[targetAlgo];
-						if (!computedHash) {
-							return { error: 'ハッシュ計算に失敗しました' };
-						}
-						return { hash: computedHash };
-					} catch (e) {
-						return {
-							error:
-								e instanceof Error ? e.message : 'ハッシュ計算に失敗しました',
-						};
-					}
-				},
-			},
-		]);
-
+		const cleanup = provideToolsFromFactory([hashTool]);
 		return cleanup;
 	}, []);
 

--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -37,7 +37,8 @@ import {
 	validateAmount,
 	validateQuantity,
 } from '@/lib/tools/tax';
-import { provideTools } from '@/lib/webmcp';
+import { provideToolsFromFactory } from '@/lib/webmcp';
+import { taxTool } from '@/lib/webmcp/tools/tax.webmcp';
 
 type Direction = TaxCalcInput['direction'];
 type CalcMode = 'single' | 'invoice';
@@ -102,99 +103,7 @@ export function TaxCalcPage() {
 
 	// --- WebMCP Tool Registration ---
 	useEffect(() => {
-		const taxRates = ['3', '5', '8', '10', '8_reduced'] as const;
-		const taxModes = ['tax_included', 'tax_excluded'] as const;
-		const roundingModes = ['floor', 'ceil', 'round'] as const;
-
-		const cleanup = provideTools([
-			{
-				name: 'calc_tax',
-				description:
-					'金額から消費税を計算する（税込→税抜／税抜→税込）。処理はすべてブラウザ内で完結し、外部送信は行わない。',
-				inputSchema: {
-					type: 'object',
-					properties: {
-						amount: { type: 'number', description: '税込または税抜の金額' },
-						taxRate: {
-							type: 'string',
-							enum: taxRates,
-							description: '税率区分（8_reduced は軽減税率）',
-						},
-						mode: {
-							type: 'string',
-							enum: taxModes,
-							description:
-								'税込金額から税抜を求めるか(tax_included)、税抜金額から税込を求めるか(tax_excluded)',
-						},
-						rounding: {
-							type: 'string',
-							enum: roundingModes,
-							description: '端数処理',
-						},
-					},
-					required: ['amount', 'taxRate', 'mode'],
-				},
-				execute: async (input) => {
-					try {
-						if (typeof input !== 'object' || input === null) {
-							return { error: '入力値が不正です' };
-						}
-
-						const candidate = input as {
-							amount?: unknown;
-							taxRate?: unknown;
-							mode?: unknown;
-							rounding?: unknown;
-						};
-
-						if (
-							typeof candidate.amount !== 'number' ||
-							!Number.isFinite(candidate.amount) ||
-							!taxRates.includes(
-								candidate.taxRate as (typeof taxRates)[number],
-							) ||
-							!taxModes.includes(candidate.mode as (typeof taxModes)[number]) ||
-							(candidate.rounding !== undefined &&
-								!roundingModes.includes(
-									candidate.rounding as (typeof roundingModes)[number],
-								))
-						) {
-							return { error: '入力値が不正です' };
-						}
-
-						const rateNum = Number(
-							(candidate.taxRate as string).replace('_reduced', ''),
-						);
-						const dir: Direction =
-							candidate.mode === 'tax_excluded'
-								? 'exclusive-to-inclusive'
-								: 'inclusive-to-exclusive';
-						const round: RoundingMode =
-							(candidate.rounding as RoundingMode) ?? 'floor';
-
-						const res = calculateTax({
-							amount: candidate.amount,
-							rate: rateNum,
-							direction: dir,
-							rounding: round,
-						});
-
-						return {
-							base: res.base,
-							tax: res.tax,
-							total: res.total,
-							result: candidate.mode === 'tax_excluded' ? res.total : res.base,
-							taxAmount: res.tax,
-						};
-					} catch (e) {
-						return {
-							error: e instanceof Error ? e.message : '計算に失敗しました',
-						};
-					}
-				},
-			},
-		]);
-
+		const cleanup = provideToolsFromFactory([taxTool]);
 		return cleanup;
 	}, []);
 

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -1,3 +1,5 @@
+import type { WebMcpToolDefinition } from './webmcp/tool-factory.ts';
+
 export type WebMcpTool = {
 	name: string;
 	description: string;
@@ -9,6 +11,27 @@ type MaybeDisposable =
 	| undefined
 	| { dispose?: () => void; unregister?: () => void }
 	| (() => void);
+
+function wrapToolForClient(tool: WebMcpToolDefinition): WebMcpTool {
+	return {
+		name: tool.name,
+		description: tool.description,
+		inputSchema: tool.inputSchema,
+		async execute(input: unknown) {
+			const result = await tool.run(input);
+			if (result.ok) {
+				return result.value;
+			}
+			return { error: result.error, isError: true };
+		},
+	};
+}
+
+export function provideToolsFromFactory(
+	tools: WebMcpToolDefinition[],
+): () => void {
+	return provideTools(tools.map(wrapToolForClient));
+}
 
 export function provideTools(tools: WebMcpTool[]): () => void {
 	if (typeof window === 'undefined') return () => {};

--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -13,7 +13,7 @@ type MaybeDisposable =
 	| (() => void);
 
 function wrapToolForClient(tool: WebMcpToolDefinition): WebMcpTool {
-	return {
+	const wrapped: WebMcpTool = {
 		name: tool.name,
 		description: tool.description,
 		inputSchema: tool.inputSchema,
@@ -25,6 +25,10 @@ function wrapToolForClient(tool: WebMcpToolDefinition): WebMcpTool {
 			return { error: result.error, isError: true };
 		},
 	};
+	if (tool.outputSchema) {
+		(wrapped as Record<string, unknown>).outputSchema = tool.outputSchema;
+	}
+	return wrapped;
 }
 
 export function provideToolsFromFactory(

--- a/src/lib/webmcp/errors.ts
+++ b/src/lib/webmcp/errors.ts
@@ -1,0 +1,11 @@
+export type WebMcpToolResult<T> =
+	| { ok: true; value: T }
+	| { ok: false; error: string };
+
+export function success<T>(value: T): WebMcpToolResult<T> {
+	return { ok: true, value };
+}
+
+export function failure(error: string): WebMcpToolResult<never> {
+	return { ok: false, error };
+}

--- a/src/lib/webmcp/tool-factory.ts
+++ b/src/lib/webmcp/tool-factory.ts
@@ -34,7 +34,9 @@ export function createWebMcpTool<TInput, TOutput>(
 				return {
 					ok: false,
 					error:
-						e instanceof Error ? e.message : 'An unexpected error occurred',
+						e instanceof Error
+							? e.message
+							: 'An unexpected error occurred / 予期しないエラーが発生しました',
 				};
 			}
 		},

--- a/src/lib/webmcp/tool-factory.ts
+++ b/src/lib/webmcp/tool-factory.ts
@@ -1,0 +1,42 @@
+import type { WebMcpToolResult } from './errors.ts';
+
+export interface WebMcpToolConfig<TInput, TOutput> {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	outputSchema?: Record<string, unknown>;
+	validate: (input: unknown) => WebMcpToolResult<TInput>;
+	execute: (input: TInput) => Promise<TOutput> | TOutput;
+}
+
+export interface WebMcpToolDefinition<TOutput = unknown> {
+	name: string;
+	description: string;
+	inputSchema: Record<string, unknown>;
+	outputSchema?: Record<string, unknown>;
+	run: (input: unknown) => Promise<WebMcpToolResult<TOutput>>;
+}
+
+export function createWebMcpTool<TInput, TOutput>(
+	config: WebMcpToolConfig<TInput, TOutput>,
+): WebMcpToolDefinition<TOutput> {
+	return {
+		name: config.name,
+		description: config.description,
+		inputSchema: config.inputSchema,
+		outputSchema: config.outputSchema,
+		run: async (input: unknown): Promise<WebMcpToolResult<TOutput>> => {
+			try {
+				const validated = config.validate(input);
+				if (!validated.ok) return { ok: false, error: validated.error };
+				return { ok: true, value: await config.execute(validated.value) };
+			} catch (e) {
+				return {
+					ok: false,
+					error:
+						e instanceof Error ? e.message : 'An unexpected error occurred',
+				};
+			}
+		},
+	};
+}

--- a/src/lib/webmcp/tools/hash.webmcp.ts
+++ b/src/lib/webmcp/tools/hash.webmcp.ts
@@ -1,0 +1,71 @@
+import type { HashAlgorithm } from '../../tools/hash.ts';
+import { hashText } from '../../tools/hash.ts';
+import { failure } from '../errors.ts';
+import { createWebMcpTool } from '../tool-factory.ts';
+import { isObject, requireEnum, requireString } from '../validation.ts';
+
+const SUPPORTED_ALGORITHMS = ['md5', 'sha-256', 'sha-512'] as const;
+type WebMcpHashAlgorithm = (typeof SUPPORTED_ALGORITHMS)[number];
+
+const ALGO_MAP: Record<WebMcpHashAlgorithm, HashAlgorithm> = {
+	md5: 'md5',
+	'sha-256': 'sha256',
+	'sha-512': 'sha512',
+};
+
+interface HashInput {
+	text: string;
+	algorithm: WebMcpHashAlgorithm;
+}
+
+interface HashOutput {
+	hash: string;
+}
+
+export const hashTool = createWebMcpTool<HashInput, HashOutput>({
+	name: 'generate_hash',
+	description:
+		'Calculate MD5 / SHA-256 / SHA-512 hash of text. Runs entirely in the browser; no data is sent externally. / 文字列のハッシュ値を計算する。処理はブラウザ内で完結し、外部送信は行わない。',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			text: {
+				type: 'string',
+				description: 'Text to hash / ハッシュ化する文字列',
+			},
+			algorithm: {
+				type: 'string',
+				enum: SUPPORTED_ALGORITHMS,
+				description: 'Hash algorithm to use',
+			},
+		},
+		required: ['text', 'algorithm'],
+	},
+	outputSchema: {
+		type: 'object',
+		properties: {
+			hash: { type: 'string', description: 'Hex-encoded hash value' },
+		},
+		required: ['hash'],
+	},
+	validate(input) {
+		if (!isObject(input)) return failure('Input must be an object');
+		const text = requireString(input, 'text');
+		if (!text.ok) return text;
+		const algorithm = requireEnum(input, 'algorithm', SUPPORTED_ALGORITHMS);
+		if (!algorithm.ok) return algorithm;
+		return {
+			ok: true,
+			value: { text: text.value, algorithm: algorithm.value },
+		};
+	},
+	async execute(input) {
+		const targetAlgo = ALGO_MAP[input.algorithm];
+		const res = await hashText(input.text, [targetAlgo]);
+		const computedHash = res[targetAlgo];
+		if (!computedHash) {
+			throw new Error('Hash computation failed');
+		}
+		return { hash: computedHash };
+	},
+});

--- a/src/lib/webmcp/tools/hash.webmcp.ts
+++ b/src/lib/webmcp/tools/hash.webmcp.ts
@@ -49,7 +49,8 @@ export const hashTool = createWebMcpTool<HashInput, HashOutput>({
 		required: ['hash'],
 	},
 	validate(input) {
-		if (!isObject(input)) return failure('Input must be an object');
+		if (!isObject(input))
+			return failure('Input must be an object / 入力値が不正です');
 		const text = requireString(input, 'text');
 		if (!text.ok) return text;
 		const algorithm = requireEnum(input, 'algorithm', SUPPORTED_ALGORITHMS);

--- a/src/lib/webmcp/tools/tax.webmcp.ts
+++ b/src/lib/webmcp/tools/tax.webmcp.ts
@@ -86,7 +86,8 @@ export const taxTool = createWebMcpTool<TaxInput, TaxOutput>({
 		required: ['base', 'tax', 'total', 'result', 'taxAmount'],
 	},
 	validate(input) {
-		if (!isObject(input)) return failure('Input must be an object');
+		if (!isObject(input))
+			return failure('Input must be an object / 入力値が不正です');
 		const amount = requireNumber(input, 'amount');
 		if (!amount.ok) return amount;
 		const taxRate = requireEnum(input, 'taxRate', TAX_RATES);

--- a/src/lib/webmcp/tools/tax.webmcp.ts
+++ b/src/lib/webmcp/tools/tax.webmcp.ts
@@ -1,0 +1,130 @@
+import {
+	calculateTax,
+	type RoundingMode,
+	type TaxCalcInput,
+} from '../../tools/tax.ts';
+import { failure } from '../errors.ts';
+import { createWebMcpTool } from '../tool-factory.ts';
+import {
+	isObject,
+	optionalEnum,
+	requireEnum,
+	requireNumber,
+} from '../validation.ts';
+
+const TAX_RATES = ['3', '5', '8', '10', '8_reduced'] as const;
+type TaxRateKey = (typeof TAX_RATES)[number];
+
+const TAX_MODES = ['tax_included', 'tax_excluded'] as const;
+type TaxMode = (typeof TAX_MODES)[number];
+
+const ROUNDING_MODES = ['floor', 'ceil', 'round'] as const;
+
+interface TaxInput {
+	amount: number;
+	taxRate: TaxRateKey;
+	mode: TaxMode;
+	rounding: RoundingMode;
+}
+
+interface TaxOutput {
+	base: number;
+	tax: number;
+	total: number;
+	result: number;
+	taxAmount: number;
+}
+
+export const taxTool = createWebMcpTool<TaxInput, TaxOutput>({
+	name: 'calc_tax',
+	description:
+		'Calculate Japanese consumption tax (tax-included ↔ tax-excluded). Runs entirely in the browser; no data is sent externally. / 金額から消費税を計算する（税込→税抜／税抜→税込）。処理はブラウザ内で完結し、外部送信は行わない。',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			amount: {
+				type: 'number',
+				description:
+					'Amount (tax-included or tax-excluded) / 税込または税抜の金額',
+			},
+			taxRate: {
+				type: 'string',
+				enum: TAX_RATES,
+				description:
+					'Tax rate key (8_reduced = reduced rate) / 税率区分（8_reduced は軽減税率）',
+			},
+			mode: {
+				type: 'string',
+				enum: TAX_MODES,
+				description:
+					'tax_included: extract base from tax-included amount; tax_excluded: calculate tax-included from base / 税込金額から税抜を求めるか、税抜金額から税込を求めるか',
+			},
+			rounding: {
+				type: 'string',
+				enum: ROUNDING_MODES,
+				description:
+					'Rounding mode for tax fraction (default: floor) / 端数処理（デフォルト: 切り捨て）',
+			},
+		},
+		required: ['amount', 'taxRate', 'mode'],
+	},
+	outputSchema: {
+		type: 'object',
+		properties: {
+			base: { type: 'number', description: 'Tax-excluded amount / 税抜金額' },
+			tax: { type: 'number', description: 'Tax amount / 消費税額' },
+			total: {
+				type: 'number',
+				description: 'Tax-included amount / 税込金額',
+			},
+			result: {
+				type: 'number',
+				description: 'Primary result based on mode / モードに応じた主要結果',
+			},
+			taxAmount: { type: 'number', description: 'Tax amount / 消費税額' },
+		},
+		required: ['base', 'tax', 'total', 'result', 'taxAmount'],
+	},
+	validate(input) {
+		if (!isObject(input)) return failure('Input must be an object');
+		const amount = requireNumber(input, 'amount');
+		if (!amount.ok) return amount;
+		const taxRate = requireEnum(input, 'taxRate', TAX_RATES);
+		if (!taxRate.ok) return taxRate;
+		const mode = requireEnum(input, 'mode', TAX_MODES);
+		if (!mode.ok) return mode;
+		const rounding = optionalEnum(input, 'rounding', ROUNDING_MODES, 'floor');
+		if (!rounding.ok) return rounding;
+		return {
+			ok: true,
+			value: {
+				amount: amount.value,
+				taxRate: taxRate.value,
+				mode: mode.value,
+				rounding: rounding.value,
+			},
+		};
+	},
+	execute(input) {
+		const rateNum = Number(input.taxRate.replace('_reduced', ''));
+		const dir: TaxCalcInput['direction'] =
+			input.mode === 'tax_excluded'
+				? 'exclusive-to-inclusive'
+				: 'inclusive-to-exclusive';
+
+		const res = calculateTax({
+			amount: input.amount,
+			rate: rateNum,
+			direction: dir,
+			rounding: input.rounding,
+		});
+
+		return {
+			base: res.base,
+			tax: res.tax,
+			total: res.total,
+			result: input.mode === 'tax_excluded' ? res.total : res.base,
+			taxAmount: res.tax,
+		};
+	},
+});

--- a/src/lib/webmcp/validation.ts
+++ b/src/lib/webmcp/validation.ts
@@ -11,7 +11,7 @@ export function requireString(
 ): WebMcpToolResult<string> {
 	const v = obj[key];
 	if (typeof v !== 'string') {
-		return failure(`"${key}" must be a string`);
+		return failure(`"${key}" must be a string / "${key}" は文字列で指定してください`);
 	}
 	return { ok: true, value: v };
 }
@@ -22,7 +22,9 @@ export function requireNumber(
 ): WebMcpToolResult<number> {
 	const v = obj[key];
 	if (typeof v !== 'number' || !Number.isFinite(v)) {
-		return failure(`"${key}" must be a finite number`);
+		return failure(
+			`"${key}" must be a finite number / "${key}" は有限の数値で指定してください`,
+		);
 	}
 	return { ok: true, value: v };
 }
@@ -34,7 +36,9 @@ export function requireEnum<T extends string>(
 ): WebMcpToolResult<T> {
 	const v = obj[key];
 	if (typeof v !== 'string' || !values.includes(v as T)) {
-		return failure(`"${key}" must be one of: ${values.join(', ')}`);
+		return failure(
+			`"${key}" must be one of: ${values.join(', ')} / "${key}" は次のいずれかを指定してください: ${values.join(', ')}`,
+		);
 	}
 	return { ok: true, value: v as T };
 }
@@ -50,7 +54,9 @@ export function optionalEnum<T extends string>(
 		return { ok: true, value: defaultValue };
 	}
 	if (typeof v !== 'string' || !values.includes(v as T)) {
-		return failure(`"${key}" must be one of: ${values.join(', ')}`);
+		return failure(
+			`"${key}" must be one of: ${values.join(', ')} / "${key}" は次のいずれかを指定してください: ${values.join(', ')}`,
+		);
 	}
 	return { ok: true, value: v as T };
 }
@@ -61,7 +67,9 @@ export function checkSizeLimit(
 	label = 'Input',
 ): WebMcpToolResult<string> {
 	if (value.length > maxChars) {
-		return failure(`${label} exceeds the maximum size limit`);
+		return failure(
+			`${label} exceeds the maximum size limit / ${label}のサイズが上限を超えています`,
+		);
 	}
 	return { ok: true, value };
 }

--- a/src/lib/webmcp/validation.ts
+++ b/src/lib/webmcp/validation.ts
@@ -1,0 +1,67 @@
+import type { WebMcpToolResult } from './errors.ts';
+import { failure } from './errors.ts';
+
+export function isObject(input: unknown): input is Record<string, unknown> {
+	return typeof input === 'object' && input !== null;
+}
+
+export function requireString(
+	obj: Record<string, unknown>,
+	key: string,
+): WebMcpToolResult<string> {
+	const v = obj[key];
+	if (typeof v !== 'string') {
+		return failure(`"${key}" must be a string`);
+	}
+	return { ok: true, value: v };
+}
+
+export function requireNumber(
+	obj: Record<string, unknown>,
+	key: string,
+): WebMcpToolResult<number> {
+	const v = obj[key];
+	if (typeof v !== 'number' || !Number.isFinite(v)) {
+		return failure(`"${key}" must be a finite number`);
+	}
+	return { ok: true, value: v };
+}
+
+export function requireEnum<T extends string>(
+	obj: Record<string, unknown>,
+	key: string,
+	values: readonly T[],
+): WebMcpToolResult<T> {
+	const v = obj[key];
+	if (typeof v !== 'string' || !values.includes(v as T)) {
+		return failure(`"${key}" must be one of: ${values.join(', ')}`);
+	}
+	return { ok: true, value: v as T };
+}
+
+export function optionalEnum<T extends string>(
+	obj: Record<string, unknown>,
+	key: string,
+	values: readonly T[],
+	defaultValue: T,
+): WebMcpToolResult<T> {
+	const v = obj[key];
+	if (v === undefined) {
+		return { ok: true, value: defaultValue };
+	}
+	if (typeof v !== 'string' || !values.includes(v as T)) {
+		return failure(`"${key}" must be one of: ${values.join(', ')}`);
+	}
+	return { ok: true, value: v as T };
+}
+
+export function checkSizeLimit(
+	value: string,
+	maxChars: number,
+	label = 'Input',
+): WebMcpToolResult<string> {
+	if (value.length > maxChars) {
+		return failure(`${label} exceeds the maximum size limit`);
+	}
+	return { ok: true, value };
+}

--- a/src/lib/webmcp/validation.ts
+++ b/src/lib/webmcp/validation.ts
@@ -11,7 +11,9 @@ export function requireString(
 ): WebMcpToolResult<string> {
 	const v = obj[key];
 	if (typeof v !== 'string') {
-		return failure(`"${key}" must be a string / "${key}" は文字列で指定してください`);
+		return failure(
+			`"${key}" must be a string / "${key}" は文字列で指定してください`,
+		);
 	}
 	return { ok: true, value: v };
 }

--- a/tests/e2e/webmcp.spec.ts
+++ b/tests/e2e/webmcp.spec.ts
@@ -56,13 +56,13 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		);
 		expect(calls.length).toBeGreaterThan(0);
 
-		const lastCall = calls.at(-1);
+		const lastCall = calls.at(-1)!;
 		const toolNames = lastCall.tools.map((t: WebMcpMockTool) => t.name);
 		expect(toolNames).toContain('generate_hash');
 
 		const hashTool = lastCall.tools.find(
 			(t: WebMcpMockTool) => t.name === 'generate_hash',
-		);
+		)!;
 		expect(hashTool.inputSchema.required).toContain('text');
 		expect(hashTool.inputSchema.required).toContain('algorithm');
 	});
@@ -78,8 +78,8 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 
 		const result = await page.evaluate(async () => {
 			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
-				.at(-1)
-				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
+				.at(-1)!
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash')!;
 			return await tool.execute({ text: 'hello', algorithm: 'md5' });
 		});
 
@@ -95,12 +95,12 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		const toolPage = createToolPage('hash');
 		await toolPage.goto();
 
-		const result = await page.evaluate(async () => {
+		const result = (await page.evaluate(async () => {
 			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
-				.at(-1)
-				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
+				.at(-1)!
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash')!;
 			return await tool.execute({ text: null });
-		});
+		})) as { isError: boolean; error: string };
 
 		expect(result.isError).toBe(true);
 		expect(typeof result.error).toBe('string');
@@ -143,13 +143,13 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		);
 		expect(calls.length).toBeGreaterThan(0);
 
-		const lastCall = calls.at(-1);
+		const lastCall = calls.at(-1)!;
 		const toolNames = lastCall.tools.map((t: WebMcpMockTool) => t.name);
 		expect(toolNames).toContain('calc_tax');
 
 		const taxTool = lastCall.tools.find(
 			(t: WebMcpMockTool) => t.name === 'calc_tax',
-		);
+		)!;
 		expect(taxTool.inputSchema.required).toContain('amount');
 		expect(taxTool.inputSchema.required).toContain('taxRate');
 		expect(taxTool.inputSchema.required).toContain('mode');
@@ -166,8 +166,8 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 
 		const result = await page.evaluate(async () => {
 			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
-				.at(-1)
-				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax');
+				.at(-1)!
+				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax')!;
 			return await tool.execute({
 				amount: 10000,
 				taxRate: '10',
@@ -193,12 +193,12 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		const toolPage = createToolPage('tax');
 		await toolPage.goto();
 
-		const result = await page.evaluate(async () => {
+		const result = (await page.evaluate(async () => {
 			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
-				.at(-1)
-				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax');
+				.at(-1)!
+				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax')!;
 			return await tool.execute({ amount: 'not a number' });
-		});
+		})) as { isError: boolean; error: string };
 
 		expect(result.isError).toBe(true);
 		expect(typeof result.error).toBe('string');
@@ -299,8 +299,8 @@ test.describe('WebMCP — no external network requests with input data', () => {
 
 		await page.evaluate(async (input) => {
 			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
-				.at(-1)
-				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
+				.at(-1)!
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash')!;
 			await tool.execute({ text: input, algorithm: 'md5' });
 		}, secretInput);
 

--- a/tests/e2e/webmcp.spec.ts
+++ b/tests/e2e/webmcp.spec.ts
@@ -1,5 +1,21 @@
 import { expect, test } from './fixtures/base';
 
+interface WebMcpMockTool {
+	name: string;
+	inputSchema: { required: string[] };
+	execute: (input: Record<string, unknown>) => Promise<unknown>;
+}
+
+interface WebMcpMockCall {
+	tools: WebMcpMockTool[];
+}
+
+interface WebMcpMockWindow extends Window {
+	__webmcpCalls: WebMcpMockCall[];
+	__webmcpDisposed: boolean;
+	__webmcpCleared?: boolean;
+}
+
 const WEBMCP_INIT_SCRIPT = `
 (() => {
   window.__webmcpCalls = [];
@@ -35,15 +51,17 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		const toolPage = createToolPage('hash');
 		await toolPage.goto();
 
-		const calls = await page.evaluate(() => (window as any).__webmcpCalls);
+		const calls = await page.evaluate(
+			() => (window as unknown as WebMcpMockWindow).__webmcpCalls,
+		);
 		expect(calls.length).toBeGreaterThan(0);
 
 		const lastCall = calls.at(-1);
-		const toolNames = lastCall.tools.map((t: any) => t.name);
+		const toolNames = lastCall.tools.map((t: WebMcpMockTool) => t.name);
 		expect(toolNames).toContain('generate_hash');
 
 		const hashTool = lastCall.tools.find(
-			(t: any) => t.name === 'generate_hash',
+			(t: WebMcpMockTool) => t.name === 'generate_hash',
 		);
 		expect(hashTool.inputSchema.required).toContain('text');
 		expect(hashTool.inputSchema.required).toContain('algorithm');
@@ -59,9 +77,9 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		await toolPage.goto();
 
 		const result = await page.evaluate(async () => {
-			const tool = (window as any).__webmcpCalls
+			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
 				.at(-1)
-				.tools.find((t: any) => t.name === 'generate_hash');
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
 			return await tool.execute({ text: 'hello', algorithm: 'md5' });
 		});
 
@@ -78,9 +96,9 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		await toolPage.goto();
 
 		const result = await page.evaluate(async () => {
-			const tool = (window as any).__webmcpCalls
+			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
 				.at(-1)
-				.tools.find((t: any) => t.name === 'generate_hash');
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
 			return await tool.execute({ text: null });
 		});
 
@@ -98,13 +116,13 @@ test.describe('WebMCP Tool Registration — /hash', () => {
 		await toolPage.goto();
 
 		const hasDispose = await page.evaluate(() => {
-			const calls = (window as any).__webmcpCalls;
+			const calls = (window as unknown as WebMcpMockWindow).__webmcpCalls;
 			return calls.length > 0;
 		});
 		expect(hasDispose).toBe(true);
 
 		const disposedBefore = await page.evaluate(
-			() => (window as any).__webmcpDisposed,
+			() => (window as unknown as WebMcpMockWindow).__webmcpDisposed,
 		);
 		expect(disposedBefore).toBe(false);
 	});
@@ -120,14 +138,18 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		const toolPage = createToolPage('tax');
 		await toolPage.goto();
 
-		const calls = await page.evaluate(() => (window as any).__webmcpCalls);
+		const calls = await page.evaluate(
+			() => (window as unknown as WebMcpMockWindow).__webmcpCalls,
+		);
 		expect(calls.length).toBeGreaterThan(0);
 
 		const lastCall = calls.at(-1);
-		const toolNames = lastCall.tools.map((t: any) => t.name);
+		const toolNames = lastCall.tools.map((t: WebMcpMockTool) => t.name);
 		expect(toolNames).toContain('calc_tax');
 
-		const taxTool = lastCall.tools.find((t: any) => t.name === 'calc_tax');
+		const taxTool = lastCall.tools.find(
+			(t: WebMcpMockTool) => t.name === 'calc_tax',
+		);
 		expect(taxTool.inputSchema.required).toContain('amount');
 		expect(taxTool.inputSchema.required).toContain('taxRate');
 		expect(taxTool.inputSchema.required).toContain('mode');
@@ -143,9 +165,9 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		await toolPage.goto();
 
 		const result = await page.evaluate(async () => {
-			const tool = (window as any).__webmcpCalls
+			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
 				.at(-1)
-				.tools.find((t: any) => t.name === 'calc_tax');
+				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax');
 			return await tool.execute({
 				amount: 10000,
 				taxRate: '10',
@@ -172,9 +194,9 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		await toolPage.goto();
 
 		const result = await page.evaluate(async () => {
-			const tool = (window as any).__webmcpCalls
+			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
 				.at(-1)
-				.tools.find((t: any) => t.name === 'calc_tax');
+				.tools.find((t: WebMcpMockTool) => t.name === 'calc_tax');
 			return await tool.execute({ amount: 'not a number' });
 		});
 
@@ -192,13 +214,13 @@ test.describe('WebMCP Tool Registration — /tax', () => {
 		await toolPage.goto();
 
 		const hasDispose = await page.evaluate(() => {
-			const calls = (window as any).__webmcpCalls;
+			const calls = (window as unknown as WebMcpMockWindow).__webmcpCalls;
 			return calls.length > 0;
 		});
 		expect(hasDispose).toBe(true);
 
 		const disposedBefore = await page.evaluate(
-			() => (window as any).__webmcpDisposed,
+			() => (window as unknown as WebMcpMockWindow).__webmcpDisposed,
 		);
 		expect(disposedBefore).toBe(false);
 	});
@@ -276,9 +298,9 @@ test.describe('WebMCP — no external network requests with input data', () => {
 		await toolPage.goto();
 
 		await page.evaluate(async (input) => {
-			const tool = (window as any).__webmcpCalls
+			const tool = (window as unknown as WebMcpMockWindow).__webmcpCalls
 				.at(-1)
-				.tools.find((t: any) => t.name === 'generate_hash');
+				.tools.find((t: WebMcpMockTool) => t.name === 'generate_hash');
 			await tool.execute({ text: input, algorithm: 'md5' });
 		}, secretInput);
 

--- a/tests/e2e/webmcp.spec.ts
+++ b/tests/e2e/webmcp.spec.ts
@@ -1,0 +1,287 @@
+import { expect, test } from './fixtures/base';
+
+const WEBMCP_INIT_SCRIPT = `
+(() => {
+  window.__webmcpCalls = [];
+  window.__webmcpDisposed = false;
+
+  Object.defineProperty(navigator, 'modelContext', {
+    configurable: true,
+    value: {
+      provideContext(args) {
+        window.__webmcpCalls.push(args);
+        return {
+          dispose() {
+            window.__webmcpDisposed = true;
+            console.log('__webmcp_disposed__');
+          },
+        };
+      },
+      clearContext() {
+        window.__webmcpCleared = true;
+      },
+    },
+  });
+})();
+`;
+
+test.describe('WebMCP Tool Registration — /hash', () => {
+	test('generate_hash tool is registered via mock modelContext', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const calls = await page.evaluate(() => (window as any).__webmcpCalls);
+		expect(calls.length).toBeGreaterThan(0);
+
+		const lastCall = calls.at(-1);
+		const toolNames = lastCall.tools.map((t: any) => t.name);
+		expect(toolNames).toContain('generate_hash');
+
+		const hashTool = lastCall.tools.find(
+			(t: any) => t.name === 'generate_hash',
+		);
+		expect(hashTool.inputSchema.required).toContain('text');
+		expect(hashTool.inputSchema.required).toContain('algorithm');
+	});
+
+	test('generate_hash execute returns correct hash for valid input', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const result = await page.evaluate(async () => {
+			const tool = (window as any).__webmcpCalls
+				.at(-1)
+				.tools.find((t: any) => t.name === 'generate_hash');
+			return await tool.execute({ text: 'hello', algorithm: 'md5' });
+		});
+
+		expect(result).toEqual({ hash: '5d41402abc4b2a76b9719d911017c592' });
+	});
+
+	test('generate_hash execute returns isError for invalid input', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const result = await page.evaluate(async () => {
+			const tool = (window as any).__webmcpCalls
+				.at(-1)
+				.tools.find((t: any) => t.name === 'generate_hash');
+			return await tool.execute({ text: null });
+		});
+
+		expect(result.isError).toBe(true);
+		expect(typeof result.error).toBe('string');
+	});
+
+	test('cleanup dispose function is returned from provideContext', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const hasDispose = await page.evaluate(() => {
+			const calls = (window as any).__webmcpCalls;
+			return calls.length > 0;
+		});
+		expect(hasDispose).toBe(true);
+
+		const disposedBefore = await page.evaluate(
+			() => (window as any).__webmcpDisposed,
+		);
+		expect(disposedBefore).toBe(false);
+	});
+});
+
+test.describe('WebMCP Tool Registration — /tax', () => {
+	test('calc_tax tool is registered via mock modelContext', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('tax');
+		await toolPage.goto();
+
+		const calls = await page.evaluate(() => (window as any).__webmcpCalls);
+		expect(calls.length).toBeGreaterThan(0);
+
+		const lastCall = calls.at(-1);
+		const toolNames = lastCall.tools.map((t: any) => t.name);
+		expect(toolNames).toContain('calc_tax');
+
+		const taxTool = lastCall.tools.find((t: any) => t.name === 'calc_tax');
+		expect(taxTool.inputSchema.required).toContain('amount');
+		expect(taxTool.inputSchema.required).toContain('taxRate');
+		expect(taxTool.inputSchema.required).toContain('mode');
+	});
+
+	test('calc_tax execute returns correct result for valid input', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('tax');
+		await toolPage.goto();
+
+		const result = await page.evaluate(async () => {
+			const tool = (window as any).__webmcpCalls
+				.at(-1)
+				.tools.find((t: any) => t.name === 'calc_tax');
+			return await tool.execute({
+				amount: 10000,
+				taxRate: '10',
+				mode: 'tax_excluded',
+			});
+		});
+
+		expect(result).toEqual({
+			base: 10000,
+			tax: 1000,
+			total: 11000,
+			result: 11000,
+			taxAmount: 1000,
+		});
+	});
+
+	test('calc_tax execute returns isError for invalid input', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('tax');
+		await toolPage.goto();
+
+		const result = await page.evaluate(async () => {
+			const tool = (window as any).__webmcpCalls
+				.at(-1)
+				.tools.find((t: any) => t.name === 'calc_tax');
+			return await tool.execute({ amount: 'not a number' });
+		});
+
+		expect(result.isError).toBe(true);
+		expect(typeof result.error).toBe('string');
+	});
+
+	test('cleanup dispose function is returned from provideContext', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const toolPage = createToolPage('tax');
+		await toolPage.goto();
+
+		const hasDispose = await page.evaluate(() => {
+			const calls = (window as any).__webmcpCalls;
+			return calls.length > 0;
+		});
+		expect(hasDispose).toBe(true);
+
+		const disposedBefore = await page.evaluate(
+			() => (window as any).__webmcpDisposed,
+		);
+		expect(disposedBefore).toBe(false);
+	});
+});
+
+test.describe('WebMCP — no modelContext', () => {
+	test('/hash page loads without error when modelContext is absent', async ({
+		page,
+		createToolPage,
+	}) => {
+		const errors: string[] = [];
+		page.on('pageerror', (err) => errors.push(err.message));
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		expect(errors).toHaveLength(0);
+	});
+
+	test('/tax page loads without error when modelContext is absent', async ({
+		page,
+		createToolPage,
+	}) => {
+		const errors: string[] = [];
+		page.on('pageerror', (err) => errors.push(err.message));
+
+		const toolPage = createToolPage('tax');
+		await toolPage.goto();
+
+		expect(errors).toHaveLength(0);
+	});
+});
+
+test.describe('WebMCP — partial modelContext (provideContext not a function)', () => {
+	test('/hash does not throw when modelContext exists but provideContext is not a function', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(`
+			Object.defineProperty(navigator, 'modelContext', {
+				configurable: true,
+				value: { notAFunction: true },
+			});
+		`);
+
+		const errors: string[] = [];
+		page.on('pageerror', (err) => errors.push(err.message));
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		expect(errors).toHaveLength(0);
+	});
+});
+
+test.describe('WebMCP — no external network requests with input data', () => {
+	test('/hash execute does not trigger external requests containing input data', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_INIT_SCRIPT);
+
+		const inputDataRequests: string[] = [];
+		const secretInput = 'secret_test_data_12345';
+
+		page.on('request', (req) => {
+			const url = req.url();
+			const postData = req.postData() ?? '';
+			if (url.includes(secretInput) || postData.includes(secretInput)) {
+				inputDataRequests.push(url);
+			}
+		});
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		await page.evaluate(async (input) => {
+			const tool = (window as any).__webmcpCalls
+				.at(-1)
+				.tools.find((t: any) => t.name === 'generate_hash');
+			await tool.execute({ text: input, algorithm: 'md5' });
+		}, secretInput);
+
+		expect(inputDataRequests).toHaveLength(0);
+	});
+});

--- a/tests/unit/webmcp-factory.test.ts
+++ b/tests/unit/webmcp-factory.test.ts
@@ -1,0 +1,557 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { failure, success } from '../../src/lib/webmcp/errors.ts';
+import { createWebMcpTool } from '../../src/lib/webmcp/tool-factory.ts';
+import { hashTool } from '../../src/lib/webmcp/tools/hash.webmcp.ts';
+import { taxTool } from '../../src/lib/webmcp/tools/tax.webmcp.ts';
+import {
+	checkSizeLimit,
+	isObject,
+	optionalEnum,
+	requireEnum,
+	requireNumber,
+	requireString,
+} from '../../src/lib/webmcp/validation.ts';
+
+// --- errors.ts ---
+
+test('errors: success wraps value correctly', () => {
+	const result = success({ hash: 'abc' });
+	assert.deepEqual(result, { ok: true, value: { hash: 'abc' } });
+});
+
+test('errors: failure wraps error message correctly', () => {
+	const result = failure('bad input');
+	assert.deepEqual(result, { ok: false, error: 'bad input' });
+});
+
+// --- validation.ts ---
+
+test('validation: isObject returns true for plain objects', () => {
+	assert.equal(isObject({}), true);
+	assert.equal(isObject({ a: 1 }), true);
+});
+
+test('validation: isObject returns false for non-objects', () => {
+	assert.equal(isObject(null), false);
+	assert.equal(isObject(undefined), false);
+	assert.equal(isObject('string'), false);
+	assert.equal(isObject(42), false);
+	assert.equal(isObject(true), false);
+});
+
+test('validation: requireString succeeds for string values', () => {
+	const result = requireString({ text: 'hello' }, 'text');
+	assert.deepEqual(result, { ok: true, value: 'hello' });
+});
+
+test('validation: requireString fails for non-string values', () => {
+	assert.equal(requireString({ text: 42 }, 'text').ok, false);
+	assert.equal(requireString({ text: null }, 'text').ok, false);
+	assert.equal(requireString({}, 'text').ok, false);
+});
+
+test('validation: requireNumber succeeds for finite numbers', () => {
+	const result = requireNumber({ amount: 1000 }, 'amount');
+	assert.deepEqual(result, { ok: true, value: 1000 });
+});
+
+test('validation: requireNumber fails for non-finite values', () => {
+	assert.equal(requireNumber({ amount: 'abc' }, 'amount').ok, false);
+	assert.equal(requireNumber({ amount: NaN }, 'amount').ok, false);
+	assert.equal(requireNumber({ amount: Infinity }, 'amount').ok, false);
+	assert.equal(requireNumber({}, 'amount').ok, false);
+});
+
+test('validation: requireEnum succeeds for valid enum values', () => {
+	const result = requireEnum({ algo: 'md5' }, 'algo', [
+		'md5',
+		'sha-256',
+	] as const);
+	assert.deepEqual(result, { ok: true, value: 'md5' });
+});
+
+test('validation: requireEnum fails for invalid enum values', () => {
+	assert.equal(
+		requireEnum({ algo: 'invalid' }, 'algo', ['md5', 'sha-256'] as const).ok,
+		false,
+	);
+	assert.equal(
+		requireEnum({ algo: 42 }, 'algo', ['md5', 'sha-256'] as const).ok,
+		false,
+	);
+});
+
+test('validation: optionalEnum uses default when key is missing', () => {
+	const result = optionalEnum(
+		{},
+		'rounding',
+		['floor', 'ceil'] as const,
+		'floor',
+	);
+	assert.deepEqual(result, { ok: true, value: 'floor' });
+});
+
+test('validation: optionalEnum uses provided value when present', () => {
+	const result = optionalEnum(
+		{ rounding: 'ceil' },
+		'rounding',
+		['floor', 'ceil'] as const,
+		'floor',
+	);
+	assert.deepEqual(result, { ok: true, value: 'ceil' });
+});
+
+test('validation: optionalEnum fails for invalid provided value', () => {
+	assert.equal(
+		optionalEnum(
+			{ rounding: 'bad' },
+			'rounding',
+			['floor', 'ceil'] as const,
+			'floor',
+		).ok,
+		false,
+	);
+});
+
+test('validation: checkSizeLimit passes for within-limit strings', () => {
+	const result = checkSizeLimit('hello', 10);
+	assert.deepEqual(result, { ok: true, value: 'hello' });
+});
+
+test('validation: checkSizeLimit fails for oversized strings', () => {
+	const result = checkSizeLimit('hello world', 5);
+	assert.equal(result.ok, false);
+});
+
+// --- tool-factory.ts ---
+
+test('tool-factory: createWebMcpTool wraps execute in try-catch and returns ok result', async () => {
+	const tool = createWebMcpTool({
+		name: 'test_tool',
+		description: 'Test',
+		inputSchema: {
+			type: 'object',
+			properties: { x: { type: 'string' } },
+			required: ['x'],
+		},
+		validate: (input) => {
+			if (!isObject(input) || typeof input.x !== 'string')
+				return failure('bad');
+			return success({ x: input.x });
+		},
+		execute: (input) => ({ result: input.x.toUpperCase() }),
+	});
+
+	const result = await tool.run({ x: 'hello' });
+	assert.deepEqual(result, { ok: true, value: { result: 'HELLO' } });
+});
+
+test('tool-factory: createWebMcpTool returns error for invalid input without throwing', async () => {
+	const tool = createWebMcpTool({
+		name: 'test_tool',
+		description: 'Test',
+		inputSchema: { type: 'object', properties: {}, required: [] },
+		validate: () => failure('validation failed'),
+		execute: () => 'never reached',
+	});
+
+	const result = await tool.run({});
+	assert.deepEqual(result, { ok: false, error: 'validation failed' });
+});
+
+test('tool-factory: createWebMcpTool catches thrown errors in execute', async () => {
+	const tool = createWebMcpTool({
+		name: 'test_tool',
+		description: 'Test',
+		inputSchema: { type: 'object', properties: {}, required: [] },
+		validate: () => success(null),
+		execute: () => {
+			throw new Error('boom');
+		},
+	});
+
+	const result = await tool.run({});
+	assert.deepEqual(result, { ok: false, error: 'boom' });
+});
+
+test('tool-factory: createWebMcpTool catches non-Error thrown values', async () => {
+	const tool = createWebMcpTool({
+		name: 'test_tool',
+		description: 'Test',
+		inputSchema: { type: 'object', properties: {}, required: [] },
+		validate: () => success(null),
+		execute: () => {
+			throw 'string error';
+		},
+	});
+
+	const result = await tool.run({});
+	assert.deepEqual(result, {
+		ok: false,
+		error: 'An unexpected error occurred',
+	});
+});
+
+test('tool-factory: createWebMcpTool preserves metadata', () => {
+	const tool = createWebMcpTool({
+		name: 'my_tool',
+		description: 'My tool description',
+		inputSchema: {
+			type: 'object',
+			properties: { a: { type: 'string' } },
+			required: ['a'],
+		},
+		outputSchema: {
+			type: 'object',
+			properties: { b: { type: 'string' } },
+			required: ['b'],
+		},
+		validate: () => success(null),
+		execute: () => ({ b: 'val' }),
+	});
+
+	assert.equal(tool.name, 'my_tool');
+	assert.equal(tool.description, 'My tool description');
+	assert.deepEqual(tool.inputSchema, {
+		type: 'object',
+		properties: { a: { type: 'string' } },
+		required: ['a'],
+	});
+	assert.deepEqual(tool.outputSchema, {
+		type: 'object',
+		properties: { b: { type: 'string' } },
+		required: ['b'],
+	});
+});
+
+// --- inputSchema.required と validate の一致を機械検証 ---
+
+function getRequiredFields(schema: Record<string, unknown>): string[] {
+	const required = schema.required;
+	if (!Array.isArray(required)) return [];
+	return [...required].sort();
+}
+
+function testValidationRejectsEachRequiredField(
+	toolName: string,
+	tool: {
+		inputSchema: Record<string, unknown>;
+		run: (input: unknown) => Promise<{ ok: boolean }>;
+	},
+	validInput: Record<string, unknown>,
+) {
+	const requiredFields = getRequiredFields(tool.inputSchema);
+
+	for (const field of requiredFields) {
+		test(`${toolName}: validate rejects input when required field "${field}" is missing`, async () => {
+			const incomplete = { ...validInput };
+			delete incomplete[field];
+			const result = await tool.run(incomplete);
+			assert.equal(
+				result.ok,
+				false,
+				`Should reject when "${field}" is missing`,
+			);
+		});
+	}
+}
+
+// --- hash.webmcp.ts ---
+
+test('hash tool: has correct name and schema', () => {
+	assert.equal(hashTool.name, 'generate_hash');
+	assert.ok(hashTool.description.length > 0);
+	assert.deepEqual(getRequiredFields(hashTool.inputSchema), [
+		'algorithm',
+		'text',
+	]);
+	assert.ok(hashTool.outputSchema);
+});
+
+test('hash tool: computes MD5 hash correctly', async () => {
+	const result = await hashTool.run({ text: 'hello', algorithm: 'md5' });
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.hash, '5d41402abc4b2a76b9719d911017c592');
+	}
+});
+
+test('hash tool: computes SHA-256 hash correctly', async () => {
+	const result = await hashTool.run({ text: 'abc', algorithm: 'sha-256' });
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(
+			result.value.hash,
+			'ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad',
+		);
+	}
+});
+
+test('hash tool: computes SHA-512 hash correctly', async () => {
+	const result = await hashTool.run({ text: 'abc', algorithm: 'sha-512' });
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(
+			result.value.hash,
+			'ddaf35a193617abacc417349ae20413112e6fa4e89a97ea20a9eeee64b55d39a2192992a274fc1a836ba3c23a3feebbd454d4423643ce80e2a9ac94fa54ca49f',
+		);
+	}
+});
+
+test('hash tool: rejects null input', async () => {
+	const result = await hashTool.run(null);
+	assert.equal(result.ok, false);
+});
+
+test('hash tool: rejects missing text', async () => {
+	const result = await hashTool.run({ algorithm: 'md5' });
+	assert.equal(result.ok, false);
+});
+
+test('hash tool: rejects missing algorithm', async () => {
+	const result = await hashTool.run({ text: 'hello' });
+	assert.equal(result.ok, false);
+});
+
+test('hash tool: rejects invalid algorithm', async () => {
+	const result = await hashTool.run({ text: 'hello', algorithm: 'sha-1024' });
+	assert.equal(result.ok, false);
+});
+
+test('hash tool: rejects non-string text', async () => {
+	const result = await hashTool.run({ text: 123, algorithm: 'md5' });
+	assert.equal(result.ok, false);
+});
+
+testValidationRejectsEachRequiredField('hash', hashTool, {
+	text: 'hello',
+	algorithm: 'md5',
+});
+
+// --- tax.webmcp.ts ---
+
+test('tax tool: has correct name and schema', () => {
+	assert.equal(taxTool.name, 'calc_tax');
+	assert.ok(taxTool.description.length > 0);
+	assert.deepEqual(getRequiredFields(taxTool.inputSchema), [
+		'amount',
+		'mode',
+		'taxRate',
+	]);
+	assert.ok(taxTool.outputSchema);
+});
+
+test('tax tool: calculates tax-excluded to tax-included correctly (10000 * 10%)', async () => {
+	const result = await taxTool.run({
+		amount: 10000,
+		taxRate: '10',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.base, 10000);
+		assert.equal(result.value.tax, 1000);
+		assert.equal(result.value.total, 11000);
+		assert.equal(result.value.result, 11000);
+		assert.equal(result.value.taxAmount, 1000);
+	}
+});
+
+test('tax tool: calculates tax-included to tax-excluded correctly (1100 * 10%)', async () => {
+	const result = await taxTool.run({
+		amount: 1100,
+		taxRate: '10',
+		mode: 'tax_included',
+	});
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.base, 1000);
+		assert.equal(result.value.tax, 100);
+		assert.equal(result.value.total, 1100);
+		assert.equal(result.value.result, 1000);
+	}
+});
+
+test('tax tool: uses floor rounding by default', async () => {
+	const result = await taxTool.run({
+		amount: 101,
+		taxRate: '10',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.tax, 10);
+	}
+});
+
+test('tax tool: uses ceil rounding when specified', async () => {
+	const result = await taxTool.run({
+		amount: 101,
+		taxRate: '10',
+		mode: 'tax_excluded',
+		rounding: 'ceil',
+	});
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.tax, 11);
+	}
+});
+
+test('tax tool: supports reduced tax rate (8_reduced)', async () => {
+	const result = await taxTool.run({
+		amount: 1000,
+		taxRate: '8_reduced',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, true);
+	if (result.ok) {
+		assert.equal(result.value.tax, 80);
+		assert.equal(result.value.total, 1080);
+	}
+});
+
+test('tax tool: rejects null input', async () => {
+	const result = await taxTool.run(null);
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects missing amount', async () => {
+	const result = await taxTool.run({ taxRate: '10', mode: 'tax_excluded' });
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects missing taxRate', async () => {
+	const result = await taxTool.run({ amount: 1000, mode: 'tax_excluded' });
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects missing mode', async () => {
+	const result = await taxTool.run({ amount: 1000, taxRate: '10' });
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects invalid taxRate', async () => {
+	const result = await taxTool.run({
+		amount: 1000,
+		taxRate: '15',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects invalid mode', async () => {
+	const result = await taxTool.run({
+		amount: 1000,
+		taxRate: '10',
+		mode: 'bad_mode',
+	});
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects non-number amount', async () => {
+	const result = await taxTool.run({
+		amount: 'abc',
+		taxRate: '10',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects NaN amount', async () => {
+	const result = await taxTool.run({
+		amount: NaN,
+		taxRate: '10',
+		mode: 'tax_excluded',
+	});
+	assert.equal(result.ok, false);
+});
+
+test('tax tool: rejects invalid rounding', async () => {
+	const result = await taxTool.run({
+		amount: 1000,
+		taxRate: '10',
+		mode: 'tax_excluded',
+		rounding: 'truncate',
+	});
+	assert.equal(result.ok, false);
+});
+
+testValidationRejectsEachRequiredField('tax', taxTool, {
+	amount: 1000,
+	taxRate: '10',
+	mode: 'tax_excluded',
+});
+
+// --- provideToolsFromFactory adapter ---
+
+test('provideToolsFromFactory: wraps tool results with isError for failures', async () => {
+	const { provideToolsFromFactory } = await import('../../src/lib/webmcp.ts');
+
+	let registeredTools: Array<{
+		execute: (input: unknown) => Promise<unknown>;
+	}> = [];
+
+	const originalDocument = globalThis.document;
+	const originalWindow = globalThis.window;
+
+	Object.defineProperty(globalThis, 'window', {
+		value: {},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			modelContext: {
+				registerTool(tool: unknown) {
+					registeredTools.push(
+						tool as { execute: (input: unknown) => Promise<unknown> },
+					);
+					return { unregister() {} };
+				},
+			},
+		},
+		configurable: true,
+	});
+
+	try {
+		const testTool = createWebMcpTool({
+			name: 'test_adapter',
+			description: 'Test adapter',
+			inputSchema: {
+				type: 'object',
+				properties: { x: { type: 'string' } },
+				required: ['x'],
+			},
+			validate: (input) => {
+				if (!isObject(input) || typeof input.x !== 'string')
+					return failure('bad input');
+				return success({ x: input.x });
+			},
+			execute: (input: { x: string }) => ({ upper: input.x.toUpperCase() }),
+		});
+
+		provideToolsFromFactory([testTool]);
+
+		assert.equal(registeredTools.length, 1);
+
+		const successResult = await registeredTools[0].execute({ x: 'hello' });
+		assert.deepEqual(successResult, { upper: 'HELLO' });
+
+		const errorResult = (await registeredTools[0].execute({ x: 123 })) as {
+			error: string;
+			isError: boolean;
+		};
+		assert.equal(errorResult.isError, true);
+		assert.equal(typeof errorResult.error, 'string');
+	} finally {
+		Object.defineProperty(globalThis, 'document', {
+			value: originalDocument,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+		});
+		registeredTools = [];
+	}
+});

--- a/tests/unit/webmcp-factory.test.ts
+++ b/tests/unit/webmcp-factory.test.ts
@@ -189,7 +189,7 @@ test('tool-factory: createWebMcpTool catches non-Error thrown values', async () 
 	const result = await tool.run({});
 	assert.deepEqual(result, {
 		ok: false,
-		error: 'An unexpected error occurred',
+		error: 'An unexpected error occurred / 予期しないエラーが発生しました',
 	});
 });
 
@@ -543,6 +543,73 @@ test('provideToolsFromFactory: wraps tool results with isError for failures', as
 		};
 		assert.equal(errorResult.isError, true);
 		assert.equal(typeof errorResult.error, 'string');
+	} finally {
+		Object.defineProperty(globalThis, 'document', {
+			value: originalDocument,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+		});
+		registeredTools = [];
+	}
+});
+
+test('provideToolsFromFactory: forwards outputSchema to registered tool', async () => {
+	const { provideToolsFromFactory } = await import('../../src/lib/webmcp.ts');
+
+	let registeredTools: Array<Record<string, unknown>> = [];
+
+	const originalDocument = globalThis.document;
+	const originalWindow = globalThis.window;
+
+	Object.defineProperty(globalThis, 'window', {
+		value: {},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			modelContext: {
+				registerTool(tool: unknown) {
+					registeredTools.push(tool as Record<string, unknown>);
+					return { unregister() {} };
+				},
+			},
+		},
+		configurable: true,
+	});
+
+	try {
+		const testTool = createWebMcpTool({
+			name: 'test_output_schema',
+			description: 'Test outputSchema forwarding',
+			inputSchema: {
+				type: 'object',
+				properties: { x: { type: 'string' } },
+				required: ['x'],
+			},
+			outputSchema: {
+				type: 'object',
+				properties: { upper: { type: 'string' } },
+				required: ['upper'],
+			},
+			validate: (input) => {
+				if (!isObject(input) || typeof input.x !== 'string')
+					return failure('bad');
+				return success({ x: input.x });
+			},
+			execute: (input: { x: string }) => ({ upper: input.x.toUpperCase() }),
+		});
+
+		provideToolsFromFactory([testTool]);
+
+		assert.equal(registeredTools.length, 1);
+		assert.deepEqual(registeredTools[0].outputSchema, {
+			type: 'object',
+			properties: { upper: { type: 'string' } },
+			required: ['upper'],
+		});
 	} finally {
 		Object.defineProperty(globalThis, 'document', {
 			value: originalDocument,


### PR DESCRIPTION
## Summary

WebMCP横展開計画書 PR 1「WebMCP基盤の横展開準備」の実装です。

既存の `/hash`・`/tax` ページにインライン定義されていたWebMCPツール定義を、共通ファクトリ(`createWebMcpTool`)ベースの構造へ移行しました。これにより、今後のツール横展開時に統一されたパターンで安全にWebMCPツールを追加できます。

- **共通基盤の新設**: `src/lib/webmcp/{tool-factory,validation,errors}.ts`
  - `createWebMcpTool()`: try-catch・validation を標準化するファクトリ
  - 内部結果表現 `{ ok: true, value }` / `{ ok: false, error }` を採用
  - `provideToolsFromFactory()`: 内部Result → MCP `isError: true` への変換アダプタ
- **ツール定義の分離**: `src/lib/webmcp/tools/{hash,tax}.webmcp.ts`
  - `description` を英語・日英併記に変更
  - `outputSchema` を追加
  - `inputSchema.required` と `validate` の一致を機械検証するテスト付き
- **React island の薄型化**: `provideToolsFromFactory([hashTool])` の1行に集約
- **既存UIの挙動に差分なし**: 回帰テスト17件全パス

## 新規ファイル

| ファイル | 役割 |
|---|---|
| `src/lib/webmcp/errors.ts` | `WebMcpToolResult<T>` 型、`success()` / `failure()` ヘルパー |
| `src/lib/webmcp/tool-factory.ts` | `createWebMcpTool()` ファクトリ |
| `src/lib/webmcp/validation.ts` | `isObject` / `requireString` / `requireEnum` 等の共通バリデータ |
| `src/lib/webmcp/tools/hash.webmcp.ts` | `generate_hash` ツール定義 |
| `src/lib/webmcp/tools/tax.webmcp.ts` | `calc_tax` ツール定義 |
| `tests/unit/webmcp-factory.test.ts` | ユニットテスト 50件 |
| `tests/e2e/webmcp.spec.ts` | E2Eテスト 12件 |

## Test plan

- [x] `npm run build` 成功
- [x] `npm run test:unit` — 新規50件パス (webmcp-factory.test.ts)
- [x] `npx playwright test tests/e2e/webmcp.spec.ts` — 新規12件パス
- [x] `npx playwright test tests/e2e/hash.spec.ts tests/e2e/tax.spec.ts` — 既存17件パス（回帰なし）
- [x] `npm run lint` — エラーなし（e2e内の `any` は Playwright evaluate コンテキストのため警告のみ）
- [x] `navigator.modelContext` 未対応環境でエラーなし (e2e テスト確認済み)
- [x] `modelContext` 存在するが `provideContext` が関数でない場合に no-op (e2e テスト確認済み)
- [x] 入力値の外部送信なし (e2e テスト確認済み)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AzS7R6ueTmZjCbKkogz18n

---
_Generated by [Claude Code](https://claude.ai/code/session_01AzS7R6ueTmZjCbKkogz18n)_