### PR TITLE
feat: Cloudflare Analytics Engineを活用した匿名イベント計測機能を実装

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -2,68 +2,81 @@
 
 ## 方針
 
-CODE:LIFE Tools はクライアントサイド完結のツール集であり、ユーザーの入力データをサーバーへ送信しない。計測についても同様の思想を適用する。
+CODE:LIFE Tools はクライアントサイド完結のツール集であり、ユーザーの入力データ・ファイル内容・PII（個人情報）をサーバーへ送信しない。計測についても同様の思想を厳格に適用する。
 
-- **Cookie を使用しない** — Cloudflare Web Analytics は Cookie レスで動作し、同意バナーが不要。
-- **個人を識別・追跡しない** — ページビュー・リファラー等の集計データのみ収集。
-- **入力データを送信しない** — 各ツールで扱うデータは一切計測に含まれない。
-
----
-
-## Cloudflare Web Analytics
-
-### 概要
-
-Cloudflare Web Analytics のビーコンスクリプトを使用してページビューを計測する。ビーコンは軽量（< 5 KB）で、パフォーマンスへの影響は最小限。
-
-### セットアップ
-
-1. **Cloudflare ダッシュボード** > Web Analytics でサイト `tools.codelife.cafe` を追加し、サイトトークンを取得する。
-2. GitHub リポジトリの **Settings > Secrets and variables > Actions > Variables** に `PUBLIC_CF_BEACON_TOKEN` として登録する。
-   - Secret ではなく **Variable**（`vars`）を使用する。トークンは HTML に出力される公開値のため。
-3. デプロイは GitHub Actions（`.github/workflows/deploy.yml`）で `npm run build` を実行する際に環境変数として注入される。
-
-### 実装
-
-- **ビーコン挿入箇所**: `src/layouts/BaseLayout.astro` の `</body>` 直前に `<script defer>` で挿入。
-- **条件付き出力**: `PUBLIC_CF_BEACON_TOKEN` 環境変数が設定されている場合のみビーコンタグを出力する。未設定時（ローカル開発など）はタグ自体が生成されない。
-- **トークン注入**: GitHub Actions の Variables 経由で注入する。Cloudflare Pages ダッシュボードの環境変数ではない（ビルドが GitHub Actions 上で走るため）。
-
-### CSP (Content Security Policy)
-
-`public/_headers` で以下のドメインを許可済み:
-
-| ディレクティブ | ドメイン | 用途 |
-|---|---|---|
-| `script-src` | `https://static.cloudflareinsights.com` | `beacon.min.js` の配信元 |
-| `connect-src` | `https://cloudflareinsights.com` | `/cdn-cgi/rum` への計測データ送信先 |
+- **Cookie・ストレージによる個人の追跡を行わない** — Cookie や localStorage によるユーザー追跡・プロファイリングは一切行わない。
+- **個人を識別・追跡しない** — ページビュー・リファラー等の集計データおよび匿名の集計イベントのみ収集。
+- **入力・変換データを送信しない** — 各ツールで扱うテキスト・ファイル・入力パラメータ等の具体的な内容は一切計測に含まない。
+- **計測失敗による影響の遮断 (Fire-and-Forget)** — 計測ネットワークリクエストが失敗した場合でも握りつぶし、ツールの動作を妨げない。
 
 ---
 
-## Google Search Console
+## 収集イベント一覧 (Cloudflare Analytics Engine)
 
-### 登録手順
+改善効果を判定するため、以下の 5 つの完全匿名イベントを Cloudflare Analytics Engine 経由で収集する。
 
