### PR TITLE
chore: Biome noDangerouslySetInnerHtml を error 化

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -42,7 +42,7 @@
 				"useExhaustiveDependencies": "warn"
 			},
 			"security": {
-				"noDangerouslySetInnerHtml": "warn"
+				"noDangerouslySetInnerHtml": "error"
 			},
 			"style": {
 				"noNonNullAssertion": "warn"


### PR DESCRIPTION
## 概要
コードベース監査で検出された課題の修正です。XSS対策を最優先とするプロジェクト方針に対し、security ルール `noDangerouslySetInnerHtml` が `warn` のままだったため `error` に厳格化します。

## 変更内容
- `biome.json`: `security.noDangerouslySetInnerHtml` を `warn` → `error`

## 影響確認
既存の `dangerouslySetInnerHTML` 使用は4箇所（WordCloudCanvas / ChartPanel / CodeBlock / MarkdownPreviewPage）で、すべてサニタイズ済み + `biome-ignore` と理由コメント付与済みのため、lint への影響はありません。

## 検証
- `npm run lint` → エラー0件（既存の noNonNullAssertion warn 5件のみ、本変更とは無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)