### PR TITLE
fix(regex-tester): add safety guard for empty match and surrogate pair boundary in execRegexSync

### DIFF
--- a/src/lib/string-utils.ts
+++ b/src/lib/string-utils.ts
@@ -1,0 +1,94 @@
+/**
+ * コードポイント安全な文字列ユーティリティ
+ * サロゲートペアやUnicode Code Point / Grapheme Cluster を安全に扱う共通関数群
+ */
+
+/**
+ * 指定位置からサロゲートペアを考慮して次のコードポイントのインデックスを返す
+ */
+export function getNextCodePointIndex(str: string, index: number): number {
+	if (index >= str.length) return index + 1;
+	const code = str.charCodeAt(index);
+	// High surrogate (0xD800 - 0xDBFF)
+	if (code >= 0xd800 && code <= 0xdbff && index + 1 < str.length) {
+		const nextCode = str.charCodeAt(index + 1);
+		// Low surrogate (0xDC00 - 0xDFFF)
+		if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+			return index + 2;
+		}
+	}
+	return index + 1;
+}
+
+/**
+ * 文字列をコードポイントの配列に分解する
+ */
+export function getCodePoints(str: string): number[] {
+	const codePoints: number[] = [];
+	for (const char of str) {
+		const cp = char.codePointAt(0);
+		if (cp !== undefined) {
+			codePoints.push(cp);
+		}
+	}
+	return codePoints;
+}
+
+/**
+ * コードポイント配列から文字列を復元する
+ */
+export function fromCodePoints(codePoints: number[]): string {
+	return String.fromCodePoint(...codePoints);
+}
+
+/**
+ * 文字列をユニコードエスケープシーケンスに変換する
+ */
+export function escapeUnicode(str: string, useCodePointSyntax = false): string {
+	if (!str) return '';
+
+	let result = '';
+	for (const char of str) {
+		const codePoint = char.codePointAt(0);
+		if (codePoint === undefined) continue;
+
+		if (useCodePointSyntax) {
+			const hex = codePoint.toString(16).toUpperCase();
+			result += `\\u{${hex}}`;
+		} else {
+			if (codePoint > 0xffff) {
+				const high = Math.floor((codePoint - 0x10000) / 0x400) + 0xd800;
+				const low = ((codePoint - 0x10000) % 0x400) + 0xdc00;
+				const hexHigh = high.toString(16).padStart(4, '0');
+				const hexLow = low.toString(16).padStart(4, '0');
+				result += `\\u${hexHigh}\\u${hexLow}`;
+			} else {
+				const hex = codePoint.toString(16).padStart(4, '0');
+				result += `\\u${hex}`;
+			}
+		}
+	}
+	return result;
+}
+
+/**
+ * ユニコードエスケープシーケンスを解読・デコードする
+ */
+export function unescapeUnicode(unicodeStr: string): string {
+	if (!unicodeStr) return '';
+
+	return unicodeStr.replace(
+		/\\u(?:\{([0-9a-fA-F]+)\}|([0-9a-fA-F]{4}))/g,
+		(_, hexCodePoint, hexCodeUnit) => {
+			if (hexCodePoint) {
+				const cp = parseInt(hexCodePoint, 16);
+				return String.fromCodePoint(cp);
+			}
+			if (hexCodeUnit) {
+				const cu = parseInt(hexCodeUnit, 16);
+				return String.fromCharCode(cu);
+			}
+			return _;
+		},
+	);
+}

