### PR TITLE
[codex] fix image mosaic E2E canvas drag

### DIFF
--- a/tests/e2e/helpers/canvas.ts
+++ b/tests/e2e/helpers/canvas.ts
@@ -140,6 +140,8 @@ export async function dragOnCanvas(
 	from: { x: number; y: number },
 	to: { x: number; y: number },
 ): Promise<void> {
+	await canvas.scrollIntoViewIfNeeded();
+
 	const p1 = await imagePointToPage(canvas, from.x, from.y);
 	const p2 = await imagePointToPage(canvas, to.x, to.y);
 	await page.mouse.move(p1.x, p1.y);


### PR DESCRIPTION
## Summary
- Scroll the target canvas into view before calculating page coordinates in the shared E2E canvas drag helper.
- Keeps image-mosaic drag interactions stable across desktop and mobile Playwright projects.

## Root cause
PR #185 now reaches the E2E execution stage, but image-mosaic tests were dragging by absolute mouse coordinates without first ensuring the canvas was inside the viewport. On mobile Chrome and some desktop layouts, the pointer events did not reach the canvas, so no mask/stamp region was added and pixel assertions stayed at the original fixture colors.

## Validation
- `npm run build`
- `npx playwright test tests/e2e/image-mosaic.spec.ts --project=mobile-chrome --project=chromium` 26 passed