### PR TITLE
QRコード読み取りツール UI/UX改善（正方形ファインダー・読み取り成功フィードバック）

### DIFF
--- a/src/components/qr-reader/BeepToggle.tsx
+++ b/src/components/qr-reader/BeepToggle.tsx
@@ -1,0 +1,31 @@
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+
+interface BeepToggleProps {
+	enabled: boolean;
+	onChange: (enabled: boolean) => void;
+}
+
+/**
+ * 読み取り成功時のビープ音トグル。既定OFF。
+ * 音声ファイルは使わず Web Audio API（OscillatorNode）で生成するため、
+ * ONにした操作（ユーザー操作）を起点に AudioContext を初期化する。
+ */
+export default function BeepToggle({ enabled, onChange }: BeepToggleProps) {
+	return (
+		<div className="flex items-start justify-between gap-4 rounded-xl border border-border bg-card p-4">
+			<div className="space-y-1">
+				<Label
+					htmlFor="beep-switch"
+					className="text-sm font-medium cursor-pointer"
+				>
+					読み取り音
+				</Label>
+				<p className="text-xs text-muted-foreground leading-relaxed">
+					ONにすると、QRコードを検出するたびに短いビープ音を鳴らします。
+				</p>
+			</div>
+			<Switch id="beep-switch" checked={enabled} onCheckedChange={onChange} />
+		</div>
+	);
+}

--- a/src/components/qr-reader/CameraScanner.tsx
+++ b/src/components/qr-reader/CameraScanner.tsx
@@ -6,6 +6,15 @@ import { decodeFrame, terminateWorker } from '@/lib/tools/qr-reader';
 const DECODE_INTERVAL_MS = 200; // 150-250ms の範囲でスロットリング
 const SAME_VALUE_DEDUPE_MS = 1500;
 
