### PR TITLE
fix(e2e): resolve flaky category-filter transition test

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -316,6 +316,7 @@ const schema = {
     if (initialId !== '') {
       applyFilter(validIds.has(initialId) ? initialId : '', false);
     }
+    filterContainer.dataset.filterReady = 'true';
   }
 
   function setupRecentTools() {

--- a/tests/e2e/category-filter.spec.ts
+++ b/tests/e2e/category-filter.spec.ts
@@ -111,10 +111,26 @@ test.describe('トップページ カテゴリフィルタ', () => {
 		await page.locator('header a[href="/"]').click();
 		await expect(page).toHaveURL('/');
 
+		// 戻り遷移後、イベントリスナーのセットアップ完了を待つ
+		await expect(page.locator('#category-filter')).toHaveAttribute(
+			'data-filter-ready',
+			'true',
+		);
+
+		// Back後の初期カテゴリ状態（「すべて」がアクティブ）を明示的に検証
+		await expect(
+			page.getByRole('button', { name: 'すべて', exact: true }),
+		).toHaveAttribute('aria-pressed', 'true');
+
 		await page
 			.locator('#category-filter')
 			.getByRole('button', { name: '開発ツール' })
 			.click();
+
+		// 件数および表示カードのカテゴリ整合性を確認
 		await expect(visibleCards(page)).toHaveCount(devCount);
+		for (const card of await visibleCards(page).all()) {
+			await expect(card).toHaveAttribute('data-category', devCategory.id);
+		}
 	});
 });


### PR DESCRIPTION
## 概要
E2Eテスト `tests/e2e/category-filter.spec.ts` 内の「ページ遷移して戻ってもフィルタが動作する（View Transitions対応）」が flaky である問題を修正しました。

### 問題の要因
View Transitionsの戻り遷移（または通常のページ遷移）が発生した直後に、ブラウザ側でJavaScript（`setupCategoryFilter`）の実行およびイベントリスナーの登録が完了する前に、Playwrightがカテゴリボタンをクリックしてしまうことで、フィルタが適用されず全件表示のままアサートに到達しタイムアウトしていました。

### 解決策
1. **アプリ側 (`index.astro`)**:
   `setupCategoryFilter` 内で初期化セットアップが完了したタイミングで、コンテナ `#category-filter` に `data-filter-ready="true"` 属性を付与するようにしました。
2. **E2Eテスト側 (`category-filter.spec.ts`)**:
   戻り遷移後に `#category-filter` が `data-filter-ready="true"` になるのを待つアサーションを追加し、イベント駆動で同期するようにしました（固定スリープは追加していません）。
   さらに、戻り後の初期カテゴリ状態（「すべて」が `aria-pressed="true"` になっていること）の明示的アサート、およびフィルタ適用後に表示されている全カードの `data-category` 属性が一致していることをループで確認する検証を追加しました。

---

## 今回の最新コミット
- `f882602` (fix(e2e): resolve flaky category-filter transition test)

---

## 検証結果

### 1. 静的解析
`npm run lint` の実行結果：
- 変更ファイル (`index.astro`, `category-filter.spec.ts`) に関するエラーや警告はありません。
- ※既存の `webmcp.spec.ts` などの non-null assertion 警告が 10 件出力されますが、本タスクの変更内容とは無関係です。

### 2. ユニットテスト
`npm run test:unit` の実行結果：
- 523件すべて正常にパスしました。

### 3. E2E テストの安定性確認
`npx playwright test tests/e2e/category-filter.spec.ts --repeat-each=20` の実行結果：
- chromium および mobile-chrome の両プロジェクトで、計240件すべてのテストが正常にパスしました。

---

## 意図的に含めなかった未ステージ変更
- `deleted: .claude/commands/add-tool.md` (今回のタスクスコープ外のため)
- `untracked: .claude/skills/` (今回のタスクスコープ外のため)
