### PR TITLE
JSONフォーマッター・SQL整形のtextareaを縦方向リサイズ可能にする

### DIFF
--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -309,7 +309,8 @@ export default function JsonFormatter() {
 								? '入力JSONにエラーがあります'
 								: '整形結果がここに表示されます...'
 						}
-						className={`min-h-[200px] font-mono-tool rounded-xl bg-muted/50`}
+						resize="vertical"
+						className="min-h-[240px] max-h-[80dvh] font-mono-tool rounded-xl bg-muted/50"
 						spellCheck={false}
 					/>
 				)}

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -241,7 +241,7 @@ export default function JsonFormatter() {
 				>
 					入力JSON
 				</Label>
-				<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex h-[250px]">
+				<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex">
 					{/* 行番号ガター */}
 					<div
 						id="json-input-line-numbers"
@@ -267,7 +267,8 @@ export default function JsonFormatter() {
 						onChange={(e) => handleInputChange(e.target.value)}
 						onScroll={handleInputScroll}
 						placeholder={'{"name":"太郎","age":30,"city":"東京"}'}
-						className="flex-1 min-h-0 bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 resize-none border-none ring-0 shadow-none focus-visible:ring-0 rounded-none whitespace-pre"
+						resize="vertical"
+						className="flex-1 h-[250px] min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 border-none ring-0 shadow-none focus-visible:ring-0 rounded-none whitespace-pre"
 						spellCheck={false}
 					/>
 				</div>

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -406,7 +406,7 @@ export default function SqlFormatter() {
 				</Button>
 			</div>
 
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
 				{/* Input */}
 				<div>
 					<div className="flex items-center justify-between mb-2">
@@ -430,7 +430,7 @@ export default function SqlFormatter() {
 							</Button>
 						</div>
 					</div>
-					<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex h-[400px]">
+					<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex">
 						{/* Gutter */}
 						<div
 							id="line-numbers"
@@ -449,7 +449,8 @@ export default function SqlFormatter() {
 							onScroll={handleScroll}
 							placeholder="SELECT * FROM users WHERE active = 1"
 							spellCheck={false}
-							className="flex-1 min-h-0 bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 resize-none border-none ring-0 shadow-none focus-visible:ring-0 rounded-none whitespace-pre"
+							resize="vertical"
+							className="flex-1 h-[400px] min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 border-none ring-0 shadow-none focus-visible:ring-0 rounded-none whitespace-pre"
 						/>
 					</div>
 				</div>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,12 +2,25 @@ import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+type TextareaResize = 'none' | 'vertical';
+
+// デスクトップ（md〜）のみ縦方向リサイズを許可する。モバイルは初期高さ＋内部スクロールで操作する。
+const resizeClasses: Record<TextareaResize, string> = {
+	none: 'resize-none',
+	vertical: 'resize-none md:resize-y overflow-auto',
+};
+
+function Textarea({
+	className,
+	resize,
+	...props
+}: React.ComponentProps<'textarea'> & { resize?: TextareaResize }) {
 	return (
 		<textarea
 			data-slot="textarea"
 			className={cn(
 				'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+				resize && resizeClasses[resize],
 				className,
 			)}
 			{...props}
@@ -15,4 +28,4 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
 	);
 }
 
-export { Textarea };
+export { Textarea, type TextareaResize };

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -34,4 +34,43 @@ test.describe('JSON Formatter', () => {
 		await expect(errorBanner).toBeVisible();
 		await expect(errorBanner).toContainText('エラー');
 	});
+
+	test('input textarea allows vertical resize with min/max height on desktop', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-formatter');
+		await toolPage.goto();
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		const inputArea = page.locator('#json-input-textarea');
+		const style = await inputArea.evaluate((el) => {
+			const computed = getComputedStyle(el);
+			return {
+				resize: computed.resize,
+				minHeight: computed.minHeight,
+				maxHeight: computed.maxHeight,
+			};
+		});
+
+		expect(style.resize).toBe('vertical');
+		expect(style.minHeight).toBe('240px');
+		// 80dvh はビューポート高さ 900px の80% = 720px
+		expect(style.maxHeight).toBe('720px');
+	});
+
+	test('input textarea disables resize on mobile viewport', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-formatter');
+		await page.setViewportSize({ width: 390, height: 844 });
+		await toolPage.goto();
+
+		const inputArea = page.locator('#json-input-textarea');
+		const resize = await inputArea.evaluate(
+			(el) => getComputedStyle(el).resize,
+		);
+		expect(resize).toBe('none');
+	});
 });

--- a/tests/e2e/json-formatter.spec.ts
+++ b/tests/e2e/json-formatter.spec.ts
@@ -73,4 +73,44 @@ test.describe('JSON Formatter', () => {
 		);
 		expect(resize).toBe('none');
 	});
