### PR TITLE
refactor: バッチ処理の状態機械を useBatchProcessing フックに共通化

### DIFF
--- a/src/components/image-compress/ImageCompressPage.tsx
+++ b/src/components/image-compress/ImageCompressPage.tsx
@@ -6,9 +6,10 @@ import {
 	Share2,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -31,12 +32,6 @@ import {
 import { type CompressItem, CompressResultList } from './CompressResultList';
 
 const ACCEPT = 'image/jpeg,image/png,image/webp';
-
-type CompletionNotice = {
-	done: number;
-	failed: number;
-	total: number;
-};
 
 function toResizeMode(kind: ResizeKind, value: number): ResizeMode {
 	switch (kind) {
@@ -71,15 +66,29 @@ export function ImageCompressPage() {
 	);
 	const [shareCopied, setShareCopied] = useState(false);
 
-	const [items, setItems] = useState<CompressItem[]>([]);
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [completion, setCompletion] = useState<CompletionNotice | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const runIdRef = useRef(0);
-	const cancelRef = useRef(false);
-	const itemsRef = useRef<CompressItem[]>([]);
-	itemsRef.current = items;
+	const {
+		items,
+		processing,
+		progress,
+		completion,
+		error,
+		setError,
+		clearCompletion,
+		start,
+		reprocess,
+		cancel,
+		clear,
+	} = useBatchProcessing<CompressItem>({
+		fallbackErrorMessage: '画像の処理に失敗しました。',
+		releaseItem: (it) => {
+			URL.revokeObjectURL(it.previewUrl);
+			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
+		},
+		releasePatch: (patch) => {
+			if (patch.resultUrl) URL.revokeObjectURL(patch.resultUrl);
+		},
+		onRunComplete: trackRun, // 圧縮実行の分析計測
+	});
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -89,69 +98,17 @@ export function ImageCompressPage() {
 		}
 	}, [trackSharedUrlOpen]);
 
-	// アンマウント時に全 object URL を解放する
-	useEffect(() => {
-		return () => {
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-			}
-		};
-	}, []);
-
-	const updateItem = useCallback((id: string, patch: Partial<CompressItem>) => {
-		setItems((prev) =>
-			prev.map((it) => (it.id === id ? { ...it, ...patch } : it)),
-		);
-	}, []);
-
-	const processAll = useCallback(
-		async (target: CompressItem[], uiOptions: CompressUiOptions) => {
-			const runId = ++runIdRef.current;
-			cancelRef.current = false;
-			setProcessing(true);
-			setCompletion(null);
-			setProgress({ done: 0, total: target.length });
-			const core = toCoreOptions(uiOptions);
-			let done = 0;
-			let failed = 0;
-
-			for (let i = 0; i < target.length; i++) {
-				if (cancelRef.current || runIdRef.current !== runId) break;
-				const item = target[i];
-				try {
-					const result =
-						uiOptions.useTargetSize && uiOptions.format !== 'png'
-							? await compressToTargetSize(item.file, uiOptions.targetKB, core)
-							: await compressImage(item.file, core);
-					const resultUrl = URL.createObjectURL(result.blob);
-					if (runIdRef.current !== runId) {
-						URL.revokeObjectURL(resultUrl);
-						break;
-					}
-					updateItem(item.id, { status: 'done', result, resultUrl });
-					done++;
-				} catch (err) {
-					updateItem(item.id, {
-						status: 'error',
-						error:
-							err instanceof Error ? err.message : '画像の処理に失敗しました。',
-					});
-					failed++;
-				}
-				if (runIdRef.current === runId) {
-					setProgress({ done: i + 1, total: target.length });
-				}
-				// イベントループへ yield して UI フリーズを防ぐ
-				await new Promise((resolve) => setTimeout(resolve, 0));
-			}
-			if (runIdRef.current === runId) {
-				setProcessing(false);
-				setCompletion({ done, failed, total: target.length });
-				trackRun(); // 圧縮実行の分析計測
-			}
+	/** 1ファイルを現在の設定で圧縮する */
+	const compressItem = useCallback(
+		async (item: CompressItem): Promise<Partial<CompressItem>> => {
+			const core = toCoreOptions(options);
+			const result =
+				options.useTargetSize && options.format !== 'png'
+					? await compressToTargetSize(item.file, options.targetKB, core)
+					: await compressImage(item.file, core);
+			return { result, resultUrl: URL.createObjectURL(result.blob) };
 		},
-		[updateItem, trackRun],
+		[options],
 	);
 
 	const handleShare = useCallback(() => {
@@ -176,28 +133,22 @@ export function ImageCompressPage() {
 				else errors.push(`${file.name}: ${v.message}`);
 			}
 			setError(errors.length > 0 ? errors.join('\n') : null);
-			setCompletion(null);
+			clearCompletion();
 			if (valid.length === 0) return;
 
-			// 差し替え: 前回結果と object URL を解放する
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-			}
 			const next: CompressItem[] = valid.map((file) => ({
 				id: createId(),
 				file,
 				previewUrl: URL.createObjectURL(file),
 				status: 'pending',
 			}));
-			setItems(next);
-			void processAll(next, options);
+			start(next, compressItem);
 		},
-		[options, processAll],
+		[setError, clearCompletion, start, compressItem],
 	);
 
 	const handleRecompress = useCallback(() => {
-		const reset = itemsRef.current.map((it) => {
+		reprocess((it) => {
 			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
 			return {
 				...it,
@@ -206,30 +157,11 @@ export function ImageCompressPage() {
 				resultUrl: undefined,
 				error: undefined,
 			};
-		});
-		setItems(reset);
-		void processAll(reset, options);
-	}, [options, processAll]);
+		}, compressItem);
+	}, [reprocess, compressItem]);
 
-	const handleCancel = useCallback(() => {
-		cancelRef.current = true;
-		runIdRef.current++;
-		setProcessing(false);
-		setCompletion(null);
-	}, []);
-
-	const handleClear = useCallback(() => {
-		runIdRef.current++;
-		cancelRef.current = true;
-		for (const it of itemsRef.current) {
-			URL.revokeObjectURL(it.previewUrl);
-			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-		}
-		setItems([]);
-		setError(null);
-		setProcessing(false);
-		setCompletion(null);
-	}, []);
+	const handleCancel = cancel;
+	const handleClear = clear;
 
 	const handleDownload = useCallback((item: CompressItem) => {
 		if (item.result) downloadBlob(item.result.blob, item.result.fileName);
@@ -240,7 +172,7 @@ export function ImageCompressPage() {
 	}, []);
 
 	const handleDownloadZip = useCallback(async () => {
-		const done = itemsRef.current.filter(
+		const done = items.filter(
 			(
 				it,
 			): it is CompressItem & { result: NonNullable<CompressItem['result']> } =>
@@ -252,7 +184,7 @@ export function ImageCompressPage() {
 			done.map((it, i) => ({ name: names[i], data: it.result.blob })),
 		);
 		downloadBlob(zip, 'images_compressed.zip');
-	}, []);
+	}, [items]);
 
 	const doneCount = items.filter((it) => it.status === 'done').length;
 

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -9,9 +9,10 @@ import {
 	Share2,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -34,15 +35,8 @@ import { type ConvertItem, ConvertResultList } from './ConvertResultList';
 const ACCEPT =
 	'image/png,image/jpeg,image/webp,image/avif,image/heic,image/heif,.heic,.heif';
 
-type CompletionNotice = {
-	done: number;
-	failed: number;
-	total: number;
-};
-
 export function ImageConvertPage() {
 	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('image-convert');
-	const [items, setItems] = useState<ConvertItem[]>([]);
 	const [options, updateOptions, generateShareUrl] = useToolSettings(
 		'image-convert',
 		DEFAULT_UI_OPTIONS,
@@ -51,14 +45,30 @@ export function ImageConvertPage() {
 	const [processedTarget, setProcessedTarget] = useState<TargetFormat>(
 		DEFAULT_UI_OPTIONS.target,
 	);
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [completion, setCompletion] = useState<CompletionNotice | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const runIdRef = useRef(0);
-	const cancelRef = useRef(false);
-	const itemsRef = useRef<ConvertItem[]>([]);
-	itemsRef.current = items;
+
+	const {
+		items,
+		processing,
+		progress,
+		completion,
+		error,
+		setError,
+		clearCompletion,
+		start,
+		reprocess,
+		cancel,
+		clear,
+	} = useBatchProcessing<ConvertItem>({
+		fallbackErrorMessage: '画像の変換に失敗しました。',
+		releaseItem: (it) => {
+			URL.revokeObjectURL(it.previewUrl);
+			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
+		},
+		releasePatch: (patch) => {
+			if (patch.resultUrl) URL.revokeObjectURL(patch.resultUrl);
+		},
+		onRunComplete: trackRun,
+	});
 
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
@@ -67,74 +77,20 @@ export function ImageConvertPage() {
 		}
 	}, [trackSharedUrlOpen]);
 
-	// アンマウント時に全 object URL を解放する
-	useEffect(() => {
-		return () => {
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-			}
-		};
-	}, []);
-
-	const updateItem = useCallback((id: string, patch: Partial<ConvertItem>) => {
-		setItems((prev) =>
-			prev.map((it) => (it.id === id ? { ...it, ...patch } : it)),
-		);
-	}, []);
-
-	const processAll = useCallback(
-		async (target: ConvertItem[], uiOptions: ConvertUiOptions) => {
-			const runId = ++runIdRef.current;
-			cancelRef.current = false;
-			setProcessing(true);
-			setProcessedTarget(uiOptions.target);
-			setCompletion(null);
-			setProgress({ done: 0, total: target.length });
-			let done = 0;
-			let failed = 0;
-
-			for (let i = 0; i < target.length; i++) {
-				if (cancelRef.current || runIdRef.current !== runId) break;
-				const item = target[i];
-				try {
-					const result = await convertOne(item.file, uiOptions);
-					const resultUrl = URL.createObjectURL(result.blob);
-					if (runIdRef.current !== runId) {
-						URL.revokeObjectURL(resultUrl);
-						break;
-					}
-					updateItem(item.id, {
-						status: 'done',
-						result: {
-							fileName: result.fileName,
-							blob: result.blob,
-							warnings: result.warnings,
-						},
-						resultUrl,
-					});
-					done++;
-				} catch (err) {
-					updateItem(item.id, {
-						status: 'error',
-						error:
-							err instanceof Error ? err.message : '画像の変換に失敗しました。',
-					});
-					failed++;
-				}
-				if (runIdRef.current === runId) {
-					setProgress({ done: i + 1, total: target.length });
-				}
-				// イベントループへ yield して UI フリーズを防ぐ
-				await new Promise((resolve) => setTimeout(resolve, 0));
-			}
-			if (runIdRef.current === runId) {
-				setProcessing(false);
-				setCompletion({ done, failed, total: target.length });
-				trackRun();
-			}
+	/** 1ファイルを現在の設定で変換する */
+	const convertItem = useCallback(
+		async (item: ConvertItem): Promise<Partial<ConvertItem>> => {
+			const result = await convertOne(item.file, options);
+			return {
+				result: {
+					fileName: result.fileName,
+					blob: result.blob,
+					warnings: result.warnings,
+				},
+				resultUrl: URL.createObjectURL(result.blob),
+			};
 		},
-		[updateItem, trackRun],
+		[options],
 	);
 
 	const handleFilesSelect = useCallback(
@@ -154,14 +110,9 @@ export function ImageConvertPage() {
 				else errors.push(v.message);
 			}
 			setError(errors.length > 0 ? errors.join('\n') : null);
-			setCompletion(null);
+			clearCompletion();
 			if (valid.length === 0) return;
 
-			// 差し替え: 前回結果と object URL を解放する
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-			}
 			const next: ConvertItem[] = valid.map(({ file, format }) => ({
 				id: createId(),
 				file,
@@ -169,19 +120,19 @@ export function ImageConvertPage() {
 				sourceFormat: format,
 				status: 'pending',
 			}));
-			setItems(next);
-			void processAll(next, options);
+			setProcessedTarget(options.target);
+			start(next, convertItem);
 		},
-		[options, processAll],
+		[options.target, setError, clearCompletion, start, convertItem],
 	);
 
 	// オプション変更時は古い完了メッセージを消す（再変換するまで結果は前回のまま）
 	const handleOptionsChange = useCallback(
 		(next: ConvertUiOptions) => {
 			updateOptions(next);
-			setCompletion(null);
+			clearCompletion();
 		},
-		[updateOptions],
+		[updateOptions, clearCompletion],
 	);
 
 	const handleShare = useCallback(() => {
@@ -192,7 +143,8 @@ export function ImageConvertPage() {
 	}, [generateShareUrl]);
 
 	const handleReconvert = useCallback(() => {
-		const reset = itemsRef.current.map((it) => {
+		setProcessedTarget(options.target);
+		reprocess((it) => {
 			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
 			return {
 				...it,
@@ -201,37 +153,18 @@ export function ImageConvertPage() {
 				resultUrl: undefined,
 				error: undefined,
 			};
-		});
-		setItems(reset);
-		void processAll(reset, options);
-	}, [options, processAll]);
+		}, convertItem);
+	}, [options.target, reprocess, convertItem]);
 
-	const handleCancel = useCallback(() => {
-		cancelRef.current = true;
-		runIdRef.current++;
-		setProcessing(false);
-		setCompletion(null);
-	}, []);
-
-	const handleClear = useCallback(() => {
-		runIdRef.current++;
-		cancelRef.current = true;
-		for (const it of itemsRef.current) {
-			URL.revokeObjectURL(it.previewUrl);
-			if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-		}
-		setItems([]);
-		setError(null);
-		setProcessing(false);
-		setCompletion(null);
-	}, []);
+	const handleCancel = cancel;
+	const handleClear = clear;
 
 	const handleDownload = useCallback((item: ConvertItem) => {
 		if (item.result) downloadBlob(item.result.blob, item.result.fileName);
 	}, []);
 
 	const handleDownloadZip = useCallback(async () => {
-		const done = itemsRef.current.filter(
+		const done = items.filter(
 			(
 				it,
 			): it is ConvertItem & { result: NonNullable<ConvertItem['result']> } =>
@@ -243,7 +176,7 @@ export function ImageConvertPage() {
 			done.map((it, i) => ({ name: names[i], data: it.result.blob })),
 		);
 		downloadBlob(zip, 'converted.zip');
-	}, []);
+	}, [items]);
 
 	const doneCount = items.filter((it) => it.status === 'done').length;
 

--- a/src/lib/hooks/useBatchProcessing.ts
+++ b/src/lib/hooks/useBatchProcessing.ts
@@ -1,0 +1,181 @@
+// useBatchProcessing — 複数ファイル逐次処理の共通フック
+// 進捗表示・キャンセル・中断検知（runId）・ObjectURL 等のリソース解放という
+// バッチ処理ページ共通の状態機械を一元管理する。
+// 使用例: ImageCompressPage / ImageConvertPage
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/** バッチ処理対象アイテムに最低限必要なフィールド */
+export type BatchItemBase = {
+	id: string;
+	status: 'pending' | 'done' | 'error';
+	error?: string;
+};
+
+export type BatchProgress = { done: number; total: number };
+
+export type BatchCompletion = { done: number; failed: number; total: number };
+
+export type UseBatchProcessingOptions<TItem extends BatchItemBase> = {
+	/** 処理失敗時にアイテムへ設定する既定エラーメッセージ */
+	fallbackErrorMessage: string;
+	/** アイテムが保持するリソース（ObjectURL 等）を解放する。差し替え・クリア・アンマウント時に呼ばれる */
+	releaseItem?: (item: TItem) => void;
+	/** 処理成功パッチがラン中断後に届いた場合に、パッチ側のリソースを解放する（例: 生成済み resultUrl の revoke） */
+	releasePatch?: (patch: Partial<TItem>) => void;
+	/** 1ラン正常完了時に呼ばれる（キャンセル・中断時は呼ばれない）。計測などに使用 */
+	onRunComplete?: (completion: BatchCompletion) => void;
+};
+
+/** 1アイテムを処理して成功時の差分を返す。失敗時は throw する */
+export type BatchItemProcessor<TItem extends BatchItemBase> = (
+	item: TItem,
+) => Promise<Partial<TItem>>;
+
+export function useBatchProcessing<TItem extends BatchItemBase>(
+	options: UseBatchProcessingOptions<TItem>,
+) {
+	const { fallbackErrorMessage, releasePatch, onRunComplete } = options;
+
+	const [items, setItems] = useState<TItem[]>([]);
+	const [processing, setProcessing] = useState(false);
+	const [progress, setProgress] = useState<BatchProgress>({
+		done: 0,
+		total: 0,
+	});
+	const [completion, setCompletion] = useState<BatchCompletion | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const runIdRef = useRef(0);
+	const cancelRef = useRef(false);
+	const itemsRef = useRef<TItem[]>([]);
+	itemsRef.current = items;
+
+	// アンマウント時の解放と onRunComplete から安定参照するための ref
+	const releaseItemRef = useRef(options.releaseItem);
+	releaseItemRef.current = options.releaseItem;
+	const onRunCompleteRef = useRef(onRunComplete);
+	onRunCompleteRef.current = onRunComplete;
+
+	// アンマウント時に全アイテムのリソースを解放する
+	useEffect(() => {
+		return () => {
+			for (const it of itemsRef.current) releaseItemRef.current?.(it);
+		};
+	}, []);
+
+	const updateItem = useCallback((id: string, patch: Partial<TItem>) => {
+		setItems((prev) =>
+			prev.map((it) => (it.id === id ? { ...it, ...patch } : it)),
+		);
+	}, []);
+
+	/** target を先頭から逐次処理する（キャンセル・差し替えで中断） */
+	const run = useCallback(
+		async (target: TItem[], processItem: BatchItemProcessor<TItem>) => {
+			const runId = ++runIdRef.current;
+			cancelRef.current = false;
+			setProcessing(true);
+			setCompletion(null);
+			setProgress({ done: 0, total: target.length });
+			let done = 0;
+			let failed = 0;
+
+			for (let i = 0; i < target.length; i++) {
+				if (cancelRef.current || runIdRef.current !== runId) break;
+				const item = target[i];
+				try {
+					const patch = await processItem(item);
+					if (runIdRef.current !== runId) {
+						// 中断後に届いた結果はアイテムへ反映せず、リソースだけ解放する
+						releasePatch?.(patch);
+						break;
+					}
+					updateItem(item.id, { ...patch, status: 'done' } as Partial<TItem>);
+					done++;
+				} catch (err) {
+					updateItem(item.id, {
+						status: 'error',
+						error: err instanceof Error ? err.message : fallbackErrorMessage,
+					} as Partial<TItem>);
+					failed++;
+				}
+				if (runIdRef.current === runId) {
+					setProgress({ done: i + 1, total: target.length });
+				}
+				// イベントループへ yield して UI フリーズを防ぐ
+				await new Promise((resolve) => setTimeout(resolve, 0));
+			}
+
+			if (runIdRef.current === runId) {
+				setProcessing(false);
+				const result = { done, failed, total: target.length };
+				setCompletion(result);
+				onRunCompleteRef.current?.(result);
+			}
+		},
+		[fallbackErrorMessage, releasePatch, updateItem],
+	);
+
+	/** 前回の items のリソースを解放してから target に差し替え、処理を開始する */
+	const start = useCallback(
+		(target: TItem[], processItem: BatchItemProcessor<TItem>) => {
+			for (const it of itemsRef.current) releaseItemRef.current?.(it);
+			setItems(target);
+			void run(target, processItem);
+		},
+		[run],
+	);
+
+	/** 現在の items を resetItem で初期化し直して再処理する（再圧縮・再変換） */
+	const reprocess = useCallback(
+		(
+			resetItem: (item: TItem) => TItem,
+			processItem: BatchItemProcessor<TItem>,
+		) => {
+			const reset = itemsRef.current.map(resetItem);
+			setItems(reset);
+			void run(reset, processItem);
+		},
+		[run],
+	);
+
+	/** 進行中の処理を中断する（items は保持） */
+	const cancel = useCallback(() => {
+		cancelRef.current = true;
+		runIdRef.current++;
+		setProcessing(false);
+		setCompletion(null);
+	}, []);
+
+	/** 全アイテムを破棄して初期状態に戻す */
+	const clear = useCallback(() => {
+		runIdRef.current++;
+		cancelRef.current = true;
+		for (const it of itemsRef.current) releaseItemRef.current?.(it);
+		setItems([]);
+		setError(null);
+		setProcessing(false);
+		setCompletion(null);
+	}, []);
+
+	/** 完了メッセージのみ消す（オプション変更時など） */
+	const clearCompletion = useCallback(() => {
+		setCompletion(null);
+	}, []);
+
+	return {
+		items,
+		itemsRef,
+		updateItem,
+		processing,
+		progress,
+		completion,
+		error,
+		setError,
+		clearCompletion,
+		start,
+		reprocess,
+		cancel,
+		clear,
+	};
+}


### PR DESCRIPTION
## 概要
コードベース監査で最大の技術的負債と判定された「バッチ処理パターンの重複」の解消第1弾です。進捗管理・キャンセル・中断検知（runId）・ObjectURLライフサイクル管理という同一の状態機械が複数ページに丸ごとコピーされていたため、共通フックに抽出します。

## 変更内容
- **新規** `src/lib/hooks/useBatchProcessing.ts`: バッチ逐次処理の共通フック
  - items / processing / progress / completion / error の状態管理
  - runId による中断検知（差し替え・キャンセル時に遅延結果を破棄しリソース解放）
  - `start` / `reprocess` / `cancel` / `clear` / `clearCompletion` を提供
  - アンマウント時の ObjectURL 等の解放（`releaseItem` / `releasePatch` コールバック）
- **移行** `ImageCompressPage.tsx` / `ImageConvertPage.tsx`（完全同型だった2ページ、計233行削除）
  - `handleDownloadZip` は ref 参照から state (`items`) 参照に変更（挙動同一）

## スコープについて
pdf-merge / pdf-split / image-edit 等は進捗の形が異なる（単一結果・コールバック進捗）ため、本PRでは対象外とし段階的に移行します（Notionタスク「バッチ処理パターンの共通フック抽出」に追記）。

## 検証
- `npm run lint` → エラー0（警告は既存5件のみ）
- `npx astro check` → エラー0
- `npm run build` + `npx playwright test image-compress / image-convert` → **40件全パス**（変換・再圧縮・キャンセル・ZIP・上限エラー・レスポンシブを含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)