--- a/src/lib/tools/regex-tester.ts
+++ b/src/lib/tools/regex-tester.ts
@@ -1,3 +1,5 @@
+import { getNextCodePointIndex } from '../string-utils';
+
 export interface RegexMatch {
 	value: string;
 	index: number;
@@ -31,6 +33,66 @@ export const COMMON_PATTERNS = [
 ];
 
 const TIMEOUT_MS = 500;
+const MAX_MATCHES = 5000;
+
+/**
+ * 正規表現を評価する同期純粋関数（Web Worker内およびテストで共有）
+ */
+export function execRegexSync(
+	pattern: string,
+	flags: string,
+	text: string,
+	replacement?: string,
+): RegexResult {
+	if (!pattern) return { matches: [] };
+
+	try {
+		const regex = new RegExp(pattern, flags);
+		const matches: RegexMatch[] = [];
+
+		if (regex.global) {
+			let match: RegExpExecArray | null = regex.exec(text);
+			while (match !== null) {
+				matches.push({
+					value: match[0],
+					index: match.index,
+					groups: match.slice(1),
+				});
+
+				if (matches.length >= MAX_MATCHES) {
+					break;
+				}
+
+				if (match.index === regex.lastIndex) {
+					regex.lastIndex = getNextCodePointIndex(text, regex.lastIndex);
+				}
+
+				match = regex.exec(text);
+			}
+		} else {
+			const match = regex.exec(text);
+			if (match) {
+				matches.push({
+					value: match[0],
+					index: match.index,
+					groups: match.slice(1),
+				});
+			}
+		}
+
+		let replacedText: string | undefined;
+		if (replacement !== undefined) {
+			replacedText = text.replace(regex, replacement);
+		}
+
+		return { matches, replacedText };
+	} catch (err: unknown) {
+		return {
+			matches: [],
+			error: err instanceof Error ? err.message : String(err),
+		};
+	}
+}
 
 export async function testRegex(
 	pattern: string,

--- a/src/lib/tools/regex-worker.ts
+++ b/src/lib/tools/regex-worker.ts
@@ -1,4 +1,4 @@
-import type { RegexMatch, RegexResult } from './regex-tester';
+import { execRegexSync } from './regex-tester';
 
 type WorkerInput = {
 	pattern: string;
@@ -9,47 +9,6 @@ type WorkerInput = {
 
 self.onmessage = (event: MessageEvent<WorkerInput>) => {
 	const { pattern, flags, text, replacement } = event.data;
-
-	try {
-		const regex = new RegExp(pattern, flags);
-		const matches: RegexMatch[] = [];
-
-		if (regex.global) {
-			let match: RegExpExecArray | null = regex.exec(text);
-			while (match !== null) {
-				matches.push({
-					value: match[0],
-					index: match.index,
-					groups: match.slice(1),
-				});
-				if (match.index === regex.lastIndex) {
-					regex.lastIndex++;
-				}
-				match = regex.exec(text);
-			}
-		} else {
-			const match = regex.exec(text);
-			if (match) {
-				matches.push({
-					value: match[0],
-					index: match.index,
-					groups: match.slice(1),
-				});
-			}
-		}
-
-		let replacedText: string | undefined;
-		if (replacement !== undefined) {
-			replacedText = text.replace(regex, replacement);
-		}
-
-		const result: RegexResult = { matches, replacedText };
-		self.postMessage(result);
-	} catch (err: unknown) {
-		const result: RegexResult = {
-			matches: [],
-			error: err instanceof Error ? err.message : String(err),
-		};
-		self.postMessage(result);
-	}
+	const result = execRegexSync(pattern, flags, text, replacement);
+	self.postMessage(result);
 };

--- a/tests/unit/regex-tester.test.ts
+++ b/tests/unit/regex-tester.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { execRegexSync } from '../../src/lib/tools/regex-tester';
+
+test('execRegexSync: グローバル空文字マッチ（^ や .* 等）でフリーズせず安全に停止・列挙される', () => {
+	const result = execRegexSync('^', 'g', 'abc');
+	assert.ok(result.matches.length > 0);
+	assert.strictEqual(result.matches[0].value, '');
+	assert.strictEqual(result.matches[0].index, 0);
+
+	const emptyMatchResult = execRegexSync('a*', 'g', 'ba');
+	// フリーズ・無限ループせずに完了すること
+	assert.ok(Array.isArray(emptyMatchResult.matches));
+});
+
+test('execRegexSync: サロゲートペア（絵文字）を含むテキストでマッチ位置とコードポイント境界が正確に評価される', () => {
+	const text = 'A🎉B';
+	// u フラグありで Unicode code point マッチ
+	const result = execRegexSync('.', 'gu', text);
+	assert.strictEqual(result.matches.length, 3);
+	assert.strictEqual(result.matches[0].value, 'A');
+	assert.strictEqual(result.matches[0].index, 0);
+	assert.strictEqual(result.matches[1].value, '🎉');
+	assert.strictEqual(result.matches[1].index, 1);
+	assert.strictEqual(result.matches[2].value, 'B');
+	assert.strictEqual(result.matches[2].index, 3); // 🎉 は 2 UTF-16 code units なので 'B' の index は 3
+});


### PR DESCRIPTION
Automated fix for Notion debug task.