### PR TITLE
fix(text-diff): normalize trailing newline in computeDiff for minimal line diff

### DIFF
--- a/src/lib/tools/text-diff.ts
+++ b/src/lib/tools/text-diff.ts
@@ -33,8 +33,14 @@ export function computeDiff(
 	textB: string,
 	mode: DiffMode,
 ): DiffResult {
-	const changes =
-		mode === 'lines' ? diffLines(textA, textB) : diffChars(textA, textB);
+	let changes: Change[];
+	if (mode === 'lines') {
+		const normA = textA === '' || textA.endsWith('\n') ? textA : `${textA}\n`;
+		const normB = textB === '' || textB.endsWith('\n') ? textB : `${textB}\n`;
+		changes = diffLines(normA, normB);
+	} else {
+		changes = diffChars(textA, textB);
+	}
 	const parts = mapChanges(changes);
 
 	let addedLines = 0;

--- a/tests/unit/text-diff.test.ts
+++ b/tests/unit/text-diff.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { computeDiff } from '../../src/lib/tools/text-diff';
+
+test('computeDiff: 末尾への行追加で既存行が未変更として維持される', () => {
+	const textA = 'line1\nline2';
+	const textB = 'line1\nline2\nline3';
+
+	const result = computeDiff(textA, textB, 'lines');
+
+	// line1 と line2 が unchanged であること
+	const unchanged = result.parts.filter((p) => p.type === 'unchanged');
+	const added = result.parts.filter((p) => p.type === 'added');
+	const removed = result.parts.filter((p) => p.type === 'removed');
+
+	assert.ok(unchanged.length > 0, '未変更行が存在すること');
+	assert.strictEqual(removed.length, 0, '削除行がないこと');
+	assert.strictEqual(added.length, 1, '追加は1箇所（line3）のみであること');
+	assert.ok(added[0].value.includes('line3'), '追加内容にline3が含まれること');
+});
+
+test('computeDiff: 先頭追加・中間挿入で最小diffが生成される', () => {
+	const textA = 'line2\nline3';
+	const textB = 'line1\nline2\nline2.5\nline3';
+
+	const result = computeDiff(textA, textB, 'lines');
+	assert.strictEqual(result.removedLines, 0);
+	assert.strictEqual(result.addedLines, 2);
+});


### PR DESCRIPTION
Automated fix for Notion debug task.