### PR TITLE
feat: ツールLP共通テンプレートとデータ駆動ルーティングの実装

### DIFF
--- a/src/components/tool/RelatedTools.astro
+++ b/src/components/tool/RelatedTools.astro
@@ -8,12 +8,16 @@ interface Props {
 
 const { relatedSlugs } = Astro.props;
 
-// relatedSlugsに指定されたスラッグに対応するツールをtoolCatalogから取得（存在しないスラッグは自動除外）
+// relatedSlugsに指定されたスラッグに対応するツールをtoolCatalogから取得（存在しないスラッグは自動除外・警告出力）
 const validTools = (relatedSlugs || [])
 	.map((slug) => {
 		// slugが "/csv-editor" や "csv-editor" の両方に対応
 		const cleanSlug = slug.replace(/^\//, '');
-		return toolCatalog.find((t) => t.id === cleanSlug || t.href === `/${cleanSlug}`);
+		const found = toolCatalog.find((t) => t.id === cleanSlug || t.href === `/${cleanSlug}`);
+		if (!found) {
+			console.warn(`[RelatedTools] 関連ツール "${slug}" はカタログ内に存在しないため除外されました。`);
+		}
+		return found;
 	})
 	.filter((tool): tool is NonNullable<typeof tool> => tool !== undefined);
 ---

--- a/src/components/tool/ToolIsland.tsx
+++ b/src/components/tool/ToolIsland.tsx
@@ -1,0 +1,16 @@
+import { getToolComponent } from './registry';
+
+interface ToolIslandProps {
+	slug: string;
+}
+
+/**
+ * ツールスラッグに基づいてregistry.tsから動的にコンポーネントを取得し描画するReact Islandラッパー
+ */
+export default function ToolIsland({ slug }: ToolIslandProps) {
+	const Component = getToolComponent(slug);
+	if (!Component) {
+		return null;
+	}
+	return <Component />;
+}

--- a/src/components/tool/registry.ts
+++ b/src/components/tool/registry.ts
@@ -1,20 +1,19 @@
+import type { ComponentType } from 'react';
 import CsvFixerTool from '../tools/CsvFixer';
 
 /**
  * ツールスラッグからツール本体コンポーネント（React Island）への静的マッピングレジストリ
  */
-export const toolRegistry = {
+export const toolRegistry: Record<string, ComponentType<any>> = {
 	'csv-mojibake': CsvFixerTool,
 	'csv-fixer': CsvFixerTool,
-} as const;
-
-export type ToolSlug = keyof typeof toolRegistry;
+};
 
 /**
  * スラッグに対応するツールコンポーネントを取得する
  * @param slug ツールスラッグ
  * @returns Reactコンポーネント、未登録の場合はnull
  */
-export function getToolComponent(slug: string) {
-	return toolRegistry[slug as ToolSlug] || null;
+export function getToolComponent(slug: string): ComponentType<any> | null {
+	return toolRegistry[slug] || null;
 }

--- a/src/components/tool/registry.ts
+++ b/src/components/tool/registry.ts
@@ -1,0 +1,20 @@
+import CsvFixerTool from '../tools/CsvFixer';
+
+/**
+ * ツールスラッグからツール本体コンポーネント（React Island）への静的マッピングレジストリ
+ */
+export const toolRegistry = {
+	'csv-mojibake': CsvFixerTool,
+	'csv-fixer': CsvFixerTool,
+} as const;
+
+export type ToolSlug = keyof typeof toolRegistry;
+
+/**
+ * スラッグに対応するツールコンポーネントを取得する
+ * @param slug ツールスラッグ
+ * @returns Reactコンポーネント、未登録の場合はnull
+ */
+export function getToolComponent(slug: string) {
+	return toolRegistry[slug as ToolSlug] || null;
+}

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection } from 'astro:content';
 import ToolLayout from '../../components/tool/ToolLayout.astro';
+import { getToolComponent } from '../../components/tool/registry';
 import CsvFixerTool from '../../components/tools/CsvFixer';
 
 export async function getStaticPaths() {
@@ -13,14 +14,14 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const slug = entry.id;
+const ToolComponent = getToolComponent(slug);
 ---
 
 <ToolLayout tool={entry}>
-	{slug === 'csv-mojibake' || slug === 'csv-fixer' ? (
-		<CsvFixerTool client:load />
-	) : (
+	{ToolComponent === CsvFixerTool && <CsvFixerTool client:load />}
+	{!ToolComponent && (
 		<div class="p-8 text-center text-muted-foreground">
-			ツールコンポーネントを読み込んでいます...
+			このツールには操作エリアがありません。
 		</div>
 	)}
 </ToolLayout>

--- a/src/pages/tools/[slug].astro
+++ b/src/pages/tools/[slug].astro
@@ -1,8 +1,8 @@
 ---
 import { getCollection } from 'astro:content';
 import ToolLayout from '../../components/tool/ToolLayout.astro';
+import ToolIsland from '../../components/tool/ToolIsland';
 import { getToolComponent } from '../../components/tool/registry';
-import CsvFixerTool from '../../components/tools/CsvFixer';
 
 export async function getStaticPaths() {
 	const toolEntries = await getCollection('tools');
@@ -14,12 +14,13 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const slug = entry.id;
-const ToolComponent = getToolComponent(slug);
+const hasComponent = getToolComponent(slug) !== null;
 ---
 
 <ToolLayout tool={entry}>
-	{ToolComponent === CsvFixerTool && <CsvFixerTool client:load />}
-	{!ToolComponent && (
+	{hasComponent ? (
+		<ToolIsland slug={slug} client:load />
+	) : (
 		<div class="p-8 text-center text-muted-foreground">
 			このツールには操作エリアがありません。
 		</div>


### PR DESCRIPTION
## 概要
個別ツールページを「課題解決の着地ページ（LP）」化するための共通テンプレート構築およびデータ駆動ルーティング機構を実装しました。

## 実施した変更
1. **コンポーネントレジストリの新設 (src/components/tool/registry.ts)**
   - ツールスラッグ（\csv-mojibake\ や \csv-fixer\）と対応する React Island ツール本体コンポーネント（\CsvFixerTool\）の同期マッピングレジストリを作成しました。
   - 未登録のスラッグに対しては \
ull\ を返し、操作エリアのない情報専用ツールも許容する設計としました。
2. **動的コンポーネント解決 (src/pages/tools/[slug].astro)**
   - 直書きされていた条件分岐を修正し、\egistry.ts\ のマッピングを参照して動的にコンポーネントを描画する構造へ整理しました。
   - Astroのハイドレーション仕様に準拠した描画形式へ調整しました。
3. **関連ツールの安全な検証 (src/components/tool/RelatedTools.astro)**
   - カタログに存在しないスラッグが指定された場合に \console.warn\ で警告を出力しつつ安全に自動除外する処理を追加しました。

## 検証結果
- 静的解析 (\
px biome check src/ tests/\): エラーなし
- プロダクションビルド (\
pm run build\): 正常終了（\dist/tools/csv-mojibake/index.html\ 生成完了）