### PR TITLE
ci: main pushデプロイ前にE2Eテストをゲートとして実行

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,11 @@ permissions:
   contents: read
   deployments: write
 jobs:
+  # デプロイ前にE2Eを実行し、失敗時はデプロイを中止する
+  e2e:
+    uses: ./.github/workflows/e2e.yml
   deploy:
+    needs: e2e
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,8 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
+  # デプロイ前ゲートとして deploy.yml からも呼び出す
+  workflow_call:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
## 概要
コードベース監査で、E2EテストがPR時のみ実行され、mainへのpush時（=デプロイ前）にはテストが走らない「ビルド成功=デプロイ」構成であることが判明したため、デプロイ前ゲートを追加します。

## 変更内容
- `.github/workflows/e2e.yml`: `workflow_call` トリガーを追加（再利用可能ワークフロー化。PR時の動作は従来どおり）
- `.github/workflows/deploy.yml`: `e2e` ジョブ（e2e.yml呼び出し）を追加し、`deploy` ジョブを `needs: e2e` で依存させる

## 効果
- mainへのpush時、E2E全件が成功しない限りCloudflare Pagesへデプロイされません
- E2E失敗時のレポートアーティファクトも従来どおり14日間保存されます

## 検証
- 両YAMLのパース検証OK
- デプロイ所要時間は E2E 分（約3-5分）増加します

🤖 Generated with [Claude Code](https://claude.com/claude-code)