### PR TITLE
[codex] 信頼バッジと導線を統一

### DIFF
--- a/src/components/common/TrustBadges.astro
+++ b/src/components/common/TrustBadges.astro
@@ -11,8 +11,8 @@ const { size = 'md', class: className = '' } = Astro.props;
 const isSm = size === 'sm';
 ---
 
-<div class:list={["flex flex-wrap gap-2", className]}>
-  {/* 1. 入力データ非送信 */}
+<div class:list={["flex flex-wrap gap-2", className]} aria-label="信頼バッジ">
+  {/* 入力データ非送信 */}
   <div
     class:list={[
       "inline-flex items-center gap-1.5 rounded-full font-medium transition-colors",
@@ -20,13 +20,13 @@ const isSm = size === 'sm';
         ? "bg-safety/5 border border-safety/20 text-safety text-[10px] px-2 py-0.5"
         : "bg-safety/10 border border-safety/20 text-safety text-xs px-3 py-1"
     ]}
-    title="入力されたデータやファイルはブラウザ内で処理され、サーバーに送信されることはありません。"
+    title="ツールに入力した内容や選択したファイルはブラウザ内で処理され、サーバーに送信されません。改善のため匿名・集計の利用統計を取得し、AI機能では初回実行時などに推論モデルをダウンロードします。"
   >
     <ShieldCheck className={isSm ? "h-3 flex-shrink-0 w-3" : "h-3.5 flex-shrink-0 w-3.5"} />
-    <span>入力データ送信なし</span>
+    <span>入力データ非送信</span>
   </div>
 
-  {/* 2. Cookie不使用 */}
+  {/* Cookieなし */}
   <div
     class:list={[
       "inline-flex items-center gap-1.5 rounded-full font-medium transition-colors",
@@ -34,13 +34,13 @@ const isSm = size === 'sm';
         ? "bg-blue-500/5 border border-blue-500/20 text-blue-600 dark:text-blue-400 text-[10px] px-2 py-0.5"
         : "bg-blue-500/10 border border-blue-500/20 text-blue-600 dark:text-blue-400 text-xs px-3 py-1"
     ]}
-    title="Cookieを使用したユーザーの追跡やセッション管理は行いません。"
+    title="Cookieを使ったセッション管理やユーザー追跡は行いません。"
   >
     <Cookie className={isSm ? "h-3 flex-shrink-0 w-3" : "h-3.5 flex-shrink-0 w-3.5"} />
-    <span>Cookie不使用</span>
+    <span>Cookieなし</span>
   </div>
 
-  {/* 3. 個人追跡なし */}
+  {/* 個人追跡なし */}
   <div
     class:list={[
       "inline-flex items-center gap-1.5 rounded-full font-medium transition-colors",
@@ -48,13 +48,13 @@ const isSm = size === 'sm';
         ? "bg-purple-500/5 border border-purple-500/20 text-purple-600 dark:text-purple-400 text-[10px] px-2 py-0.5"
         : "bg-purple-500/10 border border-purple-500/20 text-purple-600 dark:text-purple-400 text-xs px-3 py-1"
     ]}
-    title="個人を識別する情報の取得やトラッキングは一切行いません（匿名統計のみ）。"
+    title="個人を識別する情報の取得やプロファイリングは行いません。利用状況は匿名・集計の統計として扱います。"
   >
     <UserX className={isSm ? "h-3 flex-shrink-0 w-3" : "h-3.5 flex-shrink-0 w-3.5"} />
     <span>個人追跡なし</span>
   </div>
 
-  {/* 4. OSS */}
+  {/* OSS */}
   <div
     class:list={[
       "inline-flex items-center gap-1.5 rounded-full font-medium transition-colors",
@@ -62,13 +62,13 @@ const isSm = size === 'sm';
         ? "bg-orange-500/5 border border-orange-500/20 text-orange-600 dark:text-orange-400 text-[10px] px-2 py-0.5"
         : "bg-orange-500/10 border border-orange-500/20 text-orange-600 dark:text-orange-400 text-xs px-3 py-1"
     ]}
-    title="オープンソースとしてソースコードをGitHubで全面公開しています。"
+    title="オープンソースとしてソースコードをGitHubで公開しています。"
   >
     <Code className={isSm ? "h-3 flex-shrink-0 w-3" : "h-3.5 flex-shrink-0 w-3.5"} />
     <span>OSS</span>
   </div>
 
