### PR TITLE
test: string-utils のコードポイント操作関数に単体テストを追加

### DIFF
--- a/tests/unit/string-utils.test.ts
+++ b/tests/unit/string-utils.test.ts
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	fromCodePoints,
+	getCodePoints,
+	getNextCodePointIndex,
+} from '../../src/lib/string-utils.ts';
+
+test('getCodePoints: サロゲートペアを含む文字列をコードポイント配列へ正しく分解する', () => {
+	// 'あ'(U+3042) と '🎉'(U+1F389, サロゲートペア) を含む
+	assert.deepStrictEqual(getCodePoints('あ🎉'), [0x3042, 0x1f389]);
+	// 空文字列は空配列
+	assert.deepStrictEqual(getCodePoints(''), []);
+});
+
+test('fromCodePoints: getCodePoints との往復変換がサロゲートペアを破損せず無損失', () => {
+	const original = 'A𩸽あ🎉'; // ASCII・補助漢字(U+29E3D)・かな・絵文字が混在
+	assert.strictEqual(fromCodePoints(getCodePoints(original)), original);
+	// 空配列は空文字列
+	assert.strictEqual(fromCodePoints([]), '');
+});
+
+test('getNextCodePointIndex: サロゲートペアは2、BMP内の文字は1だけインデックスを進める', () => {
+	const str = '🎉a'; // '🎉' は length 2 のサロゲートペア
+	assert.strictEqual(getNextCodePointIndex(str, 0), 2); // サロゲートペアをまたぐ
+	assert.strictEqual(getNextCodePointIndex(str, 2), 3); // 'a' は1進む
+	assert.strictEqual(getNextCodePointIndex('あ', 0), 1); // BMP内の単一文字
+});


### PR DESCRIPTION
## 概要

`src/lib/string-utils.ts` のコードポイント操作関数に対する単体テストを新規追加する、小さくシンプルな変更です。PR作成能力の実証を目的とした「些細な拡張」であり、**本番コードには一切手を加えていません**（テストのみ追加）。

対象の Notion タスク: [プルリクエストの下書きを作成する](https://app.notion.com/p/392dfd36033680d88d30da5b1a583ec2)

## 変更内容（今回の最新コミット: `3e2fcac`）

- `tests/unit/string-utils.test.ts` を新規追加。以下3関数のサロゲートペア挙動を検証:
  - `getCodePoints` — 文字列 → コードポイント配列への分解（絵文字・空文字列）
  - `fromCodePoints` — コードポイント配列 → 文字列の復元、および `getCodePoints` との無損失な往復変換
  - `getNextCodePointIndex` — サロゲートペアは +2、BMP内文字は +1 のインデックス前進

`unicode-converter.test.ts` の既存規約（`node:test` / `node:assert/strict`、`.ts` 拡張子明記、タブ・シングルクォート）に合わせています。

## 検証結果

- `node --test "tests/unit/string-utils.test.ts"` → **3 pass / 0 fail**
- `npm run test:unit` → 追加した3件は成功。既存の21件の失敗は、サンドボックスに一部npm依存（`encoding-japanese`・`marked`・`pdf-lib` 等）が未インストールで `ERR_MODULE_NOT_FOUND` になる**環境要因**であり、本変更とは無関係（本テストは外部依存ゼロの `src/lib/string-utils.ts` のみをインポート）。
- ファイルは `biome.json` の設定（タブインデント・LF・シングルクォート・import整列）に一致するよう作成。

## 意図的に含めなかった未ステージ変更

なし。`git status` 上、追加は `tests/unit/string-utils.test.ts` の1ファイルのみです。

## 解説ドキュメント

[解説ドキュメント: string-utils 単体テスト追加 PR](https://app.notion.com/p/392dfd3603368105a2c4c58e9d52f351)（Background / Intuition / Code / Verification / Alternatives / Suggested people / Quiz）

---
🤖 Notion カスタムエージェント（Claude）により作成。

Co-authored-by: marumo <marumo@codelife.cafe>