### PR TITLE
fix: normalize canonical URLs

### DIFF
--- a/src/components/tool/ToolLayout.astro
+++ b/src/components/tool/ToolLayout.astro
@@ -8,6 +8,7 @@ import Faq from './Faq.astro';
 import RelatedTools from './RelatedTools.astro';
 import { getCategoryId, toolCatalog, type ToolCategory } from '../../lib/tools/catalog';
 import { generateJsonLd } from '../../lib/jsonld';
+import { normalizeCanonicalPath } from '../../lib/seo/url';
 
 interface Props {
 	tool: CollectionEntry<'tools'>;
@@ -20,8 +21,7 @@ const { title, description, canonical, category, summary, useCases, howto, faq, 
 const toolId = entry.id;
 const catalogTool = toolCatalog.find((t) => t.id === toolId);
 const path = customPath || catalogTool?.href || `/tools/${toolId}`;
-const SITE_URL = 'https://tools.codelife.cafe';
-const canonicalUrl = canonical || `${SITE_URL}${path}`;
+const canonicalPath = normalizeCanonicalPath(canonical || path);
 
 // パンくずリスト用
 const categoryHref = category ? `/?category=${getCategoryId(category as ToolCategory)}` : undefined;
@@ -41,9 +41,8 @@ const jsonLdData = generateJsonLd(
 );
 ---
 
-<BaseLayout title={title} description={description} path={path} ogImage={ogImage}>
+<BaseLayout title={title} description={description} path={canonicalPath} ogImage={ogImage}>
 	<Fragment slot="head">
-		{canonical && <link rel="canonical" href={canonicalUrl} />}
 		<script is:inline type="application/ld+json" set:html={JSON.stringify(jsonLdData).replace(/</g, '\\u003c')} />
 		<slot name="head" />
 	</Fragment>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '../styles/global.css';
 import Header from '../components/layout/Header.astro';
 import Footer from '../components/layout/Footer.astro';
+import { toCanonicalUrl } from '../lib/seo/url';
 
 interface Props {
   title: string;
@@ -13,7 +14,7 @@ interface Props {
 
 const { title, description, path, ogImage = '/og-image.png' } = Astro.props;
 const siteName = "CODE:LIFE Tools";
-const siteUrl = "https://tools.codelife.cafe";
+const canonicalUrl = toCanonicalUrl(path);
 const fullTitle = `${title} | ${siteName}`;
 
 // Cloudflare Web Analytics（Cookieレス・同意バナー不要・個人追跡なし）。
@@ -31,14 +32,14 @@ const cfBeaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN;
   <meta property="og:title" content={fullTitle} />
   <meta property="og:description" content={description} />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content={`${siteUrl}${path}`} />
-  <meta property="og:image" content={`${siteUrl}${ogImage}`} />
+  <meta property="og:url" content={canonicalUrl} />
+  <meta property="og:image" content={toCanonicalUrl(ogImage)} />
   <meta property="og:locale" content="ja_JP" />
   <meta property="og:site_name" content={siteName} />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content={fullTitle} />
   <meta name="twitter:description" content={description} />
-  <link rel="canonical" href={`${siteUrl}${path}`} />
+  <link rel="canonical" href={canonicalUrl} />
   <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
   <link rel="manifest" href="/manifest.webmanifest" />
   <meta name="theme-color" content="#0C0A09" media="(prefers-color-scheme: dark)" />

--- a/src/lib/seo/url.ts
+++ b/src/lib/seo/url.ts
@@ -1,0 +1,23 @@
+const SITE_URL = 'https://tools.codelife.cafe';
+
+function removeTrailingSlash(pathname: string): string {
+	if (pathname === '/') return pathname;
+	return pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+}
+
+export function normalizeCanonicalPath(path: string): string {
+	const rawPath = path.trim() || '/';
+	const url =
+		rawPath.startsWith('http://') || rawPath.startsWith('https://')
+			? new URL(rawPath)
+			: new URL(rawPath.startsWith('/') ? rawPath : `/${rawPath}`, SITE_URL);
+
+	const pathname = removeTrailingSlash(url.pathname || '/');
+	return pathname === '' ? '/' : pathname;
+}
+
+export function toCanonicalUrl(path: string): string {
+	return `${SITE_URL}${normalizeCanonicalPath(path)}`;
+}
+
+export { SITE_URL };

--- a/tests/unit/seo-url.test.ts
+++ b/tests/unit/seo-url.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	normalizeCanonicalPath,
+	toCanonicalUrl,
+} from '../../src/lib/seo/url.ts';
+
+test('normalizeCanonicalPath removes query, hash, and non-root trailing slash', () => {
+	assert.equal(
+		normalizeCanonicalPath('/json-formatter?settings=abc#preview'),
+		'/json-formatter',
+	);
+	assert.equal(normalizeCanonicalPath('/about/'), '/about');
+	assert.equal(normalizeCanonicalPath('/'), '/');
+});
+
+test('toCanonicalUrl converts absolute or relative paths to site canonical URLs', () => {
+	assert.equal(
+		toCanonicalUrl('privacy'),
+		'https://tools.codelife.cafe/privacy',
+	);
+	assert.equal(
+		toCanonicalUrl('https://tools.codelife.cafe/base64/?settings=abc'),
+		'https://tools.codelife.cafe/base64',
+	);
+});


### PR DESCRIPTION
### Motivation
- サイト内の canonical / og:url を一貫して正規化し、クエリ・ハッシュ・不要な末尾スラッシュによる重複や不整合を防ぐための共通ロジックを導入しました。 
- ツール個別ページでの重複した canonical 出力を集約して一箇所で管理し、SEO 出力の信頼性を高めることを目的としています。

### Description
- `src/lib/seo/url.ts` を追加し、`normalizeCanonicalPath()` と `toCanonicalUrl()` によってパス正規化（クエリ/ハッシュ除去・非ルート末尾スラッシュ削除）とサイト絶対URL変換を提供します. 
- `src/layouts/BaseLayout.astro` を更新して `og:url` / `og:image` / `link rel="canonical"` に正規化済み URL (`toCanonicalUrl`) を出力するように変更しました. 
- `src/components/tool/ToolLayout.astro` を更新してツール固有の `canonical` を `normalizeCanonicalPath()` で正規化し、`BaseLayout` に正規化パスを渡して canonical 出力を一箇所に集約しました（個別の重複 canonical 出力は削除）。 
- 正規化ロジックの単体テスト `tests/unit/seo-url.test.ts` を追加しました。 

### Testing
- `biome` による静的解析/整形（`npm run lint` / `./node_modules/.bin/biome check --write ...`）は実行済みで、実行は成功しコード整形が行われましたが既存の e2e テストに対する non-null assertion 警告が残っていることを確認しました。 
- `npm install` は環境の制約により一部の postinstall スクリプトでネットワークエラーが発生したため通常実行で失敗しましたが、`npm install --ignore-scripts` で依存を展開して以降のローカル静的解析は実行できています。 
- 追加した TypeScript 単体テスト `tests/unit/seo-url.test.ts` はリポジトリ内に作成しましたが、この実行環境の Node.js（v20.20.2）では `.ts` の `node --test` 実行がサポートされないため直接実行できず失敗しています。 
- `npx tsc --noEmit --ignoreDeprecations 6.0` は型解決（`astro:content` 型、`ImportMeta.env` 等）で失敗し、`npm run build` は Astro が要求する Node.js バージョン（>=22.12.0）と合わないため実行できませんでした。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a450e536508832fa40edfef28cbf584)