### PR TITLE
useBatchProcessing移行 第3弾-2: useSingleResultProcessing 新設と pdf-merge / pdf-split / image-merge 移行

### DIFF
--- a/src/components/image-merge/ImageMergePage.tsx
+++ b/src/components/image-merge/ImageMergePage.tsx
@@ -37,7 +37,8 @@ export function ImageMergePage() {
 	} | null>(null);
 	// 画像の読み込み中フラグ（結合結果の生成・ダウンロードは useSingleResultProcessing が管理）
 	const [loadingFiles, setLoadingFiles] = useState(false);
-	const { processing, error, setError, run } = useSingleResultProcessing<Blob>({
+	// 結果（結合画像）はダウンロード後にUIで参照しないため、React状態に保持しない
+	const { processing, error, setError, run } = useSingleResultProcessing<void>({
 		fallbackErrorMessage: '画像の書き出しに失敗しました。',
 	});
 	const busy = loadingFiles || processing;
@@ -197,7 +198,6 @@ export function ImageMergePage() {
 			);
 			const blob = await exportCanvas(merged, options);
 			downloadBlob(blob, buildMergedFilename(options.output));
-			return blob;
 		});
 	}, [items, options, run]);
 

--- a/src/components/image-merge/ImageMergePage.tsx
+++ b/src/components/image-merge/ImageMergePage.tsx
@@ -6,6 +6,7 @@ import { Download, Loader2, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { useSingleResultProcessing } from '@/lib/hooks/useSingleResultProcessing.ts';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
 import {
 	buildMergedFilename,
@@ -30,12 +31,16 @@ type LoadedItem = MergeImageItem & { bitmap: ImageBitmap };
 export function ImageMergePage() {
 	const [items, setItems] = useState<LoadedItem[]>([]);
 	const [options, setOptions] = useState<MergeOptions>(DEFAULT_MERGE_OPTIONS);
-	const [error, setError] = useState<string | null>(null);
 	const [outputSize, setOutputSize] = useState<{
 		width: number;
 		height: number;
 	} | null>(null);
-	const [busy, setBusy] = useState(false);
+	// 画像の読み込み中フラグ（結合結果の生成・ダウンロードは useSingleResultProcessing が管理）
+	const [loadingFiles, setLoadingFiles] = useState(false);
+	const { processing, error, setError, run } = useSingleResultProcessing<Blob>({
+		fallbackErrorMessage: '画像の書き出しに失敗しました。',
+	});
+	const busy = loadingFiles || processing;
 
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const itemsRef = useRef<LoadedItem[]>([]);
@@ -91,55 +96,58 @@ export function ImageMergePage() {
 				err instanceof Error ? err.message : 'プレビューの生成に失敗しました。',
 			);
 		}
-	}, [items, options]);
+	}, [items, options, setError]);
 
