### PR TITLE
refactor: useBatchProcessingからuseProcessingLifecycleプリミティブを抽出

### DIFF
--- a/src/lib/hooks/useBatchProcessing.ts
+++ b/src/lib/hooks/useBatchProcessing.ts
@@ -1,9 +1,11 @@
 // useBatchProcessing — 複数ファイル逐次処理の共通フック
 // 進捗表示・キャンセル・中断検知（runId）・ObjectURL 等のリソース解放という
 // バッチ処理ページ共通の状態機械を一元管理する。
+// ランのライフサイクル管理は useProcessingLifecycle に委譲している。
 // 使用例: ImageCompressPage / ImageConvertPage
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
+import { useProcessingLifecycle } from './useProcessingLifecycle';
 
 /** バッチ処理対象アイテムに最低限必要なフィールド */
 export type BatchItemBase = {
@@ -45,23 +47,17 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 	});
 	const [completion, setCompletion] = useState<BatchCompletion | null>(null);
 	const [error, setError] = useState<string | null>(null);
-	const runIdRef = useRef(0);
-	const cancelRef = useRef(false);
-	const itemsRef = useRef<TItem[]>([]);
-	itemsRef.current = items;
 
-	// アンマウント時の解放と onRunComplete から安定参照するための ref
-	const releaseItemRef = useRef(options.releaseItem);
-	releaseItemRef.current = options.releaseItem;
+	// runIdによる中断検知・キャンセル伝播・アンマウント時のリソース解放
+	const lifecycle = useProcessingLifecycle<TItem>({
+		release: options.releaseItem,
+	});
+	lifecycle.track(items);
+	const { resourcesRef: itemsRef } = lifecycle;
+
+	// onRunComplete から安定参照するための ref
 	const onRunCompleteRef = useRef(onRunComplete);
 	onRunCompleteRef.current = onRunComplete;
