### PR TITLE
fix: バックナビゲーション時のCSP違反およびCloudflare Insights通信エラーの修正

### DIFF
--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -57,7 +57,6 @@ import OfflineBadge from './OfflineBadge.tsx';
     }
   }
 
-  // 初回ロード時とView Transitionsによるページ遷移時の両方で実行
+  // 初回ロード時に実行
   setupSearchTrigger();
-  document.addEventListener('astro:page-load', setupSearchTrigger);
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,7 +2,6 @@
 import '../styles/global.css';
 import Header from '../components/layout/Header.astro';
 import Footer from '../components/layout/Footer.astro';
-import { ClientRouter } from 'astro:transitions';
 
 interface Props {
   title: string;
@@ -44,7 +43,6 @@ const cfBeaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN;
   <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="theme-color" content="#0C0A09" media="(prefers-color-scheme: dark)" />
   <meta name="theme-color" content="#FAFAF9" media="(prefers-color-scheme: light)" />
-  <ClientRouter />
   <script is:inline>
     const setDarkMode = () => {
       const stored = localStorage.getItem('theme');
@@ -57,9 +55,6 @@ const cfBeaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN;
 
     // Dark mode initialization - runs before paint to prevent flash
     setDarkMode();
-
-    // Re-apply theme after view transitions navigation
-    document.addEventListener('astro:after-swap', setDarkMode);
 
     // Listen for OS theme changes
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -74,16 +74,12 @@ const popularTools = POPULAR_TOOL_IDS.map((id) =>
     function setupNotFoundSearch() {
       const trigger = document.getElementById('not-found-search');
       if (trigger) {
-        // 既存リスナーの重複を防ぐためclone & replace
-        const newTrigger = trigger.cloneNode(true) as Element;
-        trigger.parentNode?.replaceChild(newTrigger, trigger);
-        newTrigger.addEventListener('click', () => {
+        trigger.addEventListener('click', () => {
           window.dispatchEvent(new CustomEvent('open-search'));
         });
       }
     }
 
     setupNotFoundSearch();
-    document.addEventListener('astro:page-load', setupNotFoundSearch);
   </script>
 </BaseLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -190,7 +190,6 @@ const schema = {
     }
   }
 
-  // 初回ロード時とView Transitionsによるページ遷移時の両方で実行
+  // 初回ロード時に実行
   setupCategoryFilter();
-  document.addEventListener('astro:page-load', setupCategoryFilter);
 </script>


### PR DESCRIPTION
## 概要
ツールページ移動後にブラウザの「戻る」ボタン（バックナビゲーション）操作を行った際に発生するCSP違反エラー（\data:application/javascript,\ のブロック）およびCloudflare Insights (RUM) の通信エラーを修正しました。

Notionの正式仕様（[Notion Task Page](https://app.notion.com/p/marumo/CSP-Cloudflare-Insights-33a6739a2a274d9fbb0a9f4785faeab6?source=copy_link)）に従い、CSPにリスクのある \data:\ スキームを安易に追加せず、構成変更による根治を行う**「案A（推奨）」**を採用しました。

## 実施した変更
1. **View Transitions (ClientRouter) の撤去** (\src/layouts/BaseLayout.astro\)
   - \<ClientRouter />\ タグを削除し、MPA（マルチページアプリケーション）化しました。
   - バックナビゲーション時に Astro が動的に生成していた \data:application/javascript,\ スクリプトの発生自体が消滅し、CSP \script-src\ 違反エラーを根本解決しました。
   - MPA化により、各ページで Cloudflare Web Analytics (\eacon.min.js\) が正常なライフサイクルで1回のみ読み込まれるようになり、重複実行やCORS / 404通信エラーも解決しました。

2. **イベントリスナーのクリーンアップ**
   - SPA遷移用の \stro:page-load\ や \stro:after-swap\ リスナーを削除し、通常のページロード時のみクリーンに実行されるよう調整しました。
   - 該当ファイル: \BaseLayout.astro\, \Header.astro\, \index.astro\, \404.astro\

## 検証結果
- \
pm run lint\ (Biome): エラー・警告なしで合格
- \
pm run build\: 47ページ全静的ビルド・OGP生成・SW生成ともに成功