### PR TITLE
fix(url-encoder): throw explicit error on malformed uri component and disable copy button

### DIFF
--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -8,6 +8,7 @@ interface CopyButtonProps {
 	variant?: 'default' | 'outline' | 'ghost' | 'secondary';
 	size?: 'default' | 'sm' | 'lg' | 'icon';
 	className?: string;
+	disabled?: boolean;
 }
 
 export default function CopyButton({
@@ -16,6 +17,7 @@ export default function CopyButton({
 	variant = 'outline',
 	size = 'sm',
 	className = '',
+	disabled = false,
 }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
 
@@ -44,6 +46,7 @@ export default function CopyButton({
 			variant={variant}
 			size={size}
 			onClick={handleCopy}
+			disabled={disabled}
 			className={`transition-all ${copied ? 'copy-flash text-safety border-safety/50' : ''} ${className}`}
 			aria-label={copied ? 'コピーしました' : label}
 		>

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -136,7 +136,10 @@ export default function UrlEncoder() {
 					<div className="flex items-center justify-between mb-2 min-h-9 pl-0 md:pl-4">
 						<Label className="text-sm font-medium">変換結果</Label>
 						<div className="flex gap-2">
-							<CopyButton text={textResult.output} />
+							<CopyButton
+								text={textResult.output}
+								disabled={!textResult.output || !!textResult.error}
+							/>
 							<Button
 								variant="outline"
 								size="sm"

--- a/src/lib/tools/url-encoder.ts
+++ b/src/lib/tools/url-encoder.ts
@@ -25,9 +25,8 @@ export function encodeUrl(
 			return encodeURI(text);
 		}
 		return encodeURIComponent(text);
-	} catch (error) {
-		console.error('URL encoding error:', error);
-		return text;
+	} catch (_error) {
+		throw new Error('URLエンコード処理に失敗しました。');
 	}
 }
 
@@ -36,7 +35,7 @@ export function encodeUrl(
  *
  * @param text The URL-encoded string to decode.
  * @param options Options for decoding, choosing between component (decodeURIComponent) and full URL (decodeURI) modes.
- * @returns The decoded string. Returns the original string if decoding fails (e.g., malformed URI).
+ * @returns The decoded string.
  */
 export function decodeUrl(
 	text: string,
@@ -46,9 +45,6 @@ export function decodeUrl(
 
 	try {
 		// "+" is often used to represent space in query parameters
-		// decodeURIComponent doesn't convert "+" to space, so we do it manually if we are in component mode
-		// However, standard encodeURIComponent encodes space as "%20", not "+".
-		// To be safely handling "+", we replace it with "%20" before decoding.
 		const normalizedText =
 			options.mode === 'component' ? text.replace(/\+/g, '%20') : text;
 
@@ -56,9 +52,7 @@ export function decodeUrl(
 			return decodeURI(normalizedText);
 		}
 		return decodeURIComponent(normalizedText);
-	} catch (error) {
-		// Return original text if malformed URI component
-		console.error('URL decoding error:', error);
-		return text;
+	} catch (_error) {
+		throw new Error('不正なURLエスケープ形式です。デコードできません。');
 	}
 }

--- a/tests/unit/url-encoder.test.ts
+++ b/tests/unit/url-encoder.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { decodeUrl, encodeUrl } from '../../src/lib/tools/url-encoder';
+
+test('encodeUrl & decodeUrl: 正常系のエンコード・デコード往復', () => {
+	const text = 'https://example.com/検索?q=東京 天気';
+	const encoded = encodeUrl(text, { mode: 'component' });
+	const decoded = decodeUrl(encoded, { mode: 'component' });
+	assert.strictEqual(decoded, text);
+});
+
+test('decodeUrl: 不正な%シーケンス（サイレント失敗せず例外送出）', () => {
+	const malformed = '%E0%A4%A';
+	assert.throws(() => {
+		decodeUrl(malformed, { mode: 'component' });
+	}, /不正なURL/);
+});


### PR DESCRIPTION
Automated fix for Notion debug task.