+
+	test('output placeholder textarea allows vertical resize with min/max height on desktop', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-formatter');
+		await toolPage.goto();
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		// 未入力状態では読み取り専用のプレースホルダーtextareaが出力欄として表示される
+		const outputArea = page.getByPlaceholder('整形結果がここに表示されます...');
+		const style = await outputArea.evaluate((el) => {
+			const computed = getComputedStyle(el);
+			return {
+				resize: computed.resize,
+				minHeight: computed.minHeight,
+				maxHeight: computed.maxHeight,
+			};
+		});
+
+		expect(style.resize).toBe('vertical');
+		expect(style.minHeight).toBe('240px');
+		// 80dvh はビューポート高さ 900px の80% = 720px
+		expect(style.maxHeight).toBe('720px');
+	});
+
+	test('output placeholder textarea disables resize on mobile viewport', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('json-formatter');
+		await page.setViewportSize({ width: 390, height: 844 });
+		await toolPage.goto();
+
+		const outputArea = page.getByPlaceholder('整形結果がここに表示されます...');
+		const resize = await outputArea.evaluate(
+			(el) => getComputedStyle(el).resize,
+		);
+		expect(resize).toBe('none');
+	});
 });

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -95,4 +95,37 @@ test.describe('SQL Formatter Tool', () => {
 			page.getByText('左側（または上）にSQLを入力すると'),
 		).toBeVisible();
 	});
+
+	test('input textarea allows vertical resize with min/max height on desktop', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		const inputArea = page.locator('textarea');
+		const style = await inputArea.evaluate((el) => {
+			const computed = getComputedStyle(el);
+			return {
+				resize: computed.resize,
+				minHeight: computed.minHeight,
+				maxHeight: computed.maxHeight,
+			};
+		});
+
+		expect(style.resize).toBe('vertical');
+		expect(style.minHeight).toBe('240px');
+		// 80dvh はビューポート高さ 900px の80% = 720px
+		expect(style.maxHeight).toBe('720px');
+	});
+
+	test('input textarea disables resize on mobile viewport', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+
+		const inputArea = page.locator('textarea');
+		const resize = await inputArea.evaluate(
+			(el) => getComputedStyle(el).resize,
+		);
+		expect(resize).toBe('none');
+	});
 });


### PR DESCRIPTION
## Summary

JSON/SQLの長文入力をしづらい「textareaが狭い問題」への対応です（Notionタスク: textareaが狭い問題）。

- 共通 `Textarea` コンポーネントに opt-in の `resize` prop（`"none" | "vertical"`）を追加。`resize` を渡さない既存の呼び出し箇所は挙動を変更しない
- `resize="vertical"` はデスクトップ（`md:`以上）でのみ `resize-y` を有効化し、モバイルは `resize-none` のまま維持する
- JSONフォーマッター・SQL整形の入力textareaに `resize="vertical"` と `min-h-[240px] max-h-[80dvh]` を適用し、初期高さ（250px / 400px）は現状を維持
- JSONフォーマッターの出力欄（未整形・エラー時に表示される読み取り専用のプレースホルダー）もtextarea実装のため同様に `resize="vertical"` を適用（初期高さは240px未満だったため240pxへ引き上げ）
- 横方向のリサイズは禁止（`resize-y`のみ）、高さ超過時は内部スクロール（`overflow-auto`）
- SQL整形の入力/出力2カラムは `items-start` にし、片側のリサイズがもう片方に伝播しないようにした
- リサイズはブラウザ標準のCSS機能のみで実現し、React state・イベント監視・外部ライブラリは追加していない