-  {/* 5. 広告表示なし */}
+  {/* 広告なし */}
   <div
     class:list={[
       "inline-flex items-center gap-1.5 rounded-full font-medium transition-colors",
@@ -82,3 +82,4 @@ const isSm = size === 'sm';
     <span>広告なし</span>
   </div>
 </div>
+

--- a/src/components/layout/Header.astro
+++ b/src/components/layout/Header.astro
@@ -2,6 +2,7 @@
 import ThemeToggle from '../common/ThemeToggle.tsx';
 import SearchModal from '../common/SearchModal.tsx';
 import OfflineBadge from './OfflineBadge.tsx';
+import { FileText } from 'lucide-react';
 ---
 
 <header class="sticky top-0 z-50 border-b border-border bg-background/80 backdrop-blur-lg">
@@ -30,6 +31,15 @@ import OfflineBadge from './OfflineBadge.tsx';
     <!-- Right: Theme toggle -->
     <div class="flex items-center gap-3">
       <OfflineBadge client:load />
+      <a
+        href="/privacy"
+        class="inline-flex items-center gap-1.5 rounded-lg p-2 text-muted-foreground hover:bg-muted hover:text-foreground transition-colors md:px-3"
+        title="プライバシーポリシーを開く"
+        aria-label="プライバシーポリシー"
+      >
+        <FileText className="h-5 w-5 md:h-4 md:w-4" aria-hidden="true" />
+        <span class="hidden lg:inline text-sm font-medium">プライバシー</span>
+      </a>
       <a
         href="https://github.com/maru0014/tools-codelife-cafe"
         target="_blank"
@@ -69,3 +79,4 @@ import OfflineBadge from './OfflineBadge.tsx';
   // 初回ロード時に実行
   setupSearchTrigger();
 </script>
+

--- a/src/components/layout/SafetyBadge.tsx
+++ b/src/components/layout/SafetyBadge.tsx
@@ -18,8 +18,8 @@ export default function SafetyBadge() {
 					aria-label="セキュリティ情報を表示"
 				>
 					<ShieldCheck className="h-4 w-4" />
-					<span className="hidden sm:inline">入力データは送信されません</span>
-					<span className="sm:hidden">ローカル処理</span>
+					<span className="hidden sm:inline">入力データ非送信</span>
+					<span className="sm:hidden">非送信</span>
 					<span className="sr-only">完全クライアントサイド処理</span>
 					<Info className="h-3 w-3 opacity-50" />
 				</button>
@@ -28,23 +28,25 @@ export default function SafetyBadge() {
 				<div className="space-y-3">
 					<h4 className="font-semibold text-sm flex items-center gap-2">
 						<ShieldCheck className="h-4 w-4 text-safety" />
-						入力データはブラウザ内で処理
+						入力データ非送信・匿名統計とモデル取得あり
 					</h4>
 					<p className="text-sm text-muted-foreground leading-relaxed">
-						このツールの処理対象となるテキストやファイルは、ブラウザ内のJavaScriptで処理されます。
-						入力内容や選択したファイルを当サイトのサーバーへ送信・保存する処理はありません。
+						このツールに入力した内容や選択したファイルは、ブラウザ内のJavaScriptで処理されます。
+						入力データを当サイトのサーバーへ送信・保存する処理はありません。
 					</p>
 					<p className="text-xs text-muted-foreground leading-relaxed italic border-l-2 border-primary/20 pl-2">
 						※
-						サービスの改善を目的として、Cookieを使用しない匿名の利用統計情報（ページビュー数など）のみを取得しています。入力されたデータ本体が送信されることは絶対にありません。
+						サービス改善のため、Cookieを使用しない匿名・集計の閲覧/利用統計のみ取得しています。入力データ本体は送信されません。
+						AI機能では初回実行時などに推論モデルを取得する通信が発生します。画像や入力内容はモデル配信元へ送信されません。
 					</p>
 					<div className="rounded-md bg-muted p-3 text-xs text-muted-foreground space-y-1">
-						<p>✅ 入力データは端末内で処理</p>
-						<p>✅ ページを閉じると処理中データは消去</p>
-						<p>✅ 広告スクリプトは不使用</p>
-						<p>✅ 閲覧統計は匿名集計のみ（Cookie・追跡なし）</p>
-						<p>ℹ️ AI機能ではモデル取得のための通信が発生する場合があります</p>
-						<p>✅ ソースコードはGitHubで公開中</p>
+						<p>入力データ非送信: 入力内容やファイルはブラウザ内で処理</p>
+						<p>Cookieなし: Cookieを使った追跡やセッション管理なし</p>
+						<p>個人追跡なし: 個人識別やプロファイリングなし</p>
+						<p>OSS: ソースコードはGitHubで公開中</p>
+						<p>広告なし: サードパーティ広告ネットワークなし</p>
+						<p>利用統計: 改善のため匿名・集計の閲覧/利用統計のみ取得</p>
+						<p>AIモデル取得: 初回実行時などに推論モデルをダウンロード</p>
 					</div>
 				</div>
 			</PopoverContent>

--- a/tests/e2e/helpers/tool-page.ts
+++ b/tests/e2e/helpers/tool-page.ts
@@ -15,6 +15,23 @@ export class ToolPage {
 		await expect(
 			this.page.getByRole('button', { name: 'セキュリティ情報を表示' }),
 		).toBeVisible();
+
+		const trustBadges = this.page.locator('[aria-label="信頼バッジ"]').first();
+		await expect(trustBadges).toBeVisible();
+		for (const label of [
+			'入力データ非送信',
+			'Cookieなし',
+			'個人追跡なし',
+			'OSS',
+			'広告なし',
+		]) {
+			await expect(trustBadges.getByText(label, { exact: true })).toBeVisible();
+		}
+
+		await expect(trustBadges.locator('div').first()).toHaveAttribute(
+			'title',
+			/AI機能では初回実行時などに推論モデルをダウンロード/,
+		);
 	}
 
 	async expectTitle(title: string) {

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -164,4 +164,48 @@ test.describe('Layout & Navigation', () => {
 			footer.getByRole('link', { name: /このサイトについて/i }),
 		).toBeVisible();
 	});
+
+	test('ヘッダーとフッターからGitHub・プライバシーポリシーへ到達できる', async ({
+		page,
+	}) => {
+		const header = page.locator('header');
+		await expect(
+			header.getByRole('link', { name: 'プライバシーポリシー' }),
+		).toHaveAttribute('href', '/privacy');
+		await expect(header.getByRole('link', { name: 'GitHub' })).toHaveAttribute(
+			'href',
+			'https://github.com/maru0014/tools-codelife-cafe',
+		);
+
+		const footer = page.locator('footer');
+		await expect(
+			footer.getByRole('link', { name: /プライバシーポリシー/i }),
+		).toHaveAttribute('href', '/privacy');
+		await expect(footer.getByRole('link', { name: /GitHub/i })).toHaveAttribute(
+			'href',
+			'https://github.com/maru0014/tools-codelife-cafe',
+		);
+	});
+
+	test('トップ一覧のツールカードに信頼バッジが表示される', async ({ page }) => {
+		const firstCard = page.locator('#tool-grid [data-tool-id]').first();
+		await expect(firstCard).toBeVisible();
+
+		for (const label of [
+			'入力データ非送信',
+			'Cookieなし',
+			'個人追跡なし',
+			'OSS',
+			'広告なし',
+		]) {
+			await expect(firstCard.getByText(label, { exact: true })).toBeVisible();
+		}
+
+		await expect(
+			firstCard.locator('[aria-label="信頼バッジ"] div').first(),
+		).toHaveAttribute(
+			'title',
+			/AI機能では初回実行時などに推論モデルをダウンロード/,
+		);
+	});
 });

--- a/tests/e2e/url-encoder.spec.ts
+++ b/tests/e2e/url-encoder.spec.ts
@@ -41,7 +41,7 @@ test.describe('URL Encoder Tool', () => {
 		);
 
 		// test full url mode encoding
-		await page.getByRole('tab', { name: 'フルURL (encodeURI)' }).click();
+		await page.getByRole('tab', { name: 'フルURL (encodeURI)' }).press('Enter');
 		await expect(outputArea).toHaveValue(
 			'https://example.com/%E6%A4%9C%E7%B4%A2?q=%E6%9D%B1%E4%BA%AC%20%E5%A4%A9%E6%B0%97',
 		);


### PR DESCRIPTION
## 概要
- 信頼バッジの文言を「入力データ非送信 / Cookieなし / 個人追跡なし / OSS / 広告なし」に統一
- SafetyBadge の詳細説明を、入力データ非送信と匿名・集計の利用統計取得が両立する表現へ更新
- ヘッダーにプライバシーポリシー導線を追加し、ヘッダー/フッターから GitHub とプライバシーポリシーへ到達できることをE2Eで検証

## 確認観点
- 全ツールカードと各詳細ページに5項目バッジが表示される
- 「解析なし」等の計測実態と矛盾する表記が残っていない
- ヘッダー/フッターからGitHubリポジトリとプライバシーポリシーへ1クリックで到達できる

## 検証
- `rg "解析なし|アクセス解析なし|利用解析なし|分析なし|入力データ送信なし|Cookie不使用" src docs README.md AGENTS.md CLAUDE.md tests -S`（該当なし）
- `npm run lint`（既存の `tests/e2e/webmcp.spec.ts` non-null assertion 警告のみ）
- `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`
- `npm run test:unit`
- `npx astro check`
- `npm run build`
- `npm test`（601 passed, 11 skipped）

## 意図的に含めなかった変更
- なし。今回スコープの6ファイルのみをstage/commitしています。