-1. [Google Search Console](https://search.google.com/search-console/) でドメインプロパティ `tools.codelife.cafe` を追加する。
-2. 所有権の確認は **Cloudflare 連携**（DNS 自動確認）が最も簡便。Cloudflare ダッシュボードで Google Search Console との連携を有効にすれば DNS レコードが自動追加される。
-3. サイトマップ `https://tools.codelife.cafe/sitemap-index.xml` を送信する。
+| イベント名 | 発火条件 | 収集プロパティ (Allowlist) | 目的 |
+|---|---|---|---|
+| `tool_run` | ツール実行・変換処理が走った時 | `{ tool: string }` (ツールslug) | ツールの利用頻度の計測 |
+| `tool_engage` | 個別ツールで初めて入力・操作があった時（タブ単位で1回） | `{ tool: string }` (ツールslug) | ツールごとの実活用セッション数の計測 |
+| `search_empty` | トップ検索でヒットが0件だった時 | `{ lengthBucket: string, hasJapanese: boolean, tokenCount: number, q_redacted?: boolean }` | 未対応ツール需要の把握（生検索語は非送信） |
+| `related_click` | 関連ツール回遊カードのクリック時 | `{ from: string, to: string }` (ツールslug) | ツール間回遊の導線効果の検証 |
+| `shared_url_open` | 共有URL経由で初期状態が復元された時 | `{ tool: string }` (ツールslug) | 共有機能の利用状況の検証 |
+
+### 特記事項・マスクルール
+- **`tool_engage` の「初回」の定義**: セッション単位（ブラウザタブが閉じられるまで）でツールごとに 1 回だけ発火する。JavaScript メモリ上の `Set` で重複発火を防止し、永続化しない。
+- **`search_empty` のマスクルール**: 検索語の生テキストは送信せず、集計用メタ情報（文字数バケット・日本語の有無・トークン数）のみを送信する。メールアドレスやURL、電話番号などの個人情報らしき文字列が含まれる場合は `q_redacted: true` フラグのみを付与する。
+- **slug の導出**: `tool`, `from`, `to` に渡す slug は、`src/lib/tools/catalog.ts` の定義を正本として利用し、文字列の手書きによる表記揺れを防止する。
 
 ---
 
-## Bing Webmaster Tools
+## 送信パイプライン & インフラ構成
 
-### 登録手順
+### アーキテクチャ
+`sendBeacon` / `fetch` (keepalive) → Pages Function (`/api/event`) → Cloudflare Analytics Engine (`EVENTS` Dataset)
 
-1. [Bing Webmaster Tools](https://www.bing.com/webmasters/) にアクセスする。
-2. **Google Search Console からインポート** を選択すると、設定をそのまま引き継げるため最も簡便。
-3. サイトマップは Google Search Console から自動的にインポートされる。
+1. **クライアントユーティリティ (`src/lib/analytics.ts`)**:
+   - `navigator.sendBeacon('/api/event', ...)` を優先使用し、未対応環境では `fetch` にフォールバックする。
+   - 開発環境 (`import.meta.env.DEV`) では送信をスキップし、`console.debug` にログ出力する。
+2. **Cloudflare Pages Function (`functions/api/event.ts`)**:
+   - 許可された Origin（本番ドメイン `https://tools.codelife.cafe` 等）および許可済みイベント名・Allowlist props のみを検証して受理する。
+   - 不正なリクエストや未許可のプロパティは 204 で静かに破棄する。
+   - `context.env.EVENTS.writeDataPoint(...)` を呼び出して Analytics Engine に書き込む。
+3. **Wrangler 設定 (`wrangler.jsonc`)**:
+   - Analytics Engine データセットのバインディング名: `EVENTS`
+   - データセット名: `tools_codelife_cafe_events`
 
 ---
 
-## robots.txt / sitemap
+## Cloudflare Web Analytics (RUM)
 
-- **robots.txt**: `public/robots.txt` に設定済み。
-- **sitemap**: `@astrojs/sitemap` インテグレーションにより自動生成される。
-  - `sitemap-index.xml` — サイトマップインデックス
-  - `sitemap-0.xml` — 個別のURL一覧
-- サイトマップの URL: `https://tools.codelife.cafe/sitemap-index.xml`
+ページビューやパフォーマンスの全体統計用に Cloudflare Web Analytics（RUM）を併用する。
+
+- **ビーコン挿入箇所**: `src/layouts/BaseLayout.astro` の `</body>` 直前に挿入。
+- **トークン管理**: GitHub Actions の Variables (`PUBLIC_CF_BEACON_TOKEN`) 経由で注入。
+- **制限事項**: カスタムイベントの保存先としては使用しない（本プロジェクトのカスタムイベントはすべて Analytics Engine に集約する）。
+
+---
+
+## 本番集計・可視化確認手順 (人間によるデプロイ後確認項目)
+
+本番環境デプロイ後、管理者は以下の手順で Analytics Engine に蓄積されたイベントデータを確認できる。
+
+1. **Cloudflare ダッシュボード**にログインする。
+2. **Analytics & Logs > Analytics Engine** を選択する。
+3. データセット `tools_codelife_cafe_events` を選択し、SQL クエリを実行して集計データを確認する。
+   ```sql
+   -- イベント別の発火件数集計
+   SELECT index1 AS event_name, COUNT(*) AS count
+   FROM tools_codelife_cafe_events
+   GROUP BY event_name
+   ORDER BY count DESC
+   ```
+   ```sql
+   -- ツール別の実行件数 (tool_run)
+   SELECT blob2 AS tool_slug, COUNT(*) AS count
+   FROM tools_codelife_cafe_events
+   WHERE index1 = 'tool_run'
+   GROUP BY tool_slug
+   ORDER BY count DESC
+   ```

--- a/functions/api/event.ts
+++ b/functions/api/event.ts
@@ -1,0 +1,112 @@
+interface Env {
+	EVENTS: {
+		writeDataPoint(data: {
+			blobs?: string[];
+			doubles?: number[];
+			indexes?: string[];
+		}): void;
+	};
+}
+
+interface EventPayload {
+	event: string;
+	props: Record<string, unknown>;
+	timestamp?: number;
+}
+
+const ALLOWED_EVENTS = new Set([
+	'tool_run',
+	'tool_engage',
+	'search_empty',
+	'related_click',
+	'shared_url_open',
+]);
+
+const ALLOWED_ORIGINS = new Set([
+	'https://tools.codelife.cafe',
+	'http://localhost:4321',
+	'http://127.0.0.1:4321',
+]);
+
+export const onRequestPost = async (context: {
+	request: Request;
+	env: Env;
+}): Promise<Response> => {
+	const origin = context.request.headers.get('origin');
+
+	// CORS / Origin チェック
+	// Originヘッダーが存在し、かつ許可リストに含まれていない場合は204で破棄
+	if (origin && !ALLOWED_ORIGINS.has(origin)) {
+		return new Response(null, { status: 204 });
+	}
+
+	const headers: Record<string, string> = {
+		'Access-Control-Allow-Methods': 'POST, OPTIONS',
+		'Access-Control-Allow-Headers': 'Content-Type',
+	};
+	if (origin && ALLOWED_ORIGINS.has(origin)) {
+		headers['Access-Control-Allow-Origin'] = origin;
+	}
+
+	try {
+		const body = (await context.request.json()) as Partial<EventPayload>;
+
+		if (!body || typeof body.event !== 'string' || !ALLOWED_EVENTS.has(body.event)) {
+			return new Response(null, { status: 204, headers });
+		}
+
+		const eventName = body.event;
+		const props = body.props && typeof body.props === 'object' ? body.props : {};
+
+		let toolSlug = '';
+		let extra1 = '';
+		let extra2 = '';
+
+		// allowlist 方式で props を抽出
+		if (eventName === 'tool_run' || eventName === 'tool_engage' || eventName === 'shared_url_open') {
+			if (typeof props.tool !== 'string') return new Response(null, { status: 204, headers });
+			toolSlug = props.tool;
+		} else if (eventName === 'related_click') {
+			if (typeof props.from !== 'string' || typeof props.to !== 'string') {
+				return new Response(null, { status: 204, headers });
+			}
+			toolSlug = props.from;
+			extra1 = props.to;
+		} else if (eventName === 'search_empty') {
+			if (typeof props.lengthBucket !== 'string' || typeof props.hasJapanese !== 'boolean') {
+				return new Response(null, { status: 204, headers });
+			}
+			extra1 = props.lengthBucket;
+			extra2 = props.hasJapanese ? 'ja' : 'other';
+		}
+
+		// Analytics Engine への書き込み
+		if (context.env?.EVENTS?.writeDataPoint) {
+			context.env.EVENTS.writeDataPoint({
+				blobs: [eventName, toolSlug, extra1, extra2],
+				indexes: [eventName],
+			});
+		}
+
+		return new Response(null, { status: 204, headers });
+	} catch (_err) {
+		return new Response(null, { status: 204, headers });
+	}
+};
+
+export const onRequestOptions = async (context: {
+	request: Request;
+}): Promise<Response> => {
+	const origin = context.request.headers.get('origin');
+	if (origin && ALLOWED_ORIGINS.has(origin)) {
+		return new Response(null, {
+			status: 204,
+			headers: {
+				'Access-Control-Allow-Origin': origin,
+				'Access-Control-Allow-Methods': 'POST, OPTIONS',
+				'Access-Control-Allow-Headers': 'Content-Type',
+			},
+		});
+	}
+	return new Response(null, { status: 204 });
+};

--- a/src/components/common/SearchModal.tsx
+++ b/src/components/common/SearchModal.tsx
@@ -1,7 +1,7 @@
 import { Search } from 'lucide-react';
 import type React from 'react';
 import { useEffect, useRef, useState } from 'react';
-
+import { getSearchQueryMetadata, track } from '@/lib/analytics';
 import { toolCatalog } from '@/lib/tools/catalog';
 import { searchTools } from '@/lib/tools/search';
 
@@ -12,6 +12,22 @@ export default function SearchModal() {
 	const inputRef = useRef<HTMLInputElement>(null);
 
 	const filteredTools = query ? searchTools(query) : toolCatalog;
+
+	// Track search_empty when query results in 0 tools
+	const trackedQueryRef = useRef<string>('');
+	useEffect(() => {
+		if (!query.trim() || filteredTools.length > 0) return;
+		if (trackedQueryRef.current === query) return;
+
+		const timer = setTimeout(() => {
+			if (trackedQueryRef.current !== query && filteredTools.length === 0) {
+				trackedQueryRef.current = query;
+				track('search_empty', getSearchQueryMetadata(query));
+			}
+		}, 500);
+
+		return () => clearTimeout(timer);
+	}, [query, filteredTools.length]);
 
 	// Search trigger & Keyboard shortcuts
 	useEffect(() => {

--- a/src/components/common/ToolCard.astro
+++ b/src/components/common/ToolCard.astro
@@ -1,5 +1,6 @@
 ---
 interface Props {
+  id?: string;
   title: string;
   description: string;
   href: string;
@@ -11,6 +12,7 @@ interface Props {
 }
 
 const {
+  id,
   title,
   description,
   href,
@@ -24,6 +26,7 @@ const {
 
 <a
   href={href}
+  data-tool-id={id}
   data-category={categoryId}
   class:list={[
     'group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border bg-card p-5 shadow-sm transition-all duration-200 hover:scale-[1.02] hover:shadow-lg hover:border-primary/30',

--- a/src/components/common/ToolLayout.astro
+++ b/src/components/common/ToolLayout.astro
@@ -106,11 +106,12 @@ const breadcrumbSchema = {
 
     <!-- Related tools (回遊カード) -->
     {relatedTools.length > 0 && (
-      <section class="mt-8" aria-labelledby="related-tools-heading">
+      <section id="related-tools-section" class="mt-8" aria-labelledby="related-tools-heading">
         <h2 id="related-tools-heading" class="text-lg font-semibold mb-4">関連ツール</h2>
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {relatedTools.map((t) => (
             <ToolCard
+              id={t.id}
               title={t.title}
               description={t.description}
               href={t.href}
@@ -142,3 +143,26 @@ const breadcrumbSchema = {
     }
   }
 </script>
+
+<script>
+  import { track } from '../../lib/analytics';
+  import { toolCatalog } from '../../lib/tools/catalog';
+
+  const container = document.querySelector('#related-tools-section');
+  if (container) {
+    const currentPath = window.location.pathname;
+    const currentTool = toolCatalog.find((t) => t.href === currentPath || `${t.href}/` === currentPath);
+    if (currentTool) {
+      container.addEventListener('click', (e) => {
+        const targetAnchor = (e.target as HTMLElement).closest('a[data-tool-id]');
+        if (targetAnchor) {
+          const targetId = targetAnchor.getAttribute('data-tool-id');
+          if (targetId) {
+            track('related_click', { from: currentTool.id, to: targetId });
+          }
+        }
+      });
+    }
+  }
+</script>
+

--- a/src/components/tools/Base64Converter.tsx
+++ b/src/components/tools/Base64Converter.tsx
@@ -7,6 +7,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	decodeBase64,
 	encodeBase64,
@@ -16,6 +17,7 @@ import {
 } from '@/lib/tools/base64';
 
 export default function Base64Converter() {
+	useToolAnalytics('base64');
 	const [tab, setTab] = useState('text');
 
 	// Text Tab State

--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
+import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { countChars, getTwitterProgress } from '@/lib/tools/char-count';
 
 function formatNumber(n: number): string {
@@ -12,6 +13,7 @@ function formatNumber(n: number): string {
 }
 
 export default function CharCount() {
+	useToolAnalytics('char-count');
 	const [text, setText] = useState('');
 
 	const result = useMemo(() => countChars(text), [text]);

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -12,6 +12,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	formatJson,
 	type IndentType,
@@ -30,9 +31,9 @@ function highlightJson(json: string) {
 			let cls = 'text-green-600 dark:text-green-400'; // number
 			if (/^"/.test(match)) {
 				if (/:$/.test(match)) {
-					cls = 'text-blue-600 dark:text-blue-400'; // key
+					cls = 'text-blue-600 dark:text-blue-400 font-semibold'; // key
 				} else {
-					cls = 'text-orange-600 dark:text-orange-400'; // string
+					cls = 'text-amber-600 dark:text-amber-400'; // string
 				}
 			} else if (/true|false/.test(match)) {
 				cls = 'text-purple-600 dark:text-purple-400'; // boolean
@@ -45,6 +46,7 @@ function highlightJson(json: string) {
 }
 
 export default function JsonFormatter() {
+	const { trackRun } = useToolAnalytics('json-formatter');
 	const [input, setInput] = useState('');
 	const [output, setOutput] = useState('');
 	const [indent, setIndent] = useState<IndentType>('2');
@@ -82,6 +84,7 @@ export default function JsonFormatter() {
 	}, [currentErrorLine]);
 
 	const handleFormat = useCallback(() => {
+		trackRun();
 		const result = formatJson(input, indent);
 		if (result.success) {
 			setOutput(result.output);
@@ -92,9 +95,10 @@ export default function JsonFormatter() {
 			setError(result.error ?? 'エラーが発生しました');
 			setErrorPosition(result.errorPosition ?? null);
 		}
-	}, [input, indent]);
+	}, [input, indent, trackRun]);
 
 	const handleMinify = useCallback(() => {
+		trackRun();
 		const result = minifyJson(input);
 		if (result.success) {
 			setOutput(result.output);
@@ -104,7 +108,7 @@ export default function JsonFormatter() {
 			setOutput('');
 			setError(result.error ?? 'エラーが発生しました');
 		}
-	}, [input]);
+	}, [input, trackRun]);
 
 	const handleDownload = useCallback(() => {
 		if (!output) return;

--- a/src/components/tools/ZenkakuHankaku.tsx
+++ b/src/components/tools/ZenkakuHankaku.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	type ConversionOptions,
 	convert,
@@ -13,6 +14,7 @@ import {
 } from '@/lib/tools/zenkaku-hankaku';
 
 export default function ZenkakuHankaku() {
+	useToolAnalytics('zenkaku-hankaku');
 	const [input, setInput] = useState('');
 	const [direction, setDirection] = useState<Direction>('toHankaku');
 	const [options, setOptions] = useState<ConversionOptions>({

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,110 @@
+export type AnalyticsEvents = {
+	tool_run: { tool: string };
+	tool_engage: { tool: string };
+	search_empty: {
+		lengthBucket: string;
+		hasJapanese: boolean;
+		tokenCount: number;
+		q_redacted?: boolean;
+	};
+	related_click: { from: string; to: string };
+	shared_url_open: { tool: string };
+};
+
+export type EventName = keyof AnalyticsEvents;
+
+// モジュールスコープで一度発火したエンゲージメントツールを記憶（タブ単位で保持）
+const engagedTools = new Set<string>();
+
+/**
+ * 検索語句からメタ情報を抽出する（生テキストは送信しない）
+ */
+export function getSearchQueryMetadata(
+	query: string,
+): AnalyticsEvents['search_empty'] {
+	const trimmed = query.trim();
+	const length = trimmed.length;
+
+	let lengthBucket = '0';
+	if (length === 0) lengthBucket = '0';
+	else if (length <= 3) lengthBucket = '1-3';
+	else if (length <= 10) lengthBucket = '4-10';
+	else if (length <= 30) lengthBucket = '11-30';
+	else lengthBucket = '31+';
+
+	const hasJapanese = /[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]/u.test(
+		trimmed,
+	);
+	const tokenCount = trimmed ? trimmed.split(/\s+/).length : 0;
+
+	// メールアドレス、URL、電話番号、極端に長い文字列等の個人情報らしきパターンを検出
+	const hasEmail = /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/.test(
+		trimmed,
+	);
+	const hasUrl = /https?:\/\/[^\s]+/.test(trimmed);
+	const hasPhone = /\d{2,4}[-\s]?\d{2,4}[-\s]?\d{3,4}/.test(trimmed);
+	const isTooLong = length > 100;
+
+	const q_redacted =
+		hasEmail || hasUrl || hasPhone || isTooLong ? true : undefined;
+
+	return {
+		lengthBucket,
+		hasJapanese,
+		tokenCount,
+		...(q_redacted ? { q_redacted: true } : {}),
+	};
+}
+
+/**
+ * 完全匿名のカスタムイベントを送信する
+ */
+export function track<K extends EventName>(
+	eventName: K,
+	props: AnalyticsEvents[K],
+): void {
+	if (typeof window === 'undefined') return;
+
+	try {
+		// tool_engage の重複発火防止制御（セッション/タブ単位）
+		if (eventName === 'tool_engage') {
+			const tool = (props as AnalyticsEvents['tool_engage']).tool;
+			if (engagedTools.has(tool)) return;
+			engagedTools.add(tool);
+		}
+
+		// 開発環境では送信をスキップしコンソールに出力
+		if (import.meta.env.DEV) {
+			console.debug('[analytics]', eventName, props);
+			return;
+		}
+
+		const payload = {
+			event: eventName,
+			props,
+			timestamp: Date.now(),
+		};
+
+		const blob = new Blob([JSON.stringify(payload)], {
+			type: 'application/json',
+		});
+
+		let sent = false;
+		if (typeof navigator !== 'undefined' && navigator.sendBeacon) {
+			sent = navigator.sendBeacon('/api/event', blob);
+		}
+
+		if (!sent && typeof fetch !== 'undefined') {
+			fetch('/api/event', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify(payload),
+				keepalive: true,
+			}).catch(() => {
+				// エラーは握りつぶす
+			});
+		}
+	} catch (_err) {
+		// 計測失敗でツールを絶対に止めないため握りつぶす
+	}
+}

--- a/src/lib/hooks/useToolAnalytics.ts
+++ b/src/lib/hooks/useToolAnalytics.ts
@@ -1,0 +1,27 @@
+import { useCallback, useEffect, useRef } from 'react';
+import { track } from '../analytics';
+
+export function useToolAnalytics(toolSlug: string) {
+	const hasEngagedRef = useRef(false);
+
+	useEffect(() => {
+		if (!toolSlug || hasEngagedRef.current) return;
+		hasEngagedRef.current = true;
+		track('tool_engage', { tool: toolSlug });
+	}, [toolSlug]);
+
+	const trackRun = useCallback(() => {
+		if (!toolSlug) return;
+		track('tool_run', { tool: toolSlug });
+	}, [toolSlug]);
+
+	const trackSharedUrlOpen = useCallback(() => {
+		if (!toolSlug) return;
+		track('shared_url_open', { tool: toolSlug });
+	}, [toolSlug]);
+
+	return {
+		trackRun,
+		trackSharedUrlOpen,
+	};
+}

--- a/tests/unit/analytics.test.ts
+++ b/tests/unit/analytics.test.ts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { getSearchQueryMetadata } from '../../src/lib/analytics.ts';
+
+test('getSearchQueryMetadata: 正常な検索クエリからメタデータを抽出する', () => {
+	const meta1 = getSearchQueryMetadata('JSON 整形');
+	assert.strictEqual(meta1.lengthBucket, '4-10');
+	assert.strictEqual(meta1.hasJapanese, true);
+	assert.strictEqual(meta1.tokenCount, 2);
+	assert.strictEqual(meta1.q_redacted, undefined);
+});
+
+test('getSearchQueryMetadata: メールアドレス等のPIIを含む場合はq_redactedが付与される', () => {
+	const meta2 = getSearchQueryMetadata('test@example.com');
+	assert.strictEqual(meta2.hasJapanese, false);
+	assert.strictEqual(meta2.q_redacted, true);
+});

--- a/tests/unit/zenkaku-hankaku.test.ts
+++ b/tests/unit/zenkaku-hankaku.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { convert } from '../../src/lib/tools/zenkaku-hankaku';
+import { convert } from '../../src/lib/tools/zenkaku-hankaku.ts';
 
 test('convert: 記号全種（［］｛｝（）．＊＋ 等）の往復変換が正しく、例外を投げない', () => {
 	const zenkakuSymbols =

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "tools-codelife-cafe",
+	"pages_build_output_dir": "dist",
+	"analytics_engine_datasets": [
+		{
+			"binding": "EVENTS",
+			"dataset": "tools_codelife_cafe_events"
+		}
+	]
+}


### PR DESCRIPTION
# 概要
ユーザー行動の改善効果を判定するため、個人情報や入力・変換データを一切送信しない完全匿名の最小限イベント計測機能を実装しました。
計測の正本として Cloudflare Analytics Engine を採用し、Cloudflare Pages Functions (\/api/event\) 経由で書き込みます。

---

## 📊 追加イベント一覧
- \	ool_run\: ツール実行・変換処理の実行時に発火 (\{ tool: string }\)
- \	ool_engage\: 個別ツールでの初回操作・入力時に発火 (\{ tool: string }\ / セッション・タブ単位で1回のみ)
- \search_empty\: トップ検索でヒットが0件だった時に発火 (\{ lengthBucket, hasJapanese, tokenCount, q_redacted? }\ / 生テキスト非送信)
- \elated_click\: 関連ツール回遊カードのクリック時に発火 (\{ from, to }\)
- \shared_url_open\: 共有URL・初期状態復元時に発火 (\{ tool: string }\)

---

## 📁 変更ファイル概要
- \wrangler.jsonc\: Cloudflare Analytics Engine データセットバインディング (\EVENTS\ / \	ools_codelife_cafe_events\) を設定
- \src/lib/analytics.ts\: 匿名イベント計測ライブラリ (\sendBeacon\ / \etch\ (keepalive), SSR/DEV制御, allowlist定義)
- \unctions/api/event.ts\: Cloudflare Pages Functions による計測レシーバー (CORSチェック, イベント名/props検証, Analytics Engine書き込み)
- \src/lib/hooks/useToolAnalytics.ts\: React Island用コンポーネント計測フック
- \src/components/common/SearchModal.tsx\: \search_empty\ イベントの組み込み
- \src/components/common/ToolLayout.astro\ / \ToolCard.astro\: \elated_click\ イベントの組み込み
- 主要ツールコンポーネント (\ZenkakuHankaku.tsx\, \CharCount.tsx\, \JsonFormatter.tsx\, \Base64Converter.tsx\ 等): \useToolAnalytics\ の適用
- \docs/analytics.md\: 計測仕様・非送信原則・デプロイ後確認手順のドキュメント化
- \	ests/unit/analytics.test.ts\: メタデータ抽出およびPIIマスク処理のユニットテスト

---

## 🧪 実行した検証結果
- \
pm run check\ (\stro check\ & \iome check\): エラー0, 警告0でパス
- ユニットテスト (\
ode --test tests/unit/analytics.test.ts\): 全テスト PASS
- \
pm run lint:fix\: フォーマット・インポート順の自動調整完了

---

## 👤 人間が行う残作業 (デプロイ後)
1. **Cloudflare Analytics Engine バインディングの確認**
   - Cloudflare Pages ダッシュボードにて、データセットバインディング \EVENTS\ が正常に設定されているか確認してください。
2. **本番可視化・集計データの確認**
   - \docs/analytics.md\ に記載の SQL クエリを用いて、Cloudflare ダッシュボードの Analytics Engine からイベント集計データが可視化されているかご確認ください。