+type Corner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+const CORNER_POSITION: Record<Corner, string> = {
+	'top-left': 'top-0 left-0 border-t-4 border-l-4 rounded-tl-lg',
+	'top-right': 'top-0 right-0 border-t-4 border-r-4 rounded-tr-lg',
+	'bottom-left': 'bottom-0 left-0 border-b-4 border-l-4 rounded-bl-lg',
+	'bottom-right': 'bottom-0 right-0 border-b-4 border-r-4 rounded-br-lg',
+};
+
 interface CameraScannerProps {
 	onDetected: (value: string) => void;
 	onSwitchToImageMode: () => void;
@@ -28,12 +37,23 @@ export default function CameraScanner({
 	const lastValueRef = useRef<{ value: string; at: number } | null>(null);
 	const onDetectedRef = useRef(onDetected);
 	onDetectedRef.current = onDetected;
+	const [flash, setFlash] = useState(false);
+	const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [reducedMotion] = useState(
+		() =>
+			typeof window !== 'undefined' &&
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+	);
 
 	// --- カメラ停止（トラック停止 + Worker 終了） ---
 	const stopCamera = useCallback(() => {
 		if (rafRef.current !== null) {
 			cancelAnimationFrame(rafRef.current);
 			rafRef.current = null;
+		}
+		if (flashTimeoutRef.current) {
+			clearTimeout(flashTimeoutRef.current);
+			flashTimeoutRef.current = null;
 		}
 		if (streamRef.current) {
 			for (const track of streamRef.current.getTracks()) {
@@ -98,6 +118,9 @@ export default function CameraScanner({
 						return;
 					}
 					lastValueRef.current = { value, at: nowMs };
+					setFlash(true);
+					if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+					flashTimeoutRef.current = setTimeout(() => setFlash(false), 250);
 					onDetectedRef.current(value);
 				})
 				.catch(() => {
@@ -248,7 +271,7 @@ export default function CameraScanner({
 	}
 
 	return (
-		<div className="relative overflow-hidden rounded-xl border border-border bg-black aspect-video">
+		<div className="relative mx-auto w-full max-w-[480px] aspect-square overflow-hidden rounded-xl border border-border bg-black">
 			{/* biome-ignore lint/a11y/useMediaCaption: カメラプレビューには音声トラックがない */}
 			<video
 				ref={videoRef}
@@ -266,8 +289,22 @@ export default function CameraScanner({
 				</div>
 			)}
 			{status === 'active' && (
-				<div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-					<div className="h-2/3 w-2/3 rounded-2xl border-2 border-white/70" />
+				// 正方形ファインダー: 周囲を半透明マスクでシェーディングし、
+				// 四隅コーナーマークで読み取り対象範囲を明示する（html5-qrcode方式）。
+				<div
+					className="pointer-events-none absolute inset-[10%] rounded-lg"
+					style={{ boxShadow: '0 0 0 9999px rgba(0,0,0,0.45)' }}
+					data-testid="qr-viewfinder"
+					data-flash={flash ? 'true' : 'false'}
+				>
+					{(Object.keys(CORNER_POSITION) as Corner[]).map((corner) => (
+						<span
+							key={corner}
+							className={`absolute h-6 w-6 ${CORNER_POSITION[corner]} ${
+								flash ? 'border-emerald-400' : 'border-white/80'
+							} ${reducedMotion ? '' : 'transition-colors duration-150'}`}
+						/>
+					))}
 				</div>
 			)}
 		</div>

--- a/src/components/qr-reader/ScanToast.tsx
+++ b/src/components/qr-reader/ScanToast.tsx
@@ -1,0 +1,33 @@
+import { CheckCircle2 } from 'lucide-react';
+
+interface ScanToastProps {
+	message: string | null;
+	reducedMotion: boolean;
+}
+
+/**
+ * 読み取り成功を伝える非モーダルなミニトースト。
+ * ファインダー付近に一時表示し、連続スキャンをブロックしない。
+ */
+export default function ScanToast({ message, reducedMotion }: ScanToastProps) {
+	if (!message) return null;
+
+	return (
+		<div
+			className="pointer-events-none absolute inset-x-0 bottom-2 flex justify-center"
+			data-testid="scan-toast"
+			data-reduced-motion={reducedMotion ? 'true' : 'false'}
+		>
+			<div
+				role="status"
+				aria-live="polite"
+				className={`flex items-center gap-1.5 rounded-full bg-emerald-600 px-3 py-1.5 text-sm font-medium text-white shadow-lg ${
+					reducedMotion ? '' : 'animate-in fade-in zoom-in-95 duration-150'
+				}`}
+			>
+				<CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+				{message}
+			</div>
+		</div>
+	);
+}

--- a/src/components/tools/QrReader.tsx
+++ b/src/components/tools/QrReader.tsx
@@ -1,11 +1,13 @@
 import { Info } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import AutosaveToggle from '@/components/qr-reader/AutosaveToggle';
+import BeepToggle from '@/components/qr-reader/BeepToggle';
 import CameraScanner from '@/components/qr-reader/CameraScanner';
 import ExportBar from '@/components/qr-reader/ExportBar';
 import ImageUploader from '@/components/qr-reader/ImageUploader';
 import ModeTabs, { type ScanMode } from '@/components/qr-reader/ModeTabs';
 import ResultsList from '@/components/qr-reader/ResultsList';
+import ScanToast from '@/components/qr-reader/ScanToast';
 import { Button } from '@/components/ui/button';
 import {
 	Dialog,
@@ -20,22 +22,37 @@ import {
 	buildCsv,
 	clearResults,
 	downloadCsv,
+	initBeepAudioContext,
 	loadAutosaveSetting,
+	loadBeepSetting,
 	loadResults,
+	playBeep,
 	type ScanResult,
 	saveAutosaveSetting,
+	saveBeepSetting,
 	saveResults,
 	terminateWorker,
+	vibrateDevice,
 } from '@/lib/tools/qr-reader';
+
+const SCAN_TOAST_DURATION_MS = 1000;
 
 export default function QrReader() {
 	const [mode, setMode] = useState<ScanMode>('camera');
 	const [results, setResults] = useState<ScanResult[]>([]);
 	const [autosave, setAutosave] = useState(false);
+	const [beepEnabled, setBeepEnabled] = useState(false);
+	const [toastMessage, setToastMessage] = useState<string | null>(null);
+	const [reducedMotion] = useState(
+		() =>
+			typeof window !== 'undefined' &&
+			window.matchMedia?.('(prefers-reduced-motion: reduce)').matches,
+	);
+	const toastTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 	const [restoreDialogOpen, setRestoreDialogOpen] = useState(false);
 	const pendingRestoreRef = useRef<ScanResult[] | null>(null);
 
-	// --- 初回マウント: autosave 設定を読み込み、有効かつ残存データがあれば復元確認 ---
+	// --- 初回マウント: autosave / beep 設定を読み込み、有効かつ残存データがあれば復元確認 ---
 	useEffect(() => {
 		const savedAutosave = loadAutosaveSetting();
 		setAutosave(savedAutosave);
@@ -46,12 +63,37 @@ export default function QrReader() {
 				setRestoreDialogOpen(true);
 			}
 		}
+		setBeepEnabled(loadBeepSetting());
 	}, []);
 
 	// --- Worker の完全終了（ページ離脱・アンマウント時） ---
 	useEffect(() => {
 		return () => terminateWorker();
 	}, []);
+
+	// --- トースト表示中のタイマーをアンマウント時にクリア ---
+	useEffect(() => {
+		return () => {
+			if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
+		};
+	}, []);
+
+	const showScanToast = (message: string) => {
+		if (toastTimeoutRef.current) clearTimeout(toastTimeoutRef.current);
+		setToastMessage(message);
+		toastTimeoutRef.current = setTimeout(
+			() => setToastMessage(null),
+			SCAN_TOAST_DURATION_MS,
+		);
+	};
+
+	// 視覚（トースト）＋聴覚（ビープ、トグルON時のみ）＋触覚（対応端末のみ）の
+	// 多層フィードバック。重複クールダウンを通過し結果リストに行が追加された時のみ発火する。
+	const notifyScanSuccess = (message: string) => {
+		showScanToast(message);
+		if (beepEnabled) playBeep();
+		vibrateDevice();
+	};
 
 	const handleAddValue = (rawValue: string, source: ScanResult['source']) => {
 		setResults((prev) => {
@@ -63,11 +105,15 @@ export default function QrReader() {
 
 	const handleCameraDetected = (value: string) => {
 		handleAddValue(value, 'camera');
+		notifyScanSuccess('✓ 読み取り成功');
 	};
 
 	const handleImageDecoded = (fileName: string, values: string[]) => {
 		for (const value of values) {
 			handleAddValue(value, { image: fileName });
+		}
+		if (values.length > 0) {
+			notifyScanSuccess(`✓ ${values.length}件検出`);
 		}
 	};
 
@@ -79,6 +125,12 @@ export default function QrReader() {
 		} else {
 			clearResults();
 		}
+	};
+
+	const handleBeepChange = (enabled: boolean) => {
+		setBeepEnabled(enabled);
+		saveBeepSetting(enabled);
+		if (enabled) initBeepAudioContext();
 	};
 
 	const handleExportCsv = () => {
@@ -123,17 +175,21 @@ export default function QrReader() {
 
 			<ModeTabs mode={mode} onModeChange={setMode} />
 
-			{mode === 'camera' ? (
-				<CameraScanner
-					key="camera"
-					onDetected={handleCameraDetected}
-					onSwitchToImageMode={() => setMode('image')}
-				/>
-			) : (
-				<ImageUploader onDecoded={handleImageDecoded} />
-			)}
+			<div className="relative">
+				{mode === 'camera' ? (
+					<CameraScanner
+						key="camera"
+						onDetected={handleCameraDetected}
+						onSwitchToImageMode={() => setMode('image')}
+					/>
+				) : (
+					<ImageUploader onDecoded={handleImageDecoded} />
+				)}
+				<ScanToast message={toastMessage} reducedMotion={reducedMotion} />
+			</div>
 
 			<AutosaveToggle enabled={autosave} onChange={handleAutosaveChange} />
+			<BeepToggle enabled={beepEnabled} onChange={handleBeepChange} />
 
 			<div className="space-y-3">
 				<div className="flex items-center justify-between">

--- a/src/lib/tools/qr-reader.ts
+++ b/src/lib/tools/qr-reader.ts
@@ -212,6 +212,91 @@ export function loadAutosaveSetting(): boolean {
 	}
 }
 
+// --- スキャン成功フィードバック（ビープ音・振動） ---
+//
+// 完全クライアントサイドの通知API（Web Audio API / Vibration API）のみを使い、
+// 新規npm依存は追加しない。失敗してもスキャン機能自体は止めず、静かに無視する。
+const BEEP_KEY = 'qr-reader:beep';
+
+export function saveBeepSetting(enabled: boolean): void {
+	try {
+		localStorage.setItem(BEEP_KEY, enabled ? '1' : '0');
+	} catch {
+		// ignore
+	}
+}
+
+export function loadBeepSetting(): boolean {
+	try {
+		return localStorage.getItem(BEEP_KEY) === '1';
+	} catch {
+		return false;
+	}
+}
+
+let audioContext: AudioContext | null = null;
+
+/**
+ * ビープ音再生用の AudioContext を明示的なユーザー操作（トグルON等）の
+ * タイミングで初期化・resumeする。自動再生ポリシー対策。
+ */
+export function initBeepAudioContext(): void {
+	try {
+		if (!audioContext) {
+			audioContext = new AudioContext();
+		}
+		if (audioContext.state === 'suspended') {
+			void audioContext.resume();
+		}
+	} catch {
+		// AudioContext 非対応環境等は無視
+	}
+}
+
+/**
+ * 短いビープ音を OscillatorNode で生成して再生する。音声ファイルは使用しない。
+ * 再生失敗時（AudioContext未初期化・自動再生制限等）はスキャン機能を止めず無視する。
+ */
+export function playBeep(): void {
+	try {
+		if (!audioContext) {
+			audioContext = new AudioContext();
+		}
+		if (audioContext.state === 'suspended') {
+			void audioContext.resume();
+		}
+		const oscillator = audioContext.createOscillator();
+		const gain = audioContext.createGain();
+		oscillator.type = 'sine';
+		oscillator.frequency.value = 880;
+		gain.gain.setValueAtTime(0.15, audioContext.currentTime);
+		gain.gain.exponentialRampToValueAtTime(
+			0.001,
+			audioContext.currentTime + 0.12,
+		);
+		oscillator.connect(gain);
+		gain.connect(audioContext.destination);
+		oscillator.start();
+		oscillator.stop(audioContext.currentTime + 0.12);
+	} catch {
+		// ignore
+	}
+}
+
+/**
+ * 対応端末のみ短時間振動する。iOS Safari等 navigator.vibrate 非対応環境では
+ * 機能検出により何もしない（エラーにしない）。
+ */
+export function vibrateDevice(): void {
+	try {
+		if (typeof navigator.vibrate === 'function') {
+			navigator.vibrate(50);
+		}
+	} catch {
+		// ignore
+	}
+}
+
 // --- CSV出力 ---
 
 const FORMAT_LABEL: Record<ScanFormat, string> = {

--- a/tests/e2e/qr-reader.spec.ts
+++ b/tests/e2e/qr-reader.spec.ts
@@ -261,7 +261,9 @@ test.describe('QRコード読み取りツール', () => {
 		await expect(beepSwitch).toBeChecked();
 
 		await page.reload();
-		await expect(page.getByRole('switch', { name: '読み取り音' })).toBeChecked();
+		await expect(
+			page.getByRole('switch', { name: '読み取り音' }),
+		).toBeChecked();
 	});
 
 	test('キーボード操作でタブ・トグル・ボタンを操作できる', async ({

--- a/tests/e2e/qr-reader.spec.ts
+++ b/tests/e2e/qr-reader.spec.ts
@@ -198,6 +198,72 @@ test.describe('QRコード読み取りツール', () => {
 		expect(text).toMatch(/'=1\+1/);
 	});
 
+	test('画像アップロードで読み取り成功トーストが表示され自動的に消える', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('qr-reader');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: '画像から読み取り' }).click();
+		await page
+			.getByLabel('QRコード画像を選択')
+			.setInputFiles(fixture('single-qr.png'));
+
+		const toast = page.getByTestId('scan-toast');
+		await expect(toast).toContainText('1件検出');
+		await expect(toast).toHaveCount(0, { timeout: 3000 });
+	});
+
+	test('複数QRを含む画像では検出件数入りトーストが表示される', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('qr-reader');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: '画像から読み取り' }).click();
+		await page
+			.getByLabel('QRコード画像を選択')
+			.setInputFiles(fixture('multi-qr-2codes.png'));
+
+		await expect(page.getByTestId('scan-toast')).toContainText('2件検出');
+	});
+
+	test('prefers-reduced-motion環境でもトーストは表示されるがアニメーションが抑制される', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		const toolPage = createToolPage('qr-reader');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: '画像から読み取り' }).click();
+		await page
+			.getByLabel('QRコード画像を選択')
+			.setInputFiles(fixture('single-qr.png'));
+
+		const toast = page.getByTestId('scan-toast');
+		await expect(toast).toContainText('1件検出');
+		await expect(toast).toHaveAttribute('data-reduced-motion', 'true');
+	});
+
+	test('読み取り音トグルがONの状態をリロード後も保持する', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('qr-reader');
+		await toolPage.goto();
+
+		const beepSwitch = page.getByRole('switch', { name: '読み取り音' });
+		await expect(beepSwitch).not.toBeChecked();
+		await beepSwitch.click();
+		await expect(beepSwitch).toBeChecked();
+
+		await page.reload();
+		await expect(page.getByRole('switch', { name: '読み取り音' })).toBeChecked();
+	});
+
 	test('キーボード操作でタブ・トグル・ボタンを操作できる', async ({
 		page,
 		createToolPage,


### PR DESCRIPTION
## Summary
- カメラプレビューを `aspect-ratio: 1/1` の正方形にし、`object-fit: cover` で中央クロップ表示するよう変更（UX-A）
- 検出枠オーバーレイを四隅コーナーマーク＋周囲半透明マスク（html5-qrcode方式）に変更し、検出時に緑色へフラッシュ
- 読み取り成功時の多層フィードバックを追加（UX-B）: 視覚（非モーダルなミニトースト）・聴覚（Web Audio APIによるビープ音、既定OFFのトグル・`qr-reader:beep`に永続化）・触覚（対応端末のみ`navigator.vibrate`）
- `prefers-reduced-motion` 環境ではトースト／フラッシュのアニメーションを抑制（表示自体は維持）
- 画像アップロードモードでは枠フラッシュを行わず、検出件数入りトーストのみ表示
- 新規npm依存の追加なし（完全クライアントサイド処理を維持）

## Test plan
- [x] `npm run check`（Astro型チェック＋Biome）がゼロエラー
- [x] `npm run test:unit` 全件通過（523 tests）
- [x] `npm run build` がゼロエラーで成功
- [x] `npx playwright test tests/e2e/qr-reader.spec.ts` 全件通過（既存テスト＋追加テスト計32件、chromium/mobile-chrome）
  - 検出成功トースト表示（画像アップロード、1件／複数件）
  - `prefers-reduced-motion` 環境でのトースト表示・抑制
  - ビープ音トグルの永続化（ON→リロード→ON維持）

https://claude.ai/code/session_012oJ1aQitaDhi6QFCjaSJqF


---
_Generated by [Claude Code](https://claude.ai/code/session_012oJ1aQitaDhi6QFCjaSJqF)_