### PR TITLE
[codex] Reduce ONNX runtime assets for Cloudflare Pages deploy

### DIFF
--- a/src/workers/upscale.worker.ts
+++ b/src/workers/upscale.worker.ts
@@ -14,7 +14,7 @@ import {
 
 // onnxruntime-web の wasm 配信元（package.json の pin と同期させること）。
 // bg-remove と同様 cdn.jsdelivr.net を使用（CSP script-src/connect-src で許可済み）。
-const ORT_VERSION = '1.26.0-dev.20260416-b7804b056c';
+const ORT_VERSION = '1.27.0';
 const ORT_WASM_BASE = `https://cdn.jsdelivr.net/npm/onnxruntime-web@${ORT_VERSION}/dist/`;
 
 // --- メッセージ型 ---
@@ -60,7 +60,7 @@ let ortPromise: Promise<Ort> | null = null;
 
 function loadOrt(): Promise<Ort> {
 	if (!ortPromise) {
-		ortPromise = import('onnxruntime-web').then((ort: Ort) => {
+		ortPromise = import('onnxruntime-web/wasm').then((ort: Ort) => {
 			ort.env.wasm.wasmPaths = ORT_WASM_BASE;
 			ort.env.wasm.numThreads = 1; // SharedArrayBuffer 不要（COOP/COEP 変更なし）
 			ort.env.wasm.simd = true;

--- a/src/workers/upscale.worker.ts
+++ b/src/workers/upscale.worker.ts
@@ -56,19 +56,28 @@ self.addEventListener('unhandledrejection', (event) => {
 // --- onnxruntime-web 遅延ロード ---
 // biome-ignore lint/suspicious/noExplicitAny: onnxruntime-web has no bundled types entry here
 type Ort = any;
-let ortPromise: Promise<Ort> | null = null;
+type OrtRuntime = 'wasm' | 'webgpu';
+const ortPromises = new Map<OrtRuntime, Promise<Ort>>();
 
-function loadOrt(): Promise<Ort> {
-	if (!ortPromise) {
-		ortPromise = import('onnxruntime-web/wasm').then((ort: Ort) => {
-			ort.env.wasm.wasmPaths = ORT_WASM_BASE;
-			ort.env.wasm.numThreads = 1; // SharedArrayBuffer 不要（COOP/COEP 変更なし）
-			ort.env.wasm.simd = true;
-			ort.env.wasm.proxy = false;
-			return ort;
-		});
-	}
-	return ortPromise;
+function configureOrt(ort: Ort): Ort {
+	ort.env.wasm.wasmPaths = ORT_WASM_BASE;
+	ort.env.wasm.numThreads = 1; // SharedArrayBuffer 不要（COOP/COEP 変更なし）
+	ort.env.wasm.simd = true;
+	ort.env.wasm.proxy = false;
+	return ort;
+}
+
+function loadOrt(runtime: OrtRuntime): Promise<Ort> {
+	const cached = ortPromises.get(runtime);
+	if (cached) return cached;
+
+	const promise = (
+		runtime === 'webgpu'
+			? import('onnxruntime-web/webgpu')
+			: import('onnxruntime-web/wasm')
+	).then(configureOrt);
+	ortPromises.set(runtime, promise);
+	return promise;
 }
 
 // --- セッションキャッシュ ---
@@ -115,8 +124,8 @@ async function getSession(
 	const cached = sessions.get(quality);
 	if (cached) return cached;
 
-	const ort = await loadOrt();
 	const spec = MODELS[quality];
+	const ort = await loadOrt(spec.device);
 	onProgress({ status: 'loading', progress: 0 });
 	const modelBuf = await fetchModel(spec.url, (p) =>
 		onProgress({ status: 'loading', progress: p }),


### PR DESCRIPTION
## Summary

Cloudflare Pages deploy was likely failing because the upscale worker bundled the default `onnxruntime-web` entrypoint, which can emit large JSEP WASM assets over the Pages 25MiB per-file limit.

This PR narrows the default upscale worker runtime import to `onnxruntime-web/wasm`, aligns the CDN WASM path version with the pinned `package.json` dependency (`1.27.0`), and preserves WebGPU support for the `最高品質` / `MODELS.max` path by loading `onnxruntime-web/webgpu` only when that model is selected.

## Latest commit

- `7511889 fix: preserve WebGPU runtime for max upscale`

## Validation

- `npm run lint`
  - Exit code 0.
  - Existing `tests/e2e/webmcp.spec.ts` non-null assertion warnings remain unrelated to this change.
- `npm run test:unit`
  - Passed: 459 tests.
- `npm run build`
  - Passed.
- `Get-ChildItem -LiteralPath dist -Recurse -File | Where-Object { $_.Length -gt 25MB }`
  - No files returned.
- Largest generated WASM after WebGPU-preserving build:
  - `dist/_astro/ort-wasm-simd-threaded.asyncify-CvvOzbbq.wasm` = 24,254,953 bytes
  - `dist/_astro/ort-wasm-simd-threaded.asyncify-DMmc6YqF.wasm` = 23,567,050 bytes
  - `dist/_astro/ort-wasm-simd-threaded-Cpm-ox6i.wasm` = 13,479,978 bytes

## Review follow-up

Addressed the review concern that `MODELS.max.device === 'webgpu'` still requested WebGPU while the runtime had been changed to the WASM-only bundle. The worker now caches ONNX Runtime by runtime type and imports:

- `onnxruntime-web/wasm` for `fast`
- `onnxruntime-web/webgpu` for `max`

## Intentionally excluded

The main checkout had unrelated uncommitted changes on `codex/complete-notion-priority-tasks`:

- `src/lib/tools/image-common.ts`
- `tests/e2e/favicon.spec.ts`
- `tests/e2e/helpers/canvas.ts`
- `tests/e2e/image-merge.spec.ts`
- `tests/e2e/url-encoder.spec.ts`

To avoid mixing scopes, this PR was prepared in a separate worktree from `origin/main` and includes only the deploy fix.