### PR TITLE
【DEBUG】ai-spreadsheet-prompt: 空行欠落＆maxRows NaNの入力堅牢性 一括修正

### DIFF
--- a/src/components/tools/AiSpreadsheetPrompt.tsx
+++ b/src/components/tools/AiSpreadsheetPrompt.tsx
@@ -25,20 +25,20 @@ export function AiSpreadsheetPrompt() {
 	const [customInstruction, setCustomInstruction] = useState(
 		'売上が高い順に特徴を整理し、次に取るべき施策を3つ提案してください。',
 	);
-	const [maxRows, setMaxRows] = useState(30);
+	const [maxRows, setMaxRows] = useState<number | ''>(30);
 	const [copied, setCopied] = useState(false);
 
-	const result = useMemo(
-		() =>
-			generateSpreadsheetPrompt({
-				input,
-				format,
-				task,
-				customInstruction,
-				maxRows,
-			}),
-		[input, format, task, customInstruction, maxRows],
-	);
+	const result = useMemo(() => {
+		const finalMaxRows =
+			maxRows === '' || Number.isNaN(maxRows) || maxRows <= 0 ? 30 : maxRows;
+		return generateSpreadsheetPrompt({
+			input,
+			format,
+			task,
+			customInstruction,
+			maxRows: finalMaxRows,
+		});
+	}, [input, format, task, customInstruction, maxRows]);
 
 	const copyPrompt = async () => {
 		if (!result.prompt) return;
@@ -102,7 +102,10 @@ export function AiSpreadsheetPrompt() {
 							min="2"
 							max="200"
 							value={maxRows}
-							onChange={(event) => setMaxRows(Number(event.target.value))}
+							onChange={(event) => {
+								const val = event.target.value;
+								setMaxRows(val === '' ? '' : Number(val));
+							}}
 							className="h-9 w-full rounded-md border border-input bg-transparent px-3 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]"
 						/>
 					</div>

--- a/src/lib/tools/ai-spreadsheet-prompt.ts
+++ b/src/lib/tools/ai-spreadsheet-prompt.ts
@@ -113,8 +113,9 @@ function parseDelimited(
 	}
 
 	return {
-		rows: rows.filter((cells) =>
-			cells.some((value) => value.trim().length > 0),
+		rows: rows.filter(
+			(cells) =>
+				cells.length > 1 || cells.some((value) => value.trim().length > 0),
 		),
 		warnings,
 	};
@@ -166,7 +167,8 @@ export function generateSpreadsheetPrompt({
 	const rowCount = rows.length;
 	const columnCount =
 		rows.length > 0 ? Math.max(...rows.map((row) => row.length)) : 0;
-	const safeMaxRows = Math.max(2, Math.min(maxRows, 200));
+	const parsedMaxRows = Number.isNaN(maxRows) || maxRows <= 0 ? 30 : maxRows;
+	const safeMaxRows = Math.max(2, Math.min(parsedMaxRows, 200));
 	const includedRows = Math.min(rowCount, safeMaxRows);
 	const includedRowsData = rows.slice(0, includedRows);
 	const truncated = rowCount > includedRows;

--- a/tests/unit/ai-spreadsheet-prompt.test.ts
+++ b/tests/unit/ai-spreadsheet-prompt.test.ts
@@ -63,3 +63,42 @@ test('自由指示と未クローズクォートの警告を扱う', () => {
 	assert.match(result.prompt, /^改善案だけを出してください。/);
 	assert.match(result.warnings.join('\n'), /ダブルクォート/);
 });
+
+test('空セルを含む行が列構造を保って保持され、完全な空行（改行のみ等）のみが除外される', () => {
+	const result = generateSpreadsheetPrompt({
+		input: '名前,値\nA,100\n,\nB,200\n\nC,300',
+		format: 'csv',
+		task: 'analyze',
+		maxRows: 10,
+	});
+
+	assert.equal(result.rowCount, 5);
+	assert.match(result.prompt, /\| 名前 \| 値 \|/);
+	assert.match(result.prompt, /\| {2}\| {2}\|/);
+	assert.match(result.prompt, /\| B \| 200 \|/);
+});
+
+test('maxRows が NaN や 0 の場合でもデフォルト値（30行）にフォールバックされる', () => {
+	const inputLines = Array.from({ length: 40 }, (_, i) => `A${i},${i}`).join(
+		'\n',
+	);
+	const resultNaN = generateSpreadsheetPrompt({
+		input: `名前,値\n${inputLines}`,
+		format: 'csv',
+		task: 'analyze',
+		maxRows: NaN,
+	});
+
+	assert.equal(resultNaN.includedRows, 30);
+	assert.equal(resultNaN.truncated, true);
+
+	const resultZero = generateSpreadsheetPrompt({
+		input: `名前,値\n${inputLines}`,
+		format: 'csv',
+		task: 'analyze',
+		maxRows: 0,
+	});
+
+	assert.equal(resultZero.includedRows, 30);
+	assert.equal(resultZero.truncated, true);
+});


### PR DESCRIPTION
# 概要
AIスプレッドシートプロンプト生成ツールにおける、空セル行の欠落バグおよび maxRows の NaN/0/空欄時における出力破綻バグを修正しました。

## 今回の最新コミット
7fae093 (fix: ai-spreadsheet-prompt input robustness (empty rows and maxRows NaN))

## 検証結果
- tests/unit/ai-spreadsheet-prompt.test.ts にテストを追加し、全6件が正常にパスすることを確認済み。
- npx @biomejs/biome check src/ tests/ による静的解析（Biome）に合格していることを確認済み。
- npm run build による Astro ビルドが正常に完了することを確認済み。

## 意図的に含めなかった未ステージ変更
- なし