-
-	// アンマウント時に全アイテムのリソースを解放する
-	useEffect(() => {
-		return () => {
-			for (const it of itemsRef.current) releaseItemRef.current?.(it);
-		};
-	}, []);
 
 	const updateItem = useCallback((id: string, patch: Partial<TItem>) => {
 		setItems((prev) =>
@@ -72,8 +68,7 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 	/** target を先頭から逐次処理する（キャンセル・差し替えで中断） */
 	const run = useCallback(
 		async (target: TItem[], processItem: BatchItemProcessor<TItem>) => {
-			const runId = ++runIdRef.current;
-			cancelRef.current = false;
+			const runId = lifecycle.beginRun();
 			setProcessing(true);
 			setCompletion(null);
 			setProgress({ done: 0, total: target.length });
@@ -81,11 +76,11 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 			let failed = 0;
 
 			for (let i = 0; i < target.length; i++) {
-				if (cancelRef.current || runIdRef.current !== runId) break;
+				if (!lifecycle.isCurrent(runId)) break;
 				const item = target[i];
 				try {
 					const patch = await processItem(item);
-					if (runIdRef.current !== runId) {
+					if (!lifecycle.isCurrent(runId)) {
 						// 中断後に届いた結果はアイテムへ反映せず、リソースだけ解放する
 						releasePatch?.(patch);
 						break;
@@ -99,31 +94,31 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 					} as Partial<TItem>);
 					failed++;
 				}
-				if (runIdRef.current === runId) {
+				if (lifecycle.isCurrent(runId)) {
 					setProgress({ done: i + 1, total: target.length });
 				}
 				// イベントループへ yield して UI フリーズを防ぐ
 				await new Promise((resolve) => setTimeout(resolve, 0));
 			}
 
-			if (runIdRef.current === runId) {
+			if (lifecycle.isCurrent(runId)) {
 				setProcessing(false);
 				const result = { done, failed, total: target.length };
 				setCompletion(result);
 				onRunCompleteRef.current?.(result);
 			}
 		},
-		[fallbackErrorMessage, releasePatch, updateItem],
+		[fallbackErrorMessage, releasePatch, updateItem, lifecycle],
 	);
 
 	/** 前回の items のリソースを解放してから target に差し替え、処理を開始する */
 	const start = useCallback(
 		(target: TItem[], processItem: BatchItemProcessor<TItem>) => {
-			for (const it of itemsRef.current) releaseItemRef.current?.(it);
+			lifecycle.releaseAll();
 			setItems(target);
 			void run(target, processItem);
 		},
-		[run],
+		[run, lifecycle],
 	);
 
 	/** 現在の items を resetItem で初期化し直して再処理する（再圧縮・再変換） */
@@ -136,27 +131,25 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 			setItems(reset);
 			void run(reset, processItem);
 		},
-		[run],
+		[run, itemsRef],
 	);
 
 	/** 進行中の処理を中断する（items は保持） */
 	const cancel = useCallback(() => {
-		cancelRef.current = true;
-		runIdRef.current++;
+		lifecycle.cancel();
 		setProcessing(false);
 		setCompletion(null);
-	}, []);
+	}, [lifecycle]);
 
 	/** 全アイテムを破棄して初期状態に戻す */
 	const clear = useCallback(() => {
-		runIdRef.current++;
-		cancelRef.current = true;
-		for (const it of itemsRef.current) releaseItemRef.current?.(it);
+		lifecycle.cancel();
+		lifecycle.releaseAll();
 		setItems([]);
 		setError(null);
 		setProcessing(false);
 		setCompletion(null);
-	}, []);
+	}, [lifecycle]);
 
 	/** 完了メッセージのみ消す（オプション変更時など） */
 	const clearCompletion = useCallback(() => {

--- a/src/lib/hooks/useProcessingLifecycle.ts
+++ b/src/lib/hooks/useProcessingLifecycle.ts
@@ -1,0 +1,125 @@
+// useProcessingLifecycle — バッチ処理系フックが共有するライフサイクル管理プリミティブ
+// runIdによる中断検知・キャンセル伝播・リソース（ObjectURL等）解放を一元管理する。
+// 状態機械そのもの（createRunTracker / createResourceTracker）は React に依存しない
+// 純粋な関数として切り出しており、DOM無しで単体テストできる。
+
+import { type RefObject, useCallback, useEffect, useMemo, useRef } from 'react';
+
+/** runIdによるラン管理・キャンセル伝播を担う（React非依存） */
+export function createRunTracker() {
+	let runId = 0;
+	let cancelled = false;
+
+	return {
+		/** 新しいランを開始し、そのrunIdを返す。キャンセル状態はリセットされる */
+		beginRun(): number {
+			cancelled = false;
+			runId += 1;
+			return runId;
+		},
+		/** runIdが現在のランと一致し、かつキャンセルされていないか */
+		isCurrent(id: number): boolean {
+			return !cancelled && runId === id;
+		},
+		/** 進行中のランを中断としてマークする（以降そのランの isCurrent は false になる） */
+		cancel(): void {
+			cancelled = true;
+			runId += 1;
+		},
+	};
+}
+
+/** アイテムが保持するリソース（ObjectURL等）の追跡・一括解放を担う（React非依存） */
+export function createResourceTracker<TResource>() {
+	let resources: TResource[] = [];
+
+	return {
+		/** 追跡対象を差し替える（解放は行わない） */
+		track(next: TResource[]): void {
+			resources = next;
+		},
+		/** 現在追跡中の全リソースに対して release を呼ぶ */
+		releaseAll(release?: (resource: TResource) => void): void {
+			for (const r of resources) release?.(r);
+		},
+	};
+}
+
+export type UseProcessingLifecycleOptions<TResource> = {
+	/** 追跡中のリソース（ObjectURL等）を解放する。アンマウント時・releaseAll呼び出し時に呼ばれる */
+	release?: (resource: TResource) => void;
+};
+
+export type ProcessingLifecycle<TResource> = {
+	/** 追跡中リソースの最新値を保持する安定参照 */
+	resourcesRef: RefObject<TResource[]>;
+	/** 追跡対象を更新する（解放は行わない） */
+	track: (resources: TResource[]) => void;
+	/** 現在追跡中の全リソースを解放する */
+	releaseAll: () => void;
+	/** 新しいランを開始し、そのrunIdを返す（キャンセル状態をリセット） */
+	beginRun: () => number;
+	/** runIdが現在のランと一致し、かつキャンセルされていないか */
+	isCurrent: (runId: number) => boolean;
+	/** 進行中のランを中断としてマークする */
+	cancel: () => void;
+};
+
+/**
+ * バッチ処理系フック（useBatchProcessing等）から利用する共通プリミティブ。
+ * runIdによる中断検知・キャンセル伝播・アンマウント時のリソース解放を提供する。
+ */
+export function useProcessingLifecycle<TResource>(
+	options: UseProcessingLifecycleOptions<TResource> = {},
+): ProcessingLifecycle<TResource> {
+	const releaseRef = useRef(options.release);
+	releaseRef.current = options.release;
+
+	const runTrackerRef = useRef<ReturnType<typeof createRunTracker> | null>(
+		null,
+	);
+	if (!runTrackerRef.current) runTrackerRef.current = createRunTracker();
+	const runTracker = runTrackerRef.current;
+
+	const resourceTrackerRef = useRef<ReturnType<
+		typeof createResourceTracker<TResource>
+	> | null>(null);
+	if (!resourceTrackerRef.current) {
+		resourceTrackerRef.current = createResourceTracker<TResource>();
+	}
+	const resourceTracker = resourceTrackerRef.current;
+
+	const resourcesRef = useRef<TResource[]>([]);
+
+	// アンマウント時に追跡中の全リソースを解放する
+	useEffect(() => {
+		return () => resourceTracker.releaseAll(releaseRef.current);
+	}, [resourceTracker]);
+
+	const track = useCallback(
+		(next: TResource[]) => {
+			resourcesRef.current = next;
+			resourceTracker.track(next);
+		},
+		[resourceTracker],
+	);
+
+	const releaseAll = useCallback(
+		() => resourceTracker.releaseAll(releaseRef.current),
+		[resourceTracker],
+	);
+
+	const beginRun = useCallback(() => runTracker.beginRun(), [runTracker]);
+
+	const isCurrent = useCallback(
+		(runId: number) => runTracker.isCurrent(runId),
+		[runTracker],
+	);
+
+	const cancel = useCallback(() => runTracker.cancel(), [runTracker]);
+
+	return useMemo(
+		() => ({ resourcesRef, track, releaseAll, beginRun, isCurrent, cancel }),
+		[track, releaseAll, beginRun, isCurrent, cancel],
+	);
+}

--- a/tests/e2e/image-compress.spec.ts
+++ b/tests/e2e/image-compress.spec.ts
@@ -174,6 +174,21 @@ test.describe('画像圧縮・リサイズ', () => {
 		await expect(page.getByRole('alert')).toContainText('対応していない形式');
 	});
 
+	test('処理中にキャンセルすると中断され、未処理のアイテムはpendingのまま残る', async ({
+		page,
+	}) => {
+		const files = Array.from({ length: 30 }, () => SAMPLE);
+		await fileInput(page).setInputFiles(files);
+
+		const cancelButton = page.getByRole('button', { name: 'キャンセル' });
+		await cancelButton.click();
+
+		await expect(cancelButton).toBeHidden();
+		// 中断により、全件が処理し終わる前に止まっている（未処理アイテムが残る）
+		await expect(page.getByText('処理中…').first()).toBeVisible();
+		await expect(page.getByTestId('compress-completion')).toBeHidden();
+	});
+
 	test('375px / 1440px でレスポンシブ表示される', async ({ page }) => {
 		await page.setViewportSize({ width: 375, height: 667 });
 		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible();

--- a/tests/e2e/image-convert.spec.ts
+++ b/tests/e2e/image-convert.spec.ts
@@ -214,6 +214,21 @@ test.describe('画像形式変換', () => {
 		}
 	});
 
+	test('処理中にキャンセルすると中断され、未処理のアイテムはpendingのまま残る', async ({
+		page,
+	}) => {
+		const files = Array.from({ length: 30 }, () => PNG);
+		await input(page).setInputFiles(files);
+
+		const cancelButton = page.getByRole('button', { name: 'キャンセル' });
+		await cancelButton.click();
+
+		await expect(cancelButton).toBeHidden();
+		// 中断により、全件が処理し終わる前に止まっている（未処理アイテムが残る）
+		await expect(page.getByText('変換中…').first()).toBeVisible();
+		await expect(page.getByTestId('convert-completion')).toBeHidden();
+	});
+
 	test('375px / 1440px でレスポンシブ表示される', async ({ page }) => {
 		await page.setViewportSize({ width: 375, height: 667 });
 		await expect(page.getByText('画像をドラッグ＆ドロップ')).toBeVisible();

--- a/tests/unit/use-processing-lifecycle.test.ts
+++ b/tests/unit/use-processing-lifecycle.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	createResourceTracker,
+	createRunTracker,
+} from '../../src/lib/hooks/useProcessingLifecycle.ts';
+
+describe('createRunTracker', () => {
+	it('cancel()を呼ぶと、直前に取得したrunIdのisCurrentがfalseになる（キャンセル伝播）', () => {
+		const tracker = createRunTracker();
+		const runId = tracker.beginRun();
+		assert.equal(tracker.isCurrent(runId), true);
+
+		tracker.cancel();
+
+		assert.equal(tracker.isCurrent(runId), false);
+	});
+
+	it('新しいbeginRun()が呼ばれると、古いrunIdのisCurrentがfalseになる（runId不一致時の中断）', () => {
+		const tracker = createRunTracker();
+		const oldRunId = tracker.beginRun();
+
+		const newRunId = tracker.beginRun();
+
+		assert.notEqual(oldRunId, newRunId);
+		assert.equal(tracker.isCurrent(oldRunId), false);
+		assert.equal(tracker.isCurrent(newRunId), true);
+	});
+
+	it('beginRun()はキャンセル状態をリセットする', () => {
+		const tracker = createRunTracker();
+		const firstRunId = tracker.beginRun();
+		tracker.cancel();
+		assert.equal(tracker.isCurrent(firstRunId), false);
+
+		const secondRunId = tracker.beginRun();
+
+		assert.equal(tracker.isCurrent(secondRunId), true);
+	});
+});
+
+describe('createResourceTracker', () => {
+	it('releaseAll()はtrack()で登録した全リソースに対して解放関数を呼ぶ（アンマウント時のrevoke相当）', () => {
+		const tracker = createResourceTracker<string>();
+		const released: string[] = [];
+		tracker.track(['a', 'b', 'c']);
+
+		tracker.releaseAll((r) => released.push(r));
+
+		assert.deepEqual(released, ['a', 'b', 'c']);
+	});
+
+	it('track()で差し替えた後は、新しい登録内容のみが解放対象になる', () => {
+		const tracker = createResourceTracker<string>();
+		tracker.track(['old']);
+
+		tracker.track(['new']);
+		const released: string[] = [];
+		tracker.releaseAll((r) => released.push(r));
+
+		assert.deepEqual(released, ['new']);
+	});
+
+	it('releaseAll()にrelease未指定でも例外を投げない', () => {
+		const tracker = createResourceTracker<string>();
+		tracker.track(['a']);
+
+		assert.doesNotThrow(() => tracker.releaseAll());
+	});
+});


### PR DESCRIPTION
## Summary
- `useBatchProcessing` から、処理ライフサイクル管理（runIdによる中断検知・キャンセル伝播・ObjectURL等のリソース解放）を共通プリミティブ `useProcessingLifecycle` として抽出しました（`src/lib/hooks/useProcessingLifecycle.ts`）。
- 状態機械そのもの（`createRunTracker` / `createResourceTracker`）は React に依存しない純粋関数として切り出しており、DOM無しで単体テスト可能です。
- `useBatchProcessing` の内部実装をこのプリミティブベースに置き換えましたが、**公開API・挙動は不変**です（`ImageCompressPage` / `ImageConvertPage` は無改修）。
- 後続の単一結果フック・遅延開始対応（親タスク: バッチ処理パターンの共通フック抽出）の土台となります。

## Test plan
- [x] `tests/unit/use-processing-lifecycle.test.ts` を新規追加し、最低3ケース（キャンセル伝播／runId不一致時の中断／アンマウント時のrevoke呼び出し相当）を含む6テストがグリーン
- [x] リファクタ前に、`ImageCompressPage` / `ImageConvertPage` の処理中キャンセル挙動を固定するE2Eテストを追加（既存テストにはキャンセル系のカバレッジが無かったため補強）
- [x] `npm run test:unit`（529件）オールグリーン
- [x] `npm run check`（Astro型チェック + Biome）エラー無し
- [x] `npm run build` 後、`image-compress.spec.ts` / `image-convert.spec.ts`（新規テスト含む計22件）をPlaywrightで実行しオールグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JP5eeHtMHPmHNXzKKYbrYH


---
_Generated by [Claude Code](https://claude.ai/code/session_01JP5eeHtMHPmHNXzKKYbrYH)_