## 出力欄の調査結果

- **JSONフォーマッター**: 整形結果がある場合は `CodeBlock`（`pre`/`code`）で表示され対象外。整形結果が無い場合（未入力・エラー時）は読み取り専用の `Textarea` がプレースホルダーとして表示されており、textarea実装のため対象内 → `resize="vertical"` を適用済み
- **SQL整形**: 出力欄はエラー表示・整形結果（`CodeBlock`）・プレースホルダーのいずれも `div` 実装で、textareaは使われていない → 対象外（コード変更なし）

## Test plan

- [x] `npm run test:unit` — 638件パス
- [x] `npm run check`（astro check + biome）— 変更ファイルにエラー・警告なし（既存の無関係な警告のみ残存）
- [x] `npx playwright test tests/e2e/json-formatter.spec.ts tests/e2e/sql-formatter.spec.ts` — chromium / mobile-chrome 全28件パス（既存テストの回帰なし、リサイズ用の新規テストを追加）
  - 新規テストはネイティブのドラッグ操作ではなく、`resize` / `min-height` / `max-height` の computed style を検証（デスクトップでは `resize: vertical` かつ `max-height` がビューポート高の80%、モバイルでは `resize: none`）。JSON入力欄・JSON出力プレースホルダー欄・SQL入力欄それぞれで確認

## 手動確認

ローカルでビルド後のプレビューをChromiumで起動し、実際のドラッグ操作・スクリーンショットで確認しました。

- [x] JSONフォーマッター: デスクトップで入力欄を縦方向にリサイズ可能（250px→400pxへドラッグで拡大を確認）
- [x] JSONフォーマッター: デスクトップで出力欄（未整形時のプレースホルダーtextarea）を縦方向にリサイズ可能（240px→390pxへドラッグで拡大を確認）
- [x] JSONフォーマッター: 幅は変化しない（入力欄・出力欄ともにドラッグ前後で幅同一を確認）
- [x] SQL整形: デスクトップで入力欄を縦方向にリサイズ可能（400px→550pxへドラッグで拡大を確認）
- [x] SQL整形: デスクトップで出力欄がtextareaの場合、縦方向にリサイズ可能 — 出力欄はtextareaではない（`div`/`CodeBlock`実装）ため対象外
- [x] SQL整形: 幅は変化しない（ドラッグ前後で幅同一を確認）
- [x] リサイズ後も入力・整形・コピー・Undo/Redoが正常 — リサイズ後の入力反映、SQL自動整形結果表示、Ctrl+Zによる入力の巻き戻りを確認
- [x] ライトテーマで境界・ハンドルを認識可能 — スクリーンショットで枠線・リサイズグリップを確認
- [x] ダークテーマで境界・ハンドルを認識可能 — JSON/SQLともにダークテーマでスクリーンショットを確認
- [x] モバイルで横スクロール・レイアウト崩れなし — 390×844ビューポートで `document.documentElement.scrollWidth` が `clientWidth` を超えないことを確認（JSON: overflow 0px、SQL: overflow 1px で許容範囲）

補足: CSSの `min-height`/`max-height` によるリサイズ範囲のクランプ（240px下限・80dvh上限）は、JS経由で強制的に範囲外の高さを指定してcomputed styleが240px/720px（900pxビューポートの80%）に収まることでも確認済みです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ckzi21HewrTk86umNqh6Qq