### PR TITLE
useBatchProcessing移行 第4弾: image-edit / image-metadata / exif の2段階フロー対応

### DIFF
--- a/src/components/exif/ExifToolPage.tsx
+++ b/src/components/exif/ExifToolPage.tsx
@@ -114,7 +114,9 @@ export function ExifToolPage() {
 		fallbackErrorMessage: 'メタデータの削除に失敗しました。',
 		releaseItem: releaseExifItem,
 		onRunComplete: () => {
-			void downloadResults(resultsRef.current);
+			const results = resultsRef.current;
+			resultsRef.current = [];
+			void downloadResults(results);
 		},
 	});
 
@@ -196,6 +198,7 @@ export function ExifToolPage() {
 
 	const handleClear = useCallback(() => {
 		clearBatch();
+		resultsRef.current = [];
 		setBakeOri(false);
 	}, [clearBatch]);
 

--- a/src/components/exif/ExifToolPage.tsx
+++ b/src/components/exif/ExifToolPage.tsx
@@ -13,11 +13,12 @@ import {
 	ShieldAlert,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
+import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import {
 	bakeOrientation,
 	type ExifData,
@@ -35,16 +36,25 @@ const MAX_DISPLAY_FILES = 30;
 
 type ExifItem = {
 	id: string;
+	status: 'pending' | 'done' | 'error';
+	error?: string;
 	file: File;
 	previewUrl: string;
 	format: 'jpeg' | 'tiff' | 'webp';
 	exif: ExifData;
-	status: 'ready' | 'stripping' | 'done' | 'error';
 	strippedBlob?: Blob;
 	strippedFileName?: string;
 	warnings?: string[];
-	error?: string;
 };
+
+type StrippedResult = {
+	blob: Blob;
+	fileName: string;
+};
+
+function releaseExifItem(item: ExifItem): void {
+	URL.revokeObjectURL(item.previewUrl);
+}
 
 function groupTags(tags: ExifTag[]): Record<ExifTag['group'], ExifTag[]> {
 	const groups: Record<ExifTag['group'], ExifTag[]> = {
@@ -74,153 +84,124 @@ function buildCleanedFileName(original: string): string {
 	return `${original.slice(0, dot)}_cleaned${original.slice(dot)}`;
 }
 
-export function ExifToolPage() {
-	const [items, setItems] = useState<ExifItem[]>([]);
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [error, setError] = useState<string | null>(null);
-	const [bakeOri, setBakeOri] = useState(false);
-	const itemsRef = useRef<ExifItem[]>([]);
-	itemsRef.current = items;
+async function downloadResults(results: StrippedResult[]): Promise<void> {
+	if (results.length === 1) {
+		downloadBlob(results[0].blob, results[0].fileName);
+	} else if (results.length >= 2) {
+		const names = dedupeZipNames(results.map((r) => r.fileName));
+		const zip = await buildZip(
+			results.map((r, i) => ({ name: names[i], data: r.blob })),
+		);
+		downloadBlob(zip, 'cleaned.zip');
+	}
+}
 
-	useEffect(() => {
-		return () => {
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-			}
-		};
-	}, []);
+export function ExifToolPage() {
+	const [bakeOri, setBakeOri] = useState(false);
+	// 実行中に生成された結果を直接蓄積する（itemsのstate反映を待たずに完了時点でダウンロードするため）
+	const resultsRef = useRef<StrippedResult[]>([]);
+
+	const {
+		items,
+		processing,
+		progress,
+		error,
+		setError,
+		hold,
+		startHeld,
+		clear: clearBatch,
+	} = useBatchProcessing<ExifItem>({
+		fallbackErrorMessage: 'メタデータの削除に失敗しました。',
+		releaseItem: releaseExifItem,
+		onRunComplete: () => {
+			void downloadResults(resultsRef.current);
+		},
+	});
 
 	const hasNonTrivialOrientation = items.some(
 		(it) => it.exif.orientation != null && it.exif.orientation !== 1,
 	);
 	const hasAnyGps = items.some((it) => it.exif.hasGps);
 
-	const handleFilesSelect = useCallback(async (files: File[]) => {
-		const batch = validateBatch(files);
-		if (!batch.ok) {
-			setError(batch.message);
-			return;
-		}
-		const checks = await Promise.all(
-			files.map(async (file) => ({
-				file,
-				v: await validateImageFile(file),
-			})),
-		);
-		const valid: { file: File; format: ExifItem['format'] }[] = [];
-		const errors: string[] = [];
-		for (const { file, v } of checks) {
-			if (v.ok) valid.push({ file, format: v.format });
-			else errors.push(v.message);
-		}
-		setError(errors.length > 0 ? errors.join('\n') : null);
-		if (valid.length === 0) return;
-
-		for (const it of itemsRef.current) {
-			URL.revokeObjectURL(it.previewUrl);
-		}
-
-		const next: ExifItem[] = await Promise.all(
-			valid.map(async ({ file, format }) => {
-				const bytes = new Uint8Array(await file.arrayBuffer());
-				const exif = parseExif(bytes);
-				return {
-					id: createId(),
-					file,
-					previewUrl: URL.createObjectURL(file),
-					format,
-					exif,
-					status: 'ready' as const,
-				};
-			}),
-		);
-		setItems(next);
-	}, []);
-
-	const handleStripAll = useCallback(async () => {
-		setProcessing(true);
-		setProgress({ done: 0, total: items.length });
-		const updated = [...items];
-
-		for (let i = 0; i < updated.length; i++) {
-			const item = updated[i];
-			try {
-				updated[i] = { ...item, status: 'stripping' };
-				setItems([...updated]);
-
-				let bytes = new Uint8Array(await item.file.arrayBuffer());
-
-				if (
-					bakeOri &&
-					item.exif.orientation != null &&
-					item.exif.orientation !== 1
-				) {
-					bytes = await bakeOrientation(bytes, item.exif.orientation);
-				}
-
-				const result = stripMetadata(bytes, item.format);
-				const blob = new Blob([result.data.slice()], {
-					type: `image/${item.format}`,
-				});
-
-				updated[i] = {
-					...item,
-					status: 'done',
-					strippedBlob: blob,
-					strippedFileName: buildCleanedFileName(item.file.name),
-					warnings: result.warnings,
-				};
-			} catch (err) {
-				updated[i] = {
-					...item,
-					status: 'error',
-					error:
-						err instanceof Error
-							? err.message
-							: 'メタデータの削除に失敗しました。',
-				};
+	const handleFilesSelect = useCallback(
+		async (files: File[]) => {
+			const batch = validateBatch(files);
+			if (!batch.ok) {
+				setError(batch.message);
+				return;
 			}
-			setItems([...updated]);
-			setProgress({ done: i + 1, total: updated.length });
-			await new Promise((resolve) => setTimeout(resolve, 0));
-		}
-
-		setProcessing(false);
-
-		const doneItems = updated.filter(
-			(it) => it.status === 'done' && it.strippedBlob,
-		);
-		if (doneItems.length === 1 && doneItems[0].strippedBlob) {
-			downloadBlob(
-				doneItems[0].strippedBlob,
-				doneItems[0].strippedFileName ?? 'cleaned.jpg',
-			);
-		} else if (doneItems.length >= 2) {
-			const names = dedupeZipNames(
-				doneItems.map((it) => it.strippedFileName ?? 'cleaned.jpg'),
-			);
-			const zip = await buildZip(
-				doneItems.map((it, i) => ({
-					name: names[i],
-					data: it.strippedBlob as Blob,
+			const checks = await Promise.all(
+				files.map(async (file) => ({
+					file,
+					v: await validateImageFile(file),
 				})),
 			);
-			downloadBlob(zip, 'cleaned.zip');
-		}
-	}, [items, bakeOri]);
+			const valid: { file: File; format: ExifItem['format'] }[] = [];
+			const errors: string[] = [];
+			for (const { file, v } of checks) {
+				if (v.ok) valid.push({ file, format: v.format });
+				else errors.push(v.message);
+			}
+			setError(errors.length > 0 ? errors.join('\n') : null);
+			if (valid.length === 0) return;
+
+			const next: ExifItem[] = await Promise.all(
+				valid.map(async ({ file, format }) => {
+					const bytes = new Uint8Array(await file.arrayBuffer());
+					const exif = parseExif(bytes);
+					return {
+						id: createId(),
+						status: 'pending' as const,
+						file,
+						previewUrl: URL.createObjectURL(file),
+						format,
+						exif,
+					};
+				}),
+			);
+			// ここでは保持のみ行い、実処理（メタデータ削除）は「メタデータを削除」ボタン押下まで開始しない
+			hold(next);
+		},
+		[hold, setError],
+	);
+
+	const handleStripAll = useCallback(() => {
+		resultsRef.current = [];
+		startHeld(async (item) => {
+			let bytes = new Uint8Array(await item.file.arrayBuffer());
+
+			if (
+				bakeOri &&
+				item.exif.orientation != null &&
+				item.exif.orientation !== 1
+			) {
+				bytes = await bakeOrientation(bytes, item.exif.orientation);
+			}
+
+			const result = stripMetadata(bytes, item.format);
+			const blob = new Blob([result.data.slice()], {
+				type: `image/${item.format}`,
+			});
+			const strippedFileName = buildCleanedFileName(item.file.name);
+
+			resultsRef.current.push({ blob, fileName: strippedFileName });
+
+			return {
+				strippedBlob: blob,
+				strippedFileName,
+				warnings: result.warnings,
+			};
+		});
+	}, [startHeld, bakeOri]);
 
 	const handleClear = useCallback(() => {
-		for (const it of itemsRef.current) {
-			URL.revokeObjectURL(it.previewUrl);
-		}
-		setItems([]);
-		setError(null);
-		setProcessing(false);
-		setProgress({ done: 0, total: 0 });
-	}, []);
+		clearBatch();
+		setBakeOri(false);
+	}, [clearBatch]);
 
 	const doneCount = items.filter((it) => it.status === 'done').length;
+	// 逐次処理は items の並び順どおりに進むため、進捗インデックスの位置にあるアイテムが処理中とみなせる
+	const strippingId = processing ? items[progress.done]?.id : undefined;
 
 	return (
 		<div className="space-y-6">
@@ -301,7 +282,7 @@ export function ExifToolPage() {
 							<Button
 								variant="outline"
 								onClick={async () => {
-									const done = itemsRef.current.filter(
+									const done = items.filter(
 										(it) => it.status === 'done' && it.strippedBlob,
 									);
 									const names = dedupeZipNames(
@@ -385,6 +366,7 @@ export function ExifToolPage() {
 							<ExifCard
 								key={item.id}
 								item={item}
+								isStripping={item.id === strippingId}
 								onDownload={() => {
 									if (item.strippedBlob) {
 										downloadBlob(
@@ -408,9 +390,11 @@ export function ExifToolPage() {
 
 function ExifCard({
 	item,
+	isStripping,
 	onDownload,
 }: {
 	item: ExifItem;
+	isStripping: boolean;
 	onDownload: () => void;
 }) {
 	const { exif } = item;
@@ -465,6 +449,10 @@ function ExifCard({
 							</Badge>
 						)}
 					</div>
+
+					{isStripping && (
+						<p className="mt-2 text-xs text-primary">処理中...</p>
+					)}
 
 					{/* 処理完了時のDLボタン */}
 					{item.status === 'done' && item.strippedBlob && (

--- a/src/components/image-edit/ImageEditPage.tsx
+++ b/src/components/image-edit/ImageEditPage.tsx
@@ -2,9 +2,10 @@
 // FileDropzone で受け取り → CropOverlay + EditToolbar で操作 → EditPreview で確認 → DL/ZIP
 
 import { CheckCircle2, Download, Loader2, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { createId } from '@/lib/tools/image-common';
 import {
 	applyEdit,
@@ -32,41 +33,51 @@ const ACCEPT = 'image/jpeg,image/png,image/webp';
 
 type EditItem = {
 	id: string;
+	status: 'pending' | 'done' | 'error';
+	error?: string;
 	file: File;
 	previewUrl: string;
 	bitmap: ImageBitmap | null;
 };
 
-type CompletionNotice = {
-	done: number;
-	failed: number;
-	total: number;
-};
+function releaseEditItem(item: EditItem): void {
+	URL.revokeObjectURL(item.previewUrl);
+	item.bitmap?.close();
+}
 
 export default function ImageEditPage() {
-	const [items, setItems] = useState<EditItem[]>([]);
 	const [editOps, setEditOps] = useState<EditOps>(DEFAULT_EDIT_OPS);
 	const [aspectPreset, setAspectPreset] = useState<AspectPreset>('free');
 	const [crop, setCrop] = useState<CropRect | null>(null);
-	const [processing, setProcessing] = useState(false);
-	const [progress, setProgress] = useState({ done: 0, total: 0 });
-	const [completion, setCompletion] = useState<CompletionNotice | null>(null);
-	const [error, setError] = useState<string | null>(null);
-	const itemsRef = useRef<EditItem[]>([]);
-	itemsRef.current = items;
+	// 実行中に生成された結果を直接蓄積する（itemsのstate反映を待たずに完了時点でダウンロードするため）
+	const resultsRef = useRef<EditResult[]>([]);
+
+	const {
+		items,
+		processing,
+		progress,
+		completion,
+		error,
+		setError,
+		hold,
+		startHeld,
+		clear: clearBatch,
+	} = useBatchProcessing<EditItem>({
+		fallbackErrorMessage: '処理に失敗しました',
+		releaseItem: releaseEditItem,
+		onRunComplete: () => {
+			const results = resultsRef.current;
+			if (results.length === 1) {
+				downloadEditedFile(results[0]);
+			} else if (results.length > 1) {
+				void downloadEditedZip(results);
+			}
+		},
+	});
 
 	const isBatch = items.length > 1;
 	const singleItem = items.length === 1 ? items[0] : null;
 	const singleBitmap = singleItem?.bitmap ?? null;
-
-	useEffect(() => {
-		return () => {
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				it.bitmap?.close();
-			}
-		};
-	}, []);
 
 	const initCrop = useCallback((bitmap: ImageBitmap, preset: AspectPreset) => {
 		const ratio = aspectPresetToRatio(preset);
@@ -99,13 +110,7 @@ export default function ImageEditPage() {
 				else errors.push(`${file.name}: ${v.message}`);
 			}
 			setError(errors.length > 0 ? errors.join('\n') : null);
-			setCompletion(null);
 			if (valid.length === 0) return;
-
-			for (const it of itemsRef.current) {
-				URL.revokeObjectURL(it.previewUrl);
-				it.bitmap?.close();
-			}
 
 			const next: EditItem[] = [];
 			for (const file of valid) {
@@ -117,6 +122,7 @@ export default function ImageEditPage() {
 				}
 				next.push({
 					id: createId(),
+					status: 'pending',
 					file,
 					previewUrl: URL.createObjectURL(file),
 					bitmap,
@@ -125,7 +131,8 @@ export default function ImageEditPage() {
 			if (errors.length > 0) {
 				setError(errors.join('\n'));
 			}
-			setItems(next);
+			// ここでは保持のみ行い、処理（applyEdit）は「ダウンロード」ボタン押下まで開始しない
+			hold(next);
 
 			if (next.length === 1 && next[0].bitmap) {
 				initCrop(next[0].bitmap, aspectPreset);
@@ -133,7 +140,7 @@ export default function ImageEditPage() {
 				setCrop(null);
 			}
 		},
-		[aspectPreset, initCrop],
+		[aspectPreset, initCrop, hold, setError],
 	);
 
 	const handleAspectChange = useCallback(
@@ -176,78 +183,43 @@ export default function ImageEditPage() {
 		return editOps;
 	}, [editOps, crop, singleBitmap]);
 
-	const handleProcess = useCallback(async () => {
-		setProcessing(true);
-		setCompletion(null);
-		setProgress({ done: 0, total: items.length });
-
-		const results: EditResult[] = [];
-		let failed = 0;
-
-		for (let i = 0; i < items.length; i++) {
-			const item = items[i];
+	const handleProcess = useCallback(() => {
+		resultsRef.current = [];
+		startHeld(async (item) => {
 			if (!item.bitmap) {
-				failed++;
-				setProgress({ done: i + 1, total: items.length });
-				continue;
+				throw new Error('画像の読み込みに失敗しました');
 			}
 
-			try {
-				const ops = { ...editOps };
+			const ops = { ...editOps };
 
-				if (isBatch) {
-					const ratio = aspectPresetToRatio(aspectPreset);
-					if (ratio !== null) {
-						ops.crop =
-							computeCenterCrop(item.bitmap.width, item.bitmap.height, ratio) ??
-							undefined;
-					}
-				} else if (crop) {
-					const isFullImage =
-						crop.x === 0 &&
-						crop.y === 0 &&
-						crop.width === item.bitmap.width &&
-						crop.height === item.bitmap.height;
-					ops.crop = isFullImage ? undefined : crop;
+			if (isBatch) {
+				const ratio = aspectPresetToRatio(aspectPreset);
+				if (ratio !== null) {
+					ops.crop =
+						computeCenterCrop(item.bitmap.width, item.bitmap.height, ratio) ??
+						undefined;
 				}
-
-				const result = await applyEdit(item.bitmap, ops, item.file.name);
-				results.push(result);
-			} catch {
-				failed++;
+			} else if (crop) {
+				const isFullImage =
+					crop.x === 0 &&
+					crop.y === 0 &&
+					crop.width === item.bitmap.width &&
+					crop.height === item.bitmap.height;
+				ops.crop = isFullImage ? undefined : crop;
 			}
 
-			setProgress({ done: i + 1, total: items.length });
-			await new Promise((r) => setTimeout(r, 0));
-		}
-
-		setProcessing(false);
-		setCompletion({
-			done: results.length,
-			failed,
-			total: items.length,
+			const result = await applyEdit(item.bitmap, ops, item.file.name);
+			resultsRef.current.push(result);
+			return {};
 		});
-
-		if (results.length === 1) {
-			downloadEditedFile(results[0]);
-		} else if (results.length > 1) {
-			await downloadEditedZip(results);
-		}
-	}, [items, editOps, crop, isBatch, aspectPreset]);
+	}, [startHeld, editOps, crop, isBatch, aspectPreset]);
 
 	const handleClear = useCallback(() => {
-		for (const it of itemsRef.current) {
-			URL.revokeObjectURL(it.previewUrl);
-			it.bitmap?.close();
-		}
-		setItems([]);
+		clearBatch();
 		setCrop(null);
-		setError(null);
-		setProcessing(false);
-		setCompletion(null);
 		setEditOps(DEFAULT_EDIT_OPS);
 		setAspectPreset('free');
-	}, []);
+	}, [clearBatch]);
 
 	const completionText = completion
 		? completion.failed > 0

--- a/src/components/image-edit/ImageEditPage.tsx
+++ b/src/components/image-edit/ImageEditPage.tsx
@@ -67,6 +67,7 @@ export default function ImageEditPage() {
 		releaseItem: releaseEditItem,
 		onRunComplete: () => {
 			const results = resultsRef.current;
+			resultsRef.current = [];
 			if (results.length === 1) {
 				downloadEditedFile(results[0]);
 			} else if (results.length > 1) {
@@ -216,6 +217,7 @@ export default function ImageEditPage() {
 
 	const handleClear = useCallback(() => {
 		clearBatch();
+		resultsRef.current = [];
 		setCrop(null);
 		setEditOps(DEFAULT_EDIT_OPS);
 		setAspectPreset('free');

--- a/src/components/image-metadata/ImageMetadataPage.tsx
+++ b/src/components/image-metadata/ImageMetadataPage.tsx
@@ -1,5 +1,5 @@
 import { CheckCircle2, Download, Loader2, Trash2 } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -12,6 +12,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
+import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
 import {
 	MAX_METADATA_FILE_COUNT,
@@ -28,12 +29,12 @@ const ACCEPT = 'image/jpeg,image/png,image/webp';
 
 type MetadataItem = {
 	id: string;
+	status: 'pending' | 'done' | 'error';
+	error?: string;
 	file: File;
 	previewUrl: string;
-	status: 'ready' | 'processing' | 'done' | 'error';
 	result?: StripMetadataResult;
 	resultUrl?: string;
-	error?: string;
 };
 
 const DEFAULT_OPTIONS: StripMetadataOptions = {
@@ -42,6 +43,11 @@ const DEFAULT_OPTIONS: StripMetadataOptions = {
 	background: '#ffffff',
 };
 
+function releaseMetadataItem(item: MetadataItem): void {
+	URL.revokeObjectURL(item.previewUrl);
+	if (item.resultUrl) URL.revokeObjectURL(item.resultUrl);
+}
+
 function formatBytes(bytes: number): string {
 	if (bytes < 1024) return `${bytes} B`;
 	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
@@ -49,102 +55,57 @@ function formatBytes(bytes: number): string {
 }
 
 export function ImageMetadataPage() {
-	const [items, setItems] = useState<MetadataItem[]>([]);
 	const [options, setOptions] = useState<StripMetadataOptions>(DEFAULT_OPTIONS);
-	const [processing, setProcessing] = useState(false);
-	const [error, setError] = useState<string | null>(null);
-	const itemsRef = useRef<MetadataItem[]>([]);
-	itemsRef.current = items;
 
-	useEffect(() => {
-		return () => {
-			for (const item of itemsRef.current) {
-				URL.revokeObjectURL(item.previewUrl);
-				if (item.resultUrl) URL.revokeObjectURL(item.resultUrl);
-			}
-		};
-	}, []);
+	const {
+		items,
+		processing,
+		progress,
+		error,
+		setError,
+		append,
+		removeItem,
+		startHeld,
+	} = useBatchProcessing<MetadataItem>({
+		fallbackErrorMessage: '処理に失敗しました。',
+		releaseItem: releaseMetadataItem,
+	});
 
-	const onFiles = useCallback((files: File[]) => {
-		setError(null);
-		const countError = validateMetadataFileCount(
-			itemsRef.current.length,
-			files.length,
-		);
-		if (countError) {
-			setError(countError);
-			return;
-		}
-		const next: MetadataItem[] = [];
-		for (const file of files) {
-			const validationError = validateMetadataImageFile(file);
-			if (validationError) {
-				setError(`${file.name}: ${validationError}`);
-				continue;
+	const onFiles = useCallback(
+		(files: File[]) => {
+			setError(null);
+			const countError = validateMetadataFileCount(items.length, files.length);
+			if (countError) {
+				setError(countError);
+				return;
 			}
-			next.push({
-				id: createId(),
-				file,
-				previewUrl: URL.createObjectURL(file),
-				status: 'ready',
-			});
-		}
-		if (next.length > 0) setItems((prev) => [...prev, ...next]);
-	}, []);
+			const next: MetadataItem[] = [];
+			for (const file of files) {
+				const validationError = validateMetadataImageFile(file);
+				if (validationError) {
+					setError(`${file.name}: ${validationError}`);
+					continue;
+				}
+				next.push({
+					id: createId(),
+					status: 'pending',
+					file,
+					previewUrl: URL.createObjectURL(file),
+				});
+			}
+			// 選択時は保持のみ行い、「メタデータを削除」ボタン押下まで処理を開始しない
+			if (next.length > 0) append(next);
+		},
+		[items.length, append, setError],
+	);
 
-	const removeItem = useCallback((id: string) => {
-		setItems((prev) => {
-			const target = prev.find((item) => item.id === id);
-			if (target) {
-				URL.revokeObjectURL(target.previewUrl);
-				if (target.resultUrl) URL.revokeObjectURL(target.resultUrl);
-			}
-			return prev.filter((item) => item.id !== id);
+	const processAll = useCallback(() => {
+		startHeld(async (item) => {
+			const result = await stripImageMetadata(item.file, options);
+			const resultUrl = URL.createObjectURL(result.blob);
+			return { result, resultUrl };
 		});
-	}, []);
-
-	const processAll = useCallback(async () => {
-		setError(null);
-		setProcessing(true);
-		for (const item of itemsRef.current) {
-			setItems((prev) =>
-				prev.map((it) =>
-					it.id === item.id ? { ...it, status: 'processing' } : it,
-				),
-			);
-			try {
-				const result = await stripImageMetadata(item.file, options);
-				const resultUrl = URL.createObjectURL(result.blob);
-				setItems((prev) =>
-					prev.map((it) => {
-						if (it.id !== item.id) return it;
-						if (it.resultUrl) URL.revokeObjectURL(it.resultUrl);
-						return {
-							...it,
-							status: 'done',
-							result,
-							resultUrl,
-							error: undefined,
-						};
-					}),
-				);
-			} catch (err) {
-				setItems((prev) =>
-					prev.map((it) =>
-						it.id === item.id
-							? {
-									...it,
-									status: 'error',
-									error:
-										err instanceof Error ? err.message : '処理に失敗しました。',
-								}
-							: it,
-					),
-				);
-			}
-		}
-		setProcessing(false);
-	}, [options]);
+	}, [startHeld, options]);
 
 	const downloadAll = useCallback(async () => {
 		const done = items.filter((item) => item.result);
@@ -164,6 +125,8 @@ export function ImageMetadataPage() {
 	}, [items]);
 
 	const doneCount = items.filter((item) => item.status === 'done').length;
+	// 逐次処理は items の並び順どおりに進むため、進捗インデックスの位置にあるアイテムが処理中とみなせる
+	const processingId = processing ? items[progress.done]?.id : undefined;
 
 	return (
 		<div className="space-y-6">
@@ -281,7 +244,7 @@ export function ImageMetadataPage() {
 								<p className="text-muted-foreground">
 									元サイズ: {formatBytes(item.file.size)}
 								</p>
-								{item.status === 'processing' && (
+								{item.id === processingId && (
 									<p className="text-primary">処理中...</p>
 								)}
 								{item.status === 'error' && (

--- a/src/components/image-metadata/ImageMetadataPage.tsx
+++ b/src/components/image-metadata/ImageMetadataPage.tsx
@@ -102,6 +102,8 @@ export function ImageMetadataPage() {
 	const processAll = useCallback(() => {
 		startHeld(async (item) => {
 			const result = await stripImageMetadata(item.file, options);
+			// オプション変更後の再実行では前回の resultUrl が残っているため、先に解放してから差し替える
+			if (item.resultUrl) URL.revokeObjectURL(item.resultUrl);
 			const resultUrl = URL.createObjectURL(result.blob);
 			return { result, resultUrl };
 		});

--- a/src/lib/hooks/useBatchProcessing.ts
+++ b/src/lib/hooks/useBatchProcessing.ts
@@ -2,10 +2,11 @@
 // 進捗表示・キャンセル・中断検知（runId）・ObjectURL 等のリソース解放という
 // バッチ処理ページ共通の状態機械を一元管理する。
 // ランのライフサイクル管理は useProcessingLifecycle に委譲している。
-// 使用例: ImageCompressPage / ImageConvertPage
+// 使用例: ImageCompressPage / ImageConvertPage（即時開始）、
+//         ImageEditPage / ImageMetadataPage / ExifToolPage（選択と処理開始を分離する2段階フロー）
 
 import { useCallback, useRef, useState } from 'react';
-import { useProcessingLifecycle } from './useProcessingLifecycle';
+import { useProcessingLifecycle } from './useProcessingLifecycle.ts';
 
 /** バッチ処理対象アイテムに最低限必要なフィールド */
 export type BatchItemBase = {
@@ -18,6 +19,77 @@ export type BatchProgress = { done: number; total: number };
 
 export type BatchCompletion = { done: number; failed: number; total: number };
 
+/** runBatch が要求するラン管理の最小インターフェース（React非依存） */
+export type BatchRunner = {
+	beginRun: () => number;
+	isCurrent: (runId: number) => boolean;
+};
+
+export type BatchRunHandlers<TItem extends BatchItemBase> = {
+	onRunStart: (total: number) => void;
+	/** 成功したアイテムに適用する差分パッチ */
+	onItemSuccess: (item: TItem, patch: Partial<TItem>) => void;
+	/** ラン中断後に届いた成功パッチ（アイテムには反映しない。リソース解放のために渡される） */
+	onStalePatch: (patch: Partial<TItem>) => void;
+	onItemError: (item: TItem, message: string) => void;
+	onProgress: (progress: BatchProgress) => void;
+	/** ラン継続中に最後まで完了した場合のみ呼ばれる（キャンセル・中断時は呼ばれない） */
+	onRunComplete: (completion: BatchCompletion) => void;
+};
+
+/** 1アイテムを処理して成功時の差分を返す。失敗時は throw する */
+export type BatchItemProcessor<TItem extends BatchItemBase> = (
+	item: TItem,
+) => Promise<Partial<TItem>>;
+
+/**
+ * target を先頭から逐次処理する（React非依存）。
+ * runner.isCurrent が false になった時点（キャンセル・新しいランの開始）で中断し、
+ * 中断後に届いた成功パッチは onStalePatch でリソース解放できるよう渡す。
+ */
+export async function runBatch<TItem extends BatchItemBase>(
+	runner: BatchRunner,
+	target: TItem[],
+	processItem: BatchItemProcessor<TItem>,
+	handlers: BatchRunHandlers<TItem>,
+	fallbackErrorMessage: string,
+): Promise<void> {
+	const runId = runner.beginRun();
+	handlers.onRunStart(target.length);
+	let done = 0;
+	let failed = 0;
+
+	for (let i = 0; i < target.length; i++) {
+		if (!runner.isCurrent(runId)) return;
+		const item = target[i];
+		try {
+			const patch = await processItem(item);
+			if (!runner.isCurrent(runId)) {
+				// 中断後に届いた結果はアイテムへ反映せず、リソースだけ解放する
+				handlers.onStalePatch(patch);
+				return;
+			}
+			handlers.onItemSuccess(item, patch);
+			done++;
+		} catch (err) {
+			handlers.onItemError(
+				item,
+				err instanceof Error ? err.message : fallbackErrorMessage,
+			);
+			failed++;
+		}
+		if (runner.isCurrent(runId)) {
+			handlers.onProgress({ done: i + 1, total: target.length });
+		}
+		// イベントループへ yield して UI フリーズを防ぐ
+		await new Promise((resolve) => setTimeout(resolve, 0));
+	}
+
+	if (runner.isCurrent(runId)) {
+		handlers.onRunComplete({ done, failed, total: target.length });
+	}
+}
+
 export type UseBatchProcessingOptions<TItem extends BatchItemBase> = {
 	/** 処理失敗時にアイテムへ設定する既定エラーメッセージ */
 	fallbackErrorMessage: string;
@@ -28,11 +100,6 @@ export type UseBatchProcessingOptions<TItem extends BatchItemBase> = {
 	/** 1ラン正常完了時に呼ばれる（キャンセル・中断時は呼ばれない）。計測などに使用 */
 	onRunComplete?: (completion: BatchCompletion) => void;
 };
-
-/** 1アイテムを処理して成功時の差分を返す。失敗時は throw する */
-export type BatchItemProcessor<TItem extends BatchItemBase> = (
-	item: TItem,
-) => Promise<Partial<TItem>>;
 
 export function useBatchProcessing<TItem extends BatchItemBase>(
 	options: UseBatchProcessingOptions<TItem>,
@@ -67,47 +134,34 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 
 	/** target を先頭から逐次処理する（キャンセル・差し替えで中断） */
 	const run = useCallback(
-		async (target: TItem[], processItem: BatchItemProcessor<TItem>) => {
-			const runId = lifecycle.beginRun();
-			setProcessing(true);
-			setCompletion(null);
-			setProgress({ done: 0, total: target.length });
-			let done = 0;
-			let failed = 0;
-
-			for (let i = 0; i < target.length; i++) {
-				if (!lifecycle.isCurrent(runId)) break;
-				const item = target[i];
-				try {
-					const patch = await processItem(item);
-					if (!lifecycle.isCurrent(runId)) {
-						// 中断後に届いた結果はアイテムへ反映せず、リソースだけ解放する
-						releasePatch?.(patch);
-						break;
-					}
-					updateItem(item.id, { ...patch, status: 'done' } as Partial<TItem>);
-					done++;
-				} catch (err) {
-					updateItem(item.id, {
-						status: 'error',
-						error: err instanceof Error ? err.message : fallbackErrorMessage,
-					} as Partial<TItem>);
-					failed++;
-				}
-				if (lifecycle.isCurrent(runId)) {
-					setProgress({ done: i + 1, total: target.length });
-				}
-				// イベントループへ yield して UI フリーズを防ぐ
-				await new Promise((resolve) => setTimeout(resolve, 0));
-			}
-
-			if (lifecycle.isCurrent(runId)) {
-				setProcessing(false);
-				const result = { done, failed, total: target.length };
-				setCompletion(result);
-				onRunCompleteRef.current?.(result);
-			}
-		},
+		(target: TItem[], processItem: BatchItemProcessor<TItem>) =>
+			runBatch(
+				lifecycle,
+				target,
+				processItem,
+				{
+					onRunStart: (total) => {
+						setProcessing(true);
+						setCompletion(null);
+						setProgress({ done: 0, total });
+					},
+					onItemSuccess: (item, patch) =>
+						updateItem(item.id, { ...patch, status: 'done' } as Partial<TItem>),
+					onStalePatch: (patch) => releasePatch?.(patch),
+					onItemError: (item, message) =>
+						updateItem(item.id, {
+							status: 'error',
+							error: message,
+						} as Partial<TItem>),
+					onProgress: setProgress,
+					onRunComplete: (result) => {
+						setProcessing(false);
+						setCompletion(result);
+						onRunCompleteRef.current?.(result);
+					},
+				},
+				fallbackErrorMessage,
+			),
 		[fallbackErrorMessage, releasePatch, updateItem, lifecycle],
 	);
 
@@ -119,6 +173,25 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 			void run(target, processItem);
 		},
 		[run, lifecycle],
+	);
+
+	/**
+	 * 前回の items のリソースを解放してから target に差し替えるが、処理は開始しない。
+	 * ファイル選択と処理開始のタイミングを分離したい2段階フロー（クロップ調整後に実行 等）で使う。
+	 */
+	const hold = useCallback(
+		(target: TItem[]) => {
+			lifecycle.releaseAll();
+			setItems(target);
+		},
+		[lifecycle],
+	);
+
+	/** hold() で保持済みの現在の items を対象に処理を開始する */
+	const startHeld = useCallback(
+		(processItem: BatchItemProcessor<TItem>) =>
+			void run(itemsRef.current, processItem),
+		[run, itemsRef],
 	);
 
 	/** 現在の items を resetItem で初期化し直して再処理する（再圧縮・再変換） */
@@ -167,6 +240,8 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 		setError,
 		clearCompletion,
 		start,
+		hold,
+		startHeld,
 		reprocess,
 		cancel,
 		clear,

--- a/src/lib/hooks/useBatchProcessing.ts
+++ b/src/lib/hooks/useBatchProcessing.ts
@@ -194,6 +194,26 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 		[run, itemsRef],
 	);
 
+	/**
+	 * 既存の items のリソースは解放せず、末尾に追加する。
+	 * 複数回に分けて選択を蓄積したい2段階フロー（都度追加・個別削除）で使う。
+	 */
+	const append = useCallback((next: TItem[]) => {
+		setItems((prev) => [...prev, ...next]);
+	}, []);
+
+	/** id で指定した1アイテムのみリソースを解放して取り除く */
+	const removeItem = useCallback(
+		(id: string) => {
+			setItems((prev) => {
+				const target = prev.find((it) => it.id === id);
+				if (target) options.releaseItem?.(target);
+				return prev.filter((it) => it.id !== id);
+			});
+		},
+		[options.releaseItem],
+	);
+
 	/** 現在の items を resetItem で初期化し直して再処理する（再圧縮・再変換） */
 	const reprocess = useCallback(
 		(
@@ -242,6 +262,8 @@ export function useBatchProcessing<TItem extends BatchItemBase>(
 		start,
 		hold,
 		startHeld,
+		append,
+		removeItem,
 		reprocess,
 		cancel,
 		clear,

--- a/tests/unit/use-batch-processing.test.ts
+++ b/tests/unit/use-batch-processing.test.ts
@@ -1,0 +1,202 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	type BatchItemBase,
+	type BatchRunHandlers,
+	runBatch,
+} from '../../src/lib/hooks/useBatchProcessing.ts';
+import {
+	createResourceTracker,
+	createRunTracker,
+} from '../../src/lib/hooks/useProcessingLifecycle.ts';
+
+type Item = BatchItemBase & { url: string };
+
+function noopHandlers(overrides: Partial<BatchRunHandlers<Item>> = {}) {
+	return {
+		onRunStart: () => {},
+		onItemSuccess: () => {},
+		onStalePatch: () => {},
+		onItemError: () => {},
+		onProgress: () => {},
+		onRunComplete: () => {},
+		...overrides,
+	} satisfies BatchRunHandlers<Item>;
+}
+
+describe('runBatch — 選択と処理開始を分離する2段階フロー', () => {
+	it('保持→遅延開始: アイテムを保持した後、任意のタイミングで開始しても全件処理される', async () => {
+		const runner = createRunTracker();
+		const held: Item[] = [
+			{ id: '1', status: 'pending', url: 'blob:1' },
+			{ id: '2', status: 'pending', url: 'blob:2' },
+		];
+		// 「保持」段階では runBatch は一切呼ばれない（選択と処理開始の分離）
+		// 後から任意のタイミングで開始する
+		const processed: string[] = [];
+		const succeeded: string[] = [];
+
+		await runBatch(
+			runner,
+			held,
+			async (item) => {
+				processed.push(item.id);
+				return { url: `${item.url}-done` };
+			},
+			noopHandlers({
+				onItemSuccess: (item) => succeeded.push(item.id),
+			}),
+			'失敗しました',
+		);
+
+		assert.deepEqual(processed, ['1', '2']);
+		assert.deepEqual(succeeded, ['1', '2']);
+	});
+
+	it('開始前キャンセル: 保持のみで開始前にキャンセルしても、後続の開始が正常に動作する', async () => {
+		const runner = createRunTracker();
+
+		// 保持段階でキャンセル（クリア）してもランは一度も始まっていない
+		runner.cancel();
+
+		const processed: string[] = [];
+		await runBatch(
+			runner,
+			[{ id: '1', status: 'pending', url: 'blob:1' }],
+			async (item) => {
+				processed.push(item.id);
+				return {};
+			},
+			noopHandlers(),
+			'失敗しました',
+		);
+
+		// beginRun() がキャンセル状態をリセットするため、開始前キャンセルは以後の開始を妨げない
+		assert.deepEqual(processed, ['1']);
+	});
+
+	it('開始前キャンセル: 保持したアイテムを一度も開始せずにクリアすると、processItem は呼ばれずリソースのみ解放される', () => {
+		const tracker = createResourceTracker<Item>();
+		const released: string[] = [];
+		const release = (item: Item) => released.push(item.url);
+		const processorCalls: string[] = [];
+
+		const held: Item[] = [
+			{ id: '1', status: 'pending', url: 'blob:1' },
+			{ id: '2', status: 'pending', url: 'blob:2' },
+		];
+		tracker.track(held);
+
+		// startHeld を一度も呼ばずに clear() 相当の操作を行う
+		tracker.releaseAll(release);
+
+		assert.deepEqual(released, ['blob:1', 'blob:2']);
+		assert.deepEqual(processorCalls, []);
+	});
+
+	it('失敗時のリソース解放: 一部アイテムが失敗しても処理は継続し、失敗アイテムのエラーが記録される', async () => {
+		const runner = createRunTracker();
+		const errors: { id: string; message: string }[] = [];
+		const succeeded: string[] = [];
+
+		await runBatch(
+			runner,
+			[
+				{ id: '1', status: 'pending', url: 'blob:1' },
+				{ id: '2', status: 'pending', url: 'blob:2' },
+				{ id: '3', status: 'pending', url: 'blob:3' },
+			],
+			async (item) => {
+				if (item.id === '2') throw new Error('boom');
+				return { url: `${item.url}-done` };
+			},
+			noopHandlers({
+				onItemSuccess: (item) => succeeded.push(item.id),
+				onItemError: (item, message) => errors.push({ id: item.id, message }),
+			}),
+			'失敗しました',
+		);
+
+		assert.deepEqual(succeeded, ['1', '3']);
+		assert.deepEqual(errors, [{ id: '2', message: 'boom' }]);
+	});
+
+	it('失敗時のリソース解放: 中断後に届いた成功パッチは onStalePatch へ渡され、確実に解放できる', async () => {
+		const runner = createRunTracker();
+		const released: string[] = [];
+
+		const run = runBatch(
+			runner,
+			[{ id: '1', status: 'pending', url: 'blob:1' }],
+			async () => {
+				runner.cancel();
+				return { url: 'blob:stale-result' };
+			},
+			noopHandlers({
+				onStalePatch: (patch) => {
+					if (patch.url) released.push(patch.url);
+				},
+			}),
+			'失敗しました',
+		);
+
+		await run;
+
+		assert.deepEqual(released, ['blob:stale-result']);
+	});
+
+	it('結果クリア時のObjectURL解放: 完了後にアイテムを差し替えると、旧アイテムのリソースが解放される', () => {
+		const tracker = createResourceTracker<Item>();
+		const revoked: string[] = [];
+		const release = (item: Item) => revoked.push(item.url);
+
+		tracker.track([
+			{ id: '1', status: 'done', url: 'blob:old-1' },
+			{ id: '2', status: 'done', url: 'blob:old-2' },
+		]);
+
+		// clear() 相当: 現在の追跡対象を解放してから空に差し替える
+		tracker.releaseAll(release);
+		tracker.track([]);
+
+		assert.deepEqual(revoked, ['blob:old-1', 'blob:old-2']);
+
+		// 差し替え後に再度 releaseAll しても二重解放されない
+		tracker.releaseAll(release);
+		assert.deepEqual(revoked, ['blob:old-1', 'blob:old-2']);
+	});
+
+	it('調整後の再実行: 完了後に同じアイテムを新しい処理内容で再実行できる', async () => {
+		const runner = createRunTracker();
+		const results: string[] = [];
+
+		const items: Item[] = [{ id: '1', status: 'pending', url: 'blob:1' }];
+
+		await runBatch(
+			runner,
+			items,
+			async () => ({ url: 'result-v1' }),
+			noopHandlers({
+				onItemSuccess: (_item, patch) => {
+					if (patch.url) results.push(patch.url);
+				},
+			}),
+			'失敗しました',
+		);
+
+		// クロップ・回転などを調整した後、同じアイテムを再実行する
+		await runBatch(
+			runner,
+			items,
+			async () => ({ url: 'result-v2' }),
+			noopHandlers({
+				onItemSuccess: (_item, patch) => {
+					if (patch.url) results.push(patch.url);
+				},
+			}),
+			'失敗しました',
+		);
+
+		assert.deepEqual(results, ['result-v1', 'result-v2']);
+	});
+});


### PR DESCRIPTION
## Summary
- `useBatchProcessing` に、ファイル選択と処理開始を分離できる `hold()` / `startHeld()` を追加（内部ループを純粋関数 `runBatch` として切り出し）。既存の `start()` / `reprocess()` の挙動は不変。
- 選択のたびにアイテムを蓄積し個別削除もできる `ImageMetadataPage` 向けに、`append()` / `removeItem()` も追加。
- 「選択時はプレビュー/解析のみ、ボタン押下まで実処理を開始しない」2段階フローを持つ3ページを移行:
  - `ImageEditPage`（クロップ・回転編集）
  - `ImageMetadataPage`（メタデータ削除）
  - `ExifToolPage`（EXIF表示・削除）
- 完了時に自動ダウンロードするページ（image-edit / exif）では、同一ラン内の `onRunComplete` で `itemsRef.current` を読むと `setItems` の再レンダー反映が間に合わないことが判明したため、`processItem` 内で直接結果を `useRef` に蓄積してダウンロードする方式にした。

親タスク: [バッチ処理パターンの共通フック抽出（8ファイル重複）](https://app.notion.com/p/391dfd360336814db954f348c5235703)
対象タスク: [useBatchProcessing移行 第4弾](https://app.notion.com/p/28fc8321cd464f90aa8b8a025f5ae034)

## Test plan
- [x] `npm run test:unit` — 542件全てパス（新規: 保持→遅延開始・開始前キャンセル・失敗時のリソース解放・結果クリア時のObjectURL解放・調整後の再実行のRED→GREEN確認を含む `tests/unit/use-batch-processing.test.ts`）
- [x] `npm run check`（Astro型チェック＋Biome）— エラーなし（既存の警告のみ、変更前と同数）
- [x] `npx playwright test tests/e2e/image-edit.spec.ts` — 7件全てパス
- [x] `npx playwright test tests/e2e/image-metadata.spec.ts` — 3件全てパス
- [x] 既存の移行済みページ（image-compress / image-convert / pdf-merge / pdf-split / image-merge）のe2eに回帰なし
- [x] フルe2eスイート（346件）— 345件パス、失敗1件は `upscale.spec.ts`（本PRと無関係なMLモデルのタイムアウト、useBatchProcessing未使用ページ）
- [x] 手動検証: image-metadata の複数回選択での蓄積・個別削除、exif の単一/複数ファイルの自動ダウンロード（単一/ZIP）、GPSバッジ表示

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01KskshKQGzrAPyRLbAkhUBX

---
_Generated by [Claude Code](https://claude.ai/code/session_01KskshKQGzrAPyRLbAkhUBX)_