-	const handleFilesSelect = useCallback(async (files: File[]) => {
-		const existing = itemsRef.current;
-		const totalCount = existing.length + files.length;
-		const totalSize =
-			existing.reduce((sum, it) => sum + it.file.size, 0) +
-			files.reduce((sum, f) => sum + f.size, 0);
-		const batchCheck = validateBatch(totalCount, totalSize);
-		if (!batchCheck.ok) {
-			setError(batchCheck.message);
-			return;
-		}
-
-		const valid: File[] = [];
-		const errors: string[] = [];
-		for (const file of files) {
-			const v = validateImageFile(file);
-			if (v.ok) valid.push(file);
-			else errors.push(`${file.name}: ${v.message}`);
-		}
-		if (valid.length === 0) {
-			setError(errors.join('\n'));
-			return;
-		}
-
-		setBusy(true);
-		const loaded: LoadedItem[] = [];
-		for (const file of valid) {
-			try {
-				const bitmap = await loadImageBitmap(file);
-				loaded.push({
-					id: createId(),
-					file,
-					previewUrl: URL.createObjectURL(file),
-					width: bitmap.width,
-					height: bitmap.height,
-					bitmap,
-				});
-			} catch {
-				errors.push(`${file.name}: 画像の読み込みに失敗しました。`);
+	const handleFilesSelect = useCallback(
+		async (files: File[]) => {
+			const existing = itemsRef.current;
+			const totalCount = existing.length + files.length;
+			const totalSize =
+				existing.reduce((sum, it) => sum + it.file.size, 0) +
+				files.reduce((sum, f) => sum + f.size, 0);
+			const batchCheck = validateBatch(totalCount, totalSize);
+			if (!batchCheck.ok) {
+				setError(batchCheck.message);
+				return;
 			}
-		}
-		setBusy(false);
-		setError(errors.length > 0 ? errors.join('\n') : null);
-		if (loaded.length > 0) {
-			setItems((prev) => [...prev, ...loaded]);
-		}
-	}, []);
+
+			const valid: File[] = [];
+			const errors: string[] = [];
+			for (const file of files) {
+				const v = validateImageFile(file);
+				if (v.ok) valid.push(file);
+				else errors.push(`${file.name}: ${v.message}`);
+			}
+			if (valid.length === 0) {
+				setError(errors.join('\n'));
+				return;
+			}
+
+			setLoadingFiles(true);
+			const loaded: LoadedItem[] = [];
+			for (const file of valid) {
+				try {
+					const bitmap = await loadImageBitmap(file);
+					loaded.push({
+						id: createId(),
+						file,
+						previewUrl: URL.createObjectURL(file),
+						width: bitmap.width,
+						height: bitmap.height,
+						bitmap,
+					});
+				} catch {
+					errors.push(`${file.name}: 画像の読み込みに失敗しました。`);
+				}
+			}
+			setLoadingFiles(false);
+			setError(errors.length > 0 ? errors.join('\n') : null);
+			if (loaded.length > 0) {
+				setItems((prev) => [...prev, ...loaded]);
+			}
+		},
+		[setError],
+	);
 
 	const handleReorder = useCallback((from: number, to: number) => {
 		setItems((prev) => {
@@ -170,13 +178,13 @@ export function ImageMergePage() {
 		setItems([]);
 		setError(null);
 		setOutputSize(null);
-	}, []);
+	}, [setError]);
 
 	const handleDownload = useCallback(async () => {
 		const canvas = canvasRef.current;
 		if (!canvas || items.length === 0) return;
-		setBusy(true);
-		try {
+
+		await run(1, async () => {
 			const sizes: ImageSize[] = items.map((it) => ({
 				width: it.width,
 				height: it.height,
@@ -189,14 +197,9 @@ export function ImageMergePage() {
 			);
 			const blob = await exportCanvas(merged, options);
 			downloadBlob(blob, buildMergedFilename(options.output));
-		} catch (err) {
-			setError(
-				err instanceof Error ? err.message : '画像の書き出しに失敗しました。',
-			);
-		} finally {
-			setBusy(false);
-		}
-	}, [items, options]);
+			return blob;
+		});
+	}, [items, options, run]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/pdf-merge/PdfMergePage.tsx
+++ b/src/components/pdf-merge/PdfMergePage.tsx
@@ -30,7 +30,7 @@ type MergeResult = {
 
 export function PdfMergePage() {
 	const [items, setItems] = useState<MergeItem[]>([]);
-	const { processing, progress, result, setResult, error, setError, run } =
+	const { processing, progress, result, clearResult, error, setError, run } =
 		useSingleResultProcessing<MergeResult>({
 			fallbackErrorMessage: '結合に失敗しました。',
 		});
@@ -77,7 +77,7 @@ export function PdfMergePage() {
 	const handleFilesSelect = useCallback(
 		async (files: File[]) => {
 			setError(null);
-			setResult(null);
+			clearResult();
 
 			const current = itemsRef.current;
 			const countCheck = validateMergeFileCount(current.length + files.length);
@@ -136,7 +136,7 @@ export function PdfMergePage() {
 				}
 			}
 		},
-		[updateItem, setError, setResult],
+		[updateItem, setError, clearResult],
 	);
 
 	const handleMove = useCallback((id: string, direction: -1 | 1) => {
@@ -162,16 +162,16 @@ export function PdfMergePage() {
 	const handleRemove = useCallback(
 		(id: string) => {
 			setItems((prev) => prev.filter((it) => it.id !== id));
-			setResult(null);
+			clearResult();
 		},
-		[setResult],
+		[clearResult],
 	);
 
 	const handleClear = useCallback(() => {
 		setItems([]);
 		setError(null);
-		setResult(null);
-	}, [setError, setResult]);
+		clearResult();
+	}, [setError, clearResult]);
 
 	const handleMerge = useCallback(async () => {
 		const targets = itemsRef.current.filter((it) => it.status === 'ready');

--- a/src/components/pdf-merge/PdfMergePage.tsx
+++ b/src/components/pdf-merge/PdfMergePage.tsx
@@ -6,6 +6,7 @@ import { Download, FileStack, Loader2, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { useSingleResultProcessing } from '@/lib/hooks/useSingleResultProcessing.ts';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
 import {
 	ENCRYPTED_PDF_MESSAGE,
@@ -29,10 +30,10 @@ type MergeResult = {
 
 export function PdfMergePage() {
 	const [items, setItems] = useState<MergeItem[]>([]);
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [error, setError] = useState<string | null>(null);
-	const [result, setResult] = useState<MergeResult | null>(null);
+	const { processing, progress, result, setResult, error, setError, run } =
+		useSingleResultProcessing<MergeResult>({
+			fallbackErrorMessage: '結合に失敗しました。',
+		});
 	const itemsRef = useRef<MergeItem[]>([]);
 	itemsRef.current = items;
 
@@ -135,7 +136,7 @@ export function PdfMergePage() {
 				}
 			}
 		},
-		[updateItem],
+		[updateItem, setError, setResult],
 	);
 
 	const handleMove = useCallback((id: string, direction: -1 | 1) => {
@@ -158,62 +159,59 @@ export function PdfMergePage() {
 		});
 	}, []);
 
-	const handleRemove = useCallback((id: string) => {
-		setItems((prev) => prev.filter((it) => it.id !== id));
-		setResult(null);
-	}, []);
+	const handleRemove = useCallback(
+		(id: string) => {
+			setItems((prev) => prev.filter((it) => it.id !== id));
+			setResult(null);
+		},
+		[setResult],
+	);
 
 	const handleClear = useCallback(() => {
 		setItems([]);
 		setError(null);
 		setResult(null);
-	}, []);
+	}, [setError, setResult]);
 
 	const handleMerge = useCallback(async () => {
 		const targets = itemsRef.current.filter((it) => it.status === 'ready');
 		if (targets.length === 0) return;
-		setProcessing(true);
-		setError(null);
-		setResult(null);
-		setProgress({ done: 0, total: targets.length });
-		try {
-			// bytes はこのスコープ内のみで保持し、結合完了後に参照を解放する
-			const inputs: MergeInput[] = [];
-			for (const item of targets) {
-				const bytes = new Uint8Array(await item.file.arrayBuffer());
-				inputs.push(
-					item.kind === 'pdf'
-						? { kind: 'pdf', name: item.file.name, bytes }
-						: {
-								kind: 'image',
-								name: item.file.name,
-								bytes,
-								mime: item.mime as 'image/jpeg' | 'image/png',
-							},
+
+		await run(targets.length, async (onProgress) => {
+			try {
+				// bytes はこのスコープ内のみで保持し、結合完了後に参照を解放する
+				const inputs: MergeInput[] = [];
+				for (const item of targets) {
+					const bytes = new Uint8Array(await item.file.arrayBuffer());
+					inputs.push(
+						item.kind === 'pdf'
+							? { kind: 'pdf', name: item.file.name, bytes }
+							: {
+									kind: 'image',
+									name: item.file.name,
+									bytes,
+									mime: item.mime as 'image/jpeg' | 'image/png',
+								},
+					);
+				}
+				const merged = await mergePdfs(inputs, onProgress);
+				inputs.length = 0;
+				const blob = new Blob([merged as Uint8Array<ArrayBuffer>], {
+					type: 'application/pdf',
+				});
+				const pageCount = targets.reduce(
+					(sum, it) => sum + (it.pageCount ?? 1),
+					0,
 				);
+				downloadBlob(blob, 'merged.pdf');
+				return { blob, pageCount };
+			} catch (err) {
+				throw err instanceof Error
+					? new Error(`結合に失敗しました: ${err.message}`)
+					: err;
 			}
-			const merged = await mergePdfs(inputs, (done, total) =>
-				setProgress({ done, total }),
-			);
-			inputs.length = 0;
-			const blob = new Blob([merged as Uint8Array<ArrayBuffer>], {
-				type: 'application/pdf',
-			});
-			const pageCount = itemsRef.current
-				.filter((it) => it.status === 'ready')
-				.reduce((sum, it) => sum + (it.pageCount ?? 1), 0);
-			setResult({ blob, pageCount });
-			downloadBlob(blob, 'merged.pdf');
-		} catch (err) {
-			setError(
-				err instanceof Error
-					? `結合に失敗しました: ${err.message}`
-					: '結合に失敗しました。',
-			);
-		} finally {
-			setProcessing(false);
-		}
-	}, []);
+		});
+	}, [run]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/pdf-split/PdfSplitPage.tsx
+++ b/src/components/pdf-split/PdfSplitPage.tsx
@@ -42,7 +42,7 @@ export function PdfSplitPage() {
 	const [mode, setMode] = useState<SplitMode>('range');
 	const [rangeInput, setRangeInput] = useState('');
 	const [extractInput, setExtractInput] = useState('');
-	const { processing, progress, result, setResult, error, setError, run } =
+	const { processing, progress, result, clearResult, error, setError, run } =
 		useSingleResultProcessing<SplitResult>({
 			fallbackErrorMessage: '処理に失敗しました。',
 		});
@@ -82,8 +82,8 @@ export function PdfSplitPage() {
 		(mode === 'single' || currentParse?.ok === true);
 
 	const resetOutputs = useCallback(() => {
-		setResult(null);
-	}, [setResult]);
+		clearResult();
+	}, [clearResult]);
 
 	const handleFileSelect = useCallback(
 		async (selected: File) => {
@@ -170,20 +170,40 @@ export function PdfSplitPage() {
 					downloadBlob(files[0].blob, files[0].fileName);
 					return { outputs: files, zipBlob: null, zipName: '' };
 				}
-				const names = dedupeZipNames(files.map((f) => f.fileName));
-				const zip = await buildZip(
-					files.map((f, i) => ({ name: names[i], data: f.blob })),
-				);
-				const zipName = `${baseName}_split.zip`;
-				downloadBlob(zip, zipName);
-				return { outputs: files, zipBlob: zip, zipName };
+
+				try {
+					const names = dedupeZipNames(files.map((f) => f.fileName));
+					const zip = await buildZip(
+						files.map((f, i) => ({ name: names[i], data: f.blob })),
+					);
+					const zipName = `${baseName}_split.zip`;
+					downloadBlob(zip, zipName);
+					return { outputs: files, zipBlob: zip, zipName };
+				} catch (zipErr) {
+					// ZIP化に失敗しても分割済みファイル自体は個別ダウンロード可能な状態で残す
+					setError(
+						zipErr instanceof Error
+							? `ZIP作成に失敗しました: ${zipErr.message}`
+							: 'ZIP作成に失敗しました。',
+					);
+					return { outputs: files, zipBlob: null, zipName: '' };
+				}
 			} catch (err) {
 				throw err instanceof Error
 					? new Error(`処理に失敗しました: ${err.message}`)
 					: err;
 			}
 		});
-	}, [file, pageCount, mode, rangeInput, extractInput, baseName, run]);
+	}, [
+		file,
+		pageCount,
+		mode,
+		rangeInput,
+		extractInput,
+		baseName,
+		run,
+		setError,
+	]);
 
 	const runLabel =
 		mode === 'range'

--- a/src/components/pdf-split/PdfSplitPage.tsx
+++ b/src/components/pdf-split/PdfSplitPage.tsx
@@ -8,6 +8,7 @@ import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useSingleResultProcessing } from '@/lib/hooks/useSingleResultProcessing.ts';
 import { downloadBlob } from '@/lib/tools/image-common';
 import {
 	ENCRYPTED_PDF_MESSAGE,
@@ -28,6 +29,12 @@ type OutputFile = {
 	pageNumbers: number[];
 };
 
+type SplitResult = {
+	outputs: OutputFile[];
+	zipBlob: Blob | null;
+	zipName: string;
+};
+
 export function PdfSplitPage() {
 	const [file, setFile] = useState<File | null>(null);
 	const [pageCount, setPageCount] = useState(0);
@@ -35,12 +42,13 @@ export function PdfSplitPage() {
 	const [mode, setMode] = useState<SplitMode>('range');
 	const [rangeInput, setRangeInput] = useState('');
 	const [extractInput, setExtractInput] = useState('');
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [error, setError] = useState<string | null>(null);
-	const [outputs, setOutputs] = useState<OutputFile[]>([]);
-	const [zipBlob, setZipBlob] = useState<Blob | null>(null);
-	const [zipName, setZipName] = useState('');
+	const { processing, progress, result, setResult, error, setError, run } =
+		useSingleResultProcessing<SplitResult>({
+			fallbackErrorMessage: '処理に失敗しました。',
+		});
+	const outputs = result?.outputs ?? [];
+	const zipBlob = result?.zipBlob ?? null;
+	const zipName = result?.zipName ?? '';
 	// 読み込み中に別ファイルが選択された場合、古い loadPdfInfo の結果で
 	// 新しい選択を上書きしないためのリクエストトークン
 	const loadIdRef = useRef(0);
@@ -74,10 +82,8 @@ export function PdfSplitPage() {
 		(mode === 'single' || currentParse?.ok === true);
 
 	const resetOutputs = useCallback(() => {
-		setOutputs([]);
-		setZipBlob(null);
-		setZipName('');
-	}, []);
+		setResult(null);
+	}, [setResult]);
 
 	const handleFileSelect = useCallback(
 		async (selected: File) => {
@@ -117,7 +123,7 @@ export function PdfSplitPage() {
 				if (loadId === loadIdRef.current) setLoading(false);
 			}
 		},
-		[resetOutputs],
+		[resetOutputs, setError],
 	);
 
 	const handleClear = useCallback(() => {
@@ -129,7 +135,7 @@ export function PdfSplitPage() {
 		setRangeInput('');
 		setExtractInput('');
 		resetOutputs();
-	}, [resetOutputs]);
+	}, [resetOutputs, setError]);
 
 	const handleRun = useCallback(async () => {
 		if (!file || pageCount === 0) return;
@@ -147,47 +153,37 @@ export function PdfSplitPage() {
 			ranges = mode === 'extract' ? [parsed.ranges.flat()] : parsed.ranges;
 		}
 
-		setProcessing(true);
-		setError(null);
-		resetOutputs();
-		setProgress({ done: 0, total: ranges.length });
-		try {
-			// bytes はこのスコープ内のみで保持し、処理完了後に参照を解放する
-			const bytes = new Uint8Array(await file.arrayBuffer());
-			const results = await splitPdf(bytes, ranges, baseName, (done, total) =>
-				setProgress({ done, total }),
-			);
-			const files: OutputFile[] = results.map((r) => ({
-				blob: new Blob([r.bytes as Uint8Array<ArrayBuffer>], {
-					type: 'application/pdf',
-				}),
-				fileName: r.fileName,
-				pageNumbers: r.pageNumbers,
-			}));
-			setOutputs(files);
+		await run(ranges.length, async (onProgress) => {
+			try {
+				// bytes はこのスコープ内のみで保持し、処理完了後に参照を解放する
+				const bytes = new Uint8Array(await file.arrayBuffer());
+				const results = await splitPdf(bytes, ranges, baseName, onProgress);
+				const files: OutputFile[] = results.map((r) => ({
+					blob: new Blob([r.bytes as Uint8Array<ArrayBuffer>], {
+						type: 'application/pdf',
+					}),
+					fileName: r.fileName,
+					pageNumbers: r.pageNumbers,
+				}));
 
-			if (files.length === 1) {
-				downloadBlob(files[0].blob, files[0].fileName);
-			} else {
+				if (files.length === 1) {
+					downloadBlob(files[0].blob, files[0].fileName);
+					return { outputs: files, zipBlob: null, zipName: '' };
+				}
 				const names = dedupeZipNames(files.map((f) => f.fileName));
 				const zip = await buildZip(
 					files.map((f, i) => ({ name: names[i], data: f.blob })),
 				);
-				const name = `${baseName}_split.zip`;
-				setZipBlob(zip);
-				setZipName(name);
-				downloadBlob(zip, name);
+				const zipName = `${baseName}_split.zip`;
+				downloadBlob(zip, zipName);
+				return { outputs: files, zipBlob: zip, zipName };
+			} catch (err) {
+				throw err instanceof Error
+					? new Error(`処理に失敗しました: ${err.message}`)
+					: err;
 			}
-		} catch (err) {
-			setError(
-				err instanceof Error
-					? `処理に失敗しました: ${err.message}`
-					: '処理に失敗しました。',
-			);
-		} finally {
-			setProcessing(false);
-		}
-	}, [file, pageCount, mode, rangeInput, extractInput, baseName, resetOutputs]);
+		});
+	}, [file, pageCount, mode, rangeInput, extractInput, baseName, run]);
 
 	const runLabel =
 		mode === 'range'

--- a/src/lib/hooks/useSingleResultProcessing.ts
+++ b/src/lib/hooks/useSingleResultProcessing.ts
@@ -1,0 +1,142 @@
+// useSingleResultProcessing — 「N入力→単一（一括）出力」パターンの共通フック
+// 進捗表示・キャンセル・中断検知（runId）・結果リソース（ObjectURL等）の解放という
+// 単一結果系ページ（PdfMergePage / PdfSplitPage / ImageMergePage 等）共通の
+// 状態機械を一元管理する。ランのライフサイクル管理は useProcessingLifecycle に委譲している。
+
+import { useCallback, useState } from 'react';
+import { useProcessingLifecycle } from './useProcessingLifecycle.ts';
+
+export type SingleResultProgress = { done: number; total: number };
+
+/** runSingleResult が要求するラン管理の最小インターフェース（React非依存） */
+export type SingleResultRunner = {
+	beginRun: () => number;
+	isCurrent: (runId: number) => boolean;
+};
+
+export type SingleResultProcessor<TResult> = (
+	onProgress: (done: number, total: number) => void,
+) => Promise<TResult>;
+
+export type SingleResultHandlers<TResult> = {
+	onProgress: (progress: SingleResultProgress) => void;
+	/** ラン継続中に完了した場合のみ呼ばれる */
+	onSuccess: (result: TResult) => void;
+	/** 中断後（cancel／新しいランの開始）に処理が完了した場合、結果を解放するために呼ばれる */
+	onStaleResult: (result: TResult) => void;
+	/** ラン継続中に失敗した場合のみ呼ばれる */
+	onError: (message: string) => void;
+	/** ラン継続中に成功・失敗いずれかで完了した場合に呼ばれる（中断時は呼ばれない） */
+	onSettled: () => void;
+};
+
+/**
+ * 1ランの進捗コールバック中継・中断検知・中断後に届いた結果の解放を担う（React非依存）。
+ * processor は onProgress を呼びながら処理を行い、完了時に単一の結果を返す。
+ */
+export async function runSingleResult<TResult>(
+	runner: SingleResultRunner,
+	processor: SingleResultProcessor<TResult>,
+	handlers: SingleResultHandlers<TResult>,
+	fallbackErrorMessage: string,
+): Promise<void> {
+	const runId = runner.beginRun();
+	try {
+		const result = await processor((done, total) => {
+			if (runner.isCurrent(runId)) handlers.onProgress({ done, total });
+		});
+		if (!runner.isCurrent(runId)) {
+			handlers.onStaleResult(result);
+			return;
+		}
+		handlers.onSuccess(result);
+	} catch (err) {
+		if (!runner.isCurrent(runId)) return;
+		handlers.onError(err instanceof Error ? err.message : fallbackErrorMessage);
+	} finally {
+		if (runner.isCurrent(runId)) handlers.onSettled();
+	}
+}
+
+export type UseSingleResultProcessingOptions<TResult> = {
+	/** 処理失敗時に設定する既定エラーメッセージ */
+	fallbackErrorMessage: string;
+	/** 結果が保持するリソース（ObjectURL等）を解放する。差し替え・クリア・アンマウント・中断時に呼ばれる */
+	releaseResult?: (result: TResult) => void;
+	/** 1ラン正常完了時に呼ばれる（キャンセル・中断時は呼ばれない） */
+	onRunComplete?: () => void;
+};
+
+export function useSingleResultProcessing<TResult>(
+	options: UseSingleResultProcessingOptions<TResult>,
+) {
+	const { fallbackErrorMessage, releaseResult, onRunComplete } = options;
+
+	const [processing, setProcessing] = useState(false);
+	const [progress, setProgress] = useState<SingleResultProgress>({
+		done: 0,
+		total: 0,
+	});
+	const [result, setResult] = useState<TResult | null>(null);
+	const [error, setError] = useState<string | null>(null);
+
+	// runIdによる中断検知・キャンセル伝播・アンマウント時のリソース解放
+	const lifecycle = useProcessingLifecycle<TResult>({ release: releaseResult });
+
+	/** total を初期進捗として、processor を1ラン実行する */
+	const run = useCallback(
+		(total: number, processor: SingleResultProcessor<TResult>) => {
+			lifecycle.releaseAll();
+			setError(null);
+			setResult(null);
+			setProcessing(true);
+			setProgress({ done: 0, total });
+
+			return runSingleResult(
+				lifecycle,
+				processor,
+				{
+					onProgress: setProgress,
+					onSuccess: (res) => {
+						lifecycle.track([res]);
+						setResult(res);
+						onRunComplete?.();
+					},
+					onStaleResult: (res) => releaseResult?.(res),
+					onError: setError,
+					onSettled: () => setProcessing(false),
+				},
+				fallbackErrorMessage,
+			);
+		},
+		[lifecycle, fallbackErrorMessage, releaseResult, onRunComplete],
+	);
+
+	/** 進行中の処理を中断する */
+	const cancel = useCallback(() => {
+		lifecycle.cancel();
+		setProcessing(false);
+	}, [lifecycle]);
+
+	/** 結果・エラーを破棄して初期状態に戻す */
+	const clear = useCallback(() => {
+		lifecycle.cancel();
+		lifecycle.releaseAll();
+		setResult(null);
+		setError(null);
+		setProcessing(false);
+		setProgress({ done: 0, total: 0 });
+	}, [lifecycle]);
+
+	return {
+		processing,
+		progress,
+		result,
+		setResult,
+		error,
+		setError,
+		run,
+		cancel,
+		clear,
+	};
+}

--- a/src/lib/hooks/useSingleResultProcessing.ts
+++ b/src/lib/hooks/useSingleResultProcessing.ts
@@ -87,6 +87,7 @@ export function useSingleResultProcessing<TResult>(
 	const run = useCallback(
 		(total: number, processor: SingleResultProcessor<TResult>) => {
 			lifecycle.releaseAll();
+			lifecycle.track([]);
 			setError(null);
 			setResult(null);
 			setProcessing(true);
@@ -118,21 +119,27 @@ export function useSingleResultProcessing<TResult>(
 		setProcessing(false);
 	}, [lifecycle]);
 
+	/** 表示中の結果を解放して非表示にする（トラッカーにも反映するため、次ランや unmount 時に二重解放しない） */
+	const clearResult = useCallback(() => {
+		lifecycle.releaseAll();
+		lifecycle.track([]);
+		setResult(null);
+	}, [lifecycle]);
+
 	/** 結果・エラーを破棄して初期状態に戻す */
 	const clear = useCallback(() => {
 		lifecycle.cancel();
-		lifecycle.releaseAll();
-		setResult(null);
+		clearResult();
 		setError(null);
 		setProcessing(false);
 		setProgress({ done: 0, total: 0 });
-	}, [lifecycle]);
+	}, [lifecycle, clearResult]);
 
 	return {
 		processing,
 		progress,
 		result,
-		setResult,
+		clearResult,
 		error,
 		setError,
 		run,

--- a/tests/unit/use-single-result-processing.test.ts
+++ b/tests/unit/use-single-result-processing.test.ts
@@ -1,0 +1,201 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	createResourceTracker,
+	createRunTracker,
+} from '../../src/lib/hooks/useProcessingLifecycle.ts';
+import { runSingleResult } from '../../src/lib/hooks/useSingleResultProcessing.ts';
+
+/** テスト内で processor の完了タイミングを外部から制御するためのヘルパー */
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	let reject!: (err: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
+}
+
+describe('runSingleResult', () => {
+	it('processor から呼ばれた進捗コールバックがそのまま onProgress に反映される', async () => {
+		const runner = createRunTracker();
+		const progress: { done: number; total: number }[] = [];
+
+		await runSingleResult(
+			runner,
+			async (onProgress) => {
+				onProgress(1, 3);
+				onProgress(2, 3);
+				onProgress(3, 3);
+				return 'result';
+			},
+			{
+				onProgress: (p) => progress.push(p),
+				onSuccess: () => {},
+				onStaleResult: () => {},
+				onError: () => {},
+				onSettled: () => {},
+			},
+			'失敗しました',
+		);
+
+		assert.deepEqual(progress, [
+			{ done: 1, total: 3 },
+			{ done: 2, total: 3 },
+			{ done: 3, total: 3 },
+		]);
+	});
+
+	it('キャンセル後に処理が完了した場合、onSuccess ではなく onStaleResult が呼ばれる（結果は解放対象）', async () => {
+		const runner = createRunTracker();
+		const success: string[] = [];
+		const stale: string[] = [];
+		let settledCalled = false;
+		const { promise, resolve } = deferred<string>();
+
+		const run = runSingleResult(
+			runner,
+			async () => promise,
+			{
+				onProgress: () => {},
+				onSuccess: (r) => success.push(r),
+				onStaleResult: (r) => stale.push(r),
+				onError: () => {},
+				onSettled: () => {
+					settledCalled = true;
+				},
+			},
+			'失敗しました',
+		);
+
+		runner.cancel();
+		resolve('blob-url-result');
+		await run;
+
+		assert.deepEqual(success, []);
+		assert.deepEqual(stale, ['blob-url-result']);
+		assert.equal(settledCalled, false);
+	});
+
+	it('processor完了前に新しいランが開始された場合（runId不一致）、古いランの結果は onStaleResult に渡される', async () => {
+		const runner = createRunTracker();
+		const success: string[] = [];
+		const stale: string[] = [];
+		const { promise, resolve } = deferred<string>();
+
+		const oldRun = runSingleResult(
+			runner,
+			async () => promise,
+			{
+				onProgress: () => {},
+				onSuccess: (r) => success.push(r),
+				onStaleResult: (r) => stale.push(r),
+				onError: () => {},
+				onSettled: () => {},
+			},
+			'失敗しました',
+		);
+
+		// 古いランが完了するより先に、新しいランを開始して中断させる
+		runner.beginRun();
+		resolve('old-run-result');
+		await oldRun;
+
+		assert.deepEqual(success, []);
+		assert.deepEqual(stale, ['old-run-result']);
+	});
+
+	it('中断された結果がObjectURLを保持している場合、releaseで確実にrevokeされる', async () => {
+		const runner = createRunTracker();
+		const resourceTracker = createResourceTracker<{ url: string }>();
+		const revoked: string[] = [];
+		const release = (r: { url: string }) => revoked.push(r.url);
+		const { promise, resolve } = deferred<{ url: string }>();
+
+		const run = runSingleResult(
+			runner,
+			async () => promise,
+			{
+				onProgress: () => {},
+				onSuccess: (r) => resourceTracker.track([r]),
+				onStaleResult: (r) => release(r),
+				onError: () => {},
+				onSettled: () => {},
+			},
+			'失敗しました',
+		);
+
+		runner.cancel();
+		resolve({ url: 'blob:stale-result' });
+		await run;
+
+		assert.deepEqual(revoked, ['blob:stale-result']);
+
+		// 通常完了時は resourceTracker に追跡させ、次ランの releaseAll で解放される
+		const runner2 = createRunTracker();
+		await runSingleResult(
+			runner2,
+			async () => ({ url: 'blob:kept-result' }),
+			{
+				onProgress: () => {},
+				onSuccess: (r) => resourceTracker.track([r]),
+				onStaleResult: () => {},
+				onError: () => {},
+				onSettled: () => {},
+			},
+			'失敗しました',
+		);
+		resourceTracker.releaseAll(release);
+
+		assert.deepEqual(revoked, ['blob:stale-result', 'blob:kept-result']);
+	});
+
+	it('processorが失敗した場合、ラン継続中であればonErrorにメッセージが渡りonSettledが呼ばれる', async () => {
+		const runner = createRunTracker();
+		const errors: string[] = [];
+		let settledCalled = false;
+
+		await runSingleResult(
+			runner,
+			async () => {
+				throw new Error('boom');
+			},
+			{
+				onProgress: () => {},
+				onSuccess: () => {},
+				onStaleResult: () => {},
+				onError: (message) => errors.push(message),
+				onSettled: () => {
+					settledCalled = true;
+				},
+			},
+			'失敗しました',
+		);
+
+		assert.deepEqual(errors, ['boom']);
+		assert.equal(settledCalled, true);
+	});
+
+	it('Errorインスタンスでない例外の場合はfallbackErrorMessageが使われる', async () => {
+		const runner = createRunTracker();
+		const errors: string[] = [];
+
+		await runSingleResult(
+			runner,
+			async () => {
+				throw 'not-an-error';
+			},
+			{
+				onProgress: () => {},
+				onSuccess: () => {},
+				onStaleResult: () => {},
+				onError: (message) => errors.push(message),
+				onSettled: () => {},
+			},
+			'失敗しました',
+		);
+
+		assert.deepEqual(errors, ['失敗しました']);
+	});
+});


### PR DESCRIPTION
## Summary
- 「N入力→単一（一括）出力」パターン用の薄いフック `useSingleResultProcessing` を `useProcessingLifecycle` の上に新設。進捗コールバック中継・キャンセル・runId中断検知・中断後結果の解放を担う純粋関数 `runSingleResult` を切り出し、DOM無しで単体テストできるようにした
- `PdfMergePage` / `PdfSplitPage` / `ImageMergePage` を新フックへ移行（各1コミット）
- 既存の `useBatchProcessing` 利用ページ（image-compress / image-convert）への影響がないことをE2Eで確認

## Test plan
- [x] `npm run test:unit`（535件全パス）
- [x] `npm run check`（Astro型チェック + Biome、0 errors）
- [x] `npm run build`
- [x] E2E: `pdf-merge.spec.ts` / `pdf-split.spec.ts` / `image-merge.spec.ts` 全パス
- [x] E2E回帰確認: `image-compress.spec.ts` / `image-convert.spec.ts` 全パス
- [x] E2E全件実行（chromium）: 345/346 パス。唯一の失敗（`upscale.spec.ts`）は本PRで変更していないツールで、単独実行でも同様にタイムアウトする環境固有の既知フレークであり、本変更とは無関係

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bha78Uowr4EHBEUWqVeuih

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bha78Uowr4EHBEUWqVeuih)_