### PR TITLE
TextDiff/RegexTester/Maskingのtextareaを縦方向リサイズ可能にする

### DIFF
--- a/src/components/tools/Masking.tsx
+++ b/src/components/tools/Masking.tsx
@@ -200,7 +200,7 @@ export default function Masking() {
 				</div>
 			</div>
 
-			<div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
 				{/* Input */}
 				<div>
 					<div className="flex items-center justify-between mb-2">
@@ -215,7 +215,7 @@ export default function Masking() {
 							<Trash2 className="h-4 w-4 mr-1" /> クリア
 						</Button>
 					</div>
-					<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex h-[300px]">
+					<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex">
 						<div
 							id="mask-highlight-overlay"
 							className="absolute inset-0 pointer-events-none p-3 text-sm leading-5 whitespace-pre-wrap break-words font-mono-tool overflow-hidden"
@@ -224,11 +224,13 @@ export default function Masking() {
 							{highlightNodes}
 						</div>
 						<Textarea
+							id="masking-input-textarea"
 							value={text}
 							onChange={(e) => setText(e.target.value)}
 							onScroll={handleScroll}
 							placeholder="山田太郎 (yamada@example.com) 090-1234-5678"
-							className="flex-1 min-h-[300px] h-full bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 resize-none border-none ring-0 shadow-none focus-visible:ring-0 rounded-none relative z-10"
+							resize="vertical"
+							className="flex-1 min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 border-none ring-0 shadow-none focus-visible:ring-0 rounded-none relative z-10"
 							spellCheck={false}
 						/>
 					</div>
@@ -260,9 +262,11 @@ export default function Masking() {
 						</div>
 					</div>
 					<Textarea
+						id="masking-output-textarea"
 						value={maskedText}
 						readOnly
-						className={`min-h-[300px] font-mono-tool text-sm leading-5 rounded-xl bg-card border shadow-sm ${
+						resize="vertical"
+						className={`min-h-[240px] max-h-[80dvh] font-mono-tool text-sm leading-5 rounded-xl bg-card border shadow-sm ${
 							maskedText ? 'shimmer' : ''
 						}`}
 						spellCheck={false}

--- a/src/components/tools/Masking.tsx
+++ b/src/components/tools/Masking.tsx
@@ -230,7 +230,7 @@ export default function Masking() {
 							onScroll={handleScroll}
 							placeholder="山田太郎 (yamada@example.com) 090-1234-5678"
 							resize="vertical"
-							className="flex-1 min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 border-none ring-0 shadow-none focus-visible:ring-0 rounded-none relative z-10"
+							className="flex-1 h-[300px] min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool text-sm leading-5 p-3 border-none ring-0 shadow-none focus-visible:ring-0 rounded-none relative z-10"
 							spellCheck={false}
 						/>
 					</div>

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -261,7 +261,7 @@ export default function RegexTester() {
 				</div>
 
 				{/* Highlight Overlay Container */}
-				<div className="relative min-h-[160px] rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex">
+				<div className="relative rounded-xl border border-input shadow-sm focus-within:ring-2 focus-within:ring-primary bg-background overflow-hidden flex">
 					{/* 行番号ガター */}
 					<div
 						id="regex-line-numbers"
@@ -289,10 +289,12 @@ export default function RegexTester() {
 						</div>
 						{/* Actual Textarea */}
 						<Textarea
+							id="regex-test-string-textarea"
 							value={text}
 							onChange={(e) => setText(e.target.value)}
 							onScroll={handleScroll}
-							className="absolute inset-0 min-h-0 bg-transparent text-foreground font-mono-tool resize-none border-none ring-0 shadow-none focus-visible:ring-0 rounded-none"
+							resize="vertical"
+							className="w-full min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool border-none ring-0 shadow-none focus-visible:ring-0 rounded-none"
 							spellCheck={false}
 						/>
 					</div>
@@ -315,7 +317,7 @@ export default function RegexTester() {
 
 			<div className="relative">
 				<div
-					className={`grid grid-cols-1 md:grid-cols-2 gap-6 transition-all duration-300 ${!showReplace && 'opacity-30 grayscale blur-[1px] select-none pointer-events-none'}`}
+					className={`grid grid-cols-1 md:grid-cols-2 gap-6 items-start transition-all duration-300 ${!showReplace && 'opacity-30 grayscale blur-[1px] select-none pointer-events-none'}`}
 				>
 					<div>
 						<Label className="text-sm font-medium mb-2 block">置換文字列</Label>
@@ -337,9 +339,11 @@ export default function RegexTester() {
 							<CopyButton text={result.replacedText || ''} />
 						</div>
 						<Textarea
+							id="regex-replace-output-textarea"
 							value={result.replacedText}
 							readOnly
-							className="min-h-[120px] font-mono-tool rounded-xl bg-muted/50"
+							resize="vertical"
+							className="min-h-[240px] max-h-[80dvh] font-mono-tool rounded-xl bg-muted/50"
 						/>
 					</div>
 				</div>

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -294,7 +294,7 @@ export default function RegexTester() {
 							onChange={(e) => setText(e.target.value)}
 							onScroll={handleScroll}
 							resize="vertical"
-							className="w-full min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool border-none ring-0 shadow-none focus-visible:ring-0 rounded-none"
+							className="w-full h-[240px] min-h-[240px] max-h-[80dvh] bg-transparent text-foreground font-mono-tool border-none ring-0 shadow-none focus-visible:ring-0 rounded-none"
 							spellCheck={false}
 						/>
 					</div>

--- a/src/components/tools/TextDiff.tsx
+++ b/src/components/tools/TextDiff.tsx
@@ -175,7 +175,7 @@ export default function TextDiff() {
 			</div>
 
 			{/* Two-pane input */}
-			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+			<div className="grid grid-cols-1 sm:grid-cols-2 gap-4 items-start">
 				<div>
 					<div className="flex items-center justify-between mb-2">
 						<Label className="text-sm font-medium">テキストA（変更前）</Label>
@@ -191,6 +191,7 @@ export default function TextDiff() {
 						</Button>
 					</div>
 					<Textarea
+						id="text-diff-textarea-a"
 						value={textA}
 						onChange={(e) => setTextA(e.target.value)}
 						onDrop={(e) => handleDrop(e, 'A')}
@@ -200,7 +201,8 @@ export default function TextDiff() {
 						}}
 						onDragLeave={() => setDragOverA(false)}
 						placeholder="変更前のテキストをここに入力..."
-						className={`min-h-[200px] font-mono-tool rounded-xl focus:ring-2 focus:ring-primary ${
+						resize="vertical"
+						className={`min-h-[240px] max-h-[80dvh] font-mono-tool rounded-xl focus:ring-2 focus:ring-primary ${
 							dragOverA ? 'border-primary border-dashed bg-primary/5' : ''
 						}`}
 					/>
@@ -224,6 +226,7 @@ export default function TextDiff() {
 						</Button>
 					</div>
 					<Textarea
+						id="text-diff-textarea-b"
 						value={textB}
 						onChange={(e) => setTextB(e.target.value)}
 						onDrop={(e) => handleDrop(e, 'B')}
@@ -233,7 +236,8 @@ export default function TextDiff() {
 						}}
 						onDragLeave={() => setDragOverB(false)}
 						placeholder="変更後のテキストをここに入力..."
-						className={`min-h-[200px] font-mono-tool rounded-xl focus:ring-2 focus:ring-primary ${
+						resize="vertical"
+						className={`min-h-[240px] max-h-[80dvh] font-mono-tool rounded-xl focus:ring-2 focus:ring-primary ${
 							dragOverB ? 'border-primary border-dashed bg-primary/5' : ''
 						}`}
 					/>

--- a/tests/e2e/masking.spec.ts
+++ b/tests/e2e/masking.spec.ts
@@ -28,4 +28,46 @@ test.describe('Personal Info Masking Tool', () => {
 		await expect(textareas.last()).not.toContainText('test@example.com');
 		await expect(textareas.last()).not.toContainText('090-1234-5678');
 	});
+
+	test('input and output textareas allow vertical resize with min/max height on desktop', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('masking');
+		await toolPage.goto();
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		for (const id of ['#masking-input-textarea', '#masking-output-textarea']) {
+			const textarea = page.locator(id);
+			const style = await textarea.evaluate((el) => {
+				const computed = getComputedStyle(el);
+				return {
+					resize: computed.resize,
+					minHeight: computed.minHeight,
+					maxHeight: computed.maxHeight,
+				};
+			});
+
+			expect(style.resize).toBe('vertical');
+			expect(style.minHeight).toBe('240px');
+			// 80dvh はビューポート高さ 900px の80% = 720px
+			expect(style.maxHeight).toBe('720px');
+		}
+	});
+
+	test('input and output textareas disable resize on mobile viewport', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		const toolPage = createToolPage('masking');
+		await toolPage.goto();
+
+		for (const id of ['#masking-input-textarea', '#masking-output-textarea']) {
+			const resize = await page
+				.locator(id)
+				.evaluate((el) => getComputedStyle(el).resize);
+			expect(resize).toBe('none');
+		}
+	});
 });

--- a/tests/e2e/masking.spec.ts
+++ b/tests/e2e/masking.spec.ts
@@ -70,4 +70,23 @@ test.describe('Personal Info Masking Tool', () => {
 			expect(resize).toBe('none');
 		}
 	});
+
+	test('input textarea keeps a fixed height on mobile even with long content', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		const toolPage = createToolPage('masking');
+		await toolPage.goto();
+
+		const textarea = page.locator('#masking-input-textarea');
+		const heightBefore = await textarea.evaluate((el) => el.clientHeight);
+
+		await textarea.fill(
+			Array.from({ length: 60 }, (_, i) => `line ${i}`).join('\n'),
+		);
+
+		const heightAfter = await textarea.evaluate((el) => el.clientHeight);
+		expect(heightAfter).toBe(heightBefore);
+	});
 });

--- a/tests/e2e/regex-tester.spec.ts
+++ b/tests/e2e/regex-tester.spec.ts
@@ -74,4 +74,23 @@ test.describe('Regex Tester Tool', () => {
 			expect(resize).toBe('none');
 		}
 	});
+
+	test('test string textarea keeps a fixed height on mobile even with long content', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		const toolPage = createToolPage('regex-tester');
+		await toolPage.goto();
+
+		const textarea = page.locator('#regex-test-string-textarea');
+		const heightBefore = await textarea.evaluate((el) => el.clientHeight);
+
+		await textarea.fill(
+			Array.from({ length: 60 }, (_, i) => `line ${i}`).join('\n'),
+		);
+
+		const heightAfter = await textarea.evaluate((el) => el.clientHeight);
+		expect(heightAfter).toBe(heightBefore);
+	});
 });

--- a/tests/e2e/regex-tester.spec.ts
+++ b/tests/e2e/regex-tester.spec.ts
@@ -26,4 +26,52 @@ test.describe('Regex Tester Tool', () => {
 		// 3. Verify match count updates to 4 (100, 0001, 530, 0001)
 		await expect(matchCount).toHaveText('4');
 	});
+
+	test('test string and replace textareas allow vertical resize with min/max height on desktop', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('regex-tester');
+		await toolPage.goto();
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		for (const id of [
+			'#regex-test-string-textarea',
+			'#regex-replace-output-textarea',
+		]) {
+			const textarea = page.locator(id);
+			const style = await textarea.evaluate((el) => {
+				const computed = getComputedStyle(el);
+				return {
+					resize: computed.resize,
+					minHeight: computed.minHeight,
+					maxHeight: computed.maxHeight,
+				};
+			});
+
+			expect(style.resize).toBe('vertical');
+			expect(style.minHeight).toBe('240px');
+			// 80dvh はビューポート高さ 900px の80% = 720px
+			expect(style.maxHeight).toBe('720px');
+		}
+	});
+
+	test('test string and replace textareas disable resize on mobile viewport', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+		const toolPage = createToolPage('regex-tester');
+		await toolPage.goto();
+
+		for (const id of [
+			'#regex-test-string-textarea',
+			'#regex-replace-output-textarea',
+		]) {
+			const resize = await page
+				.locator(id)
+				.evaluate((el) => getComputedStyle(el).resize);
+			expect(resize).toBe('none');
+		}
+	});
 });

--- a/tests/e2e/text-diff.spec.ts
+++ b/tests/e2e/text-diff.spec.ts
@@ -16,4 +16,38 @@ test.describe('Text Diff', () => {
 		await expect(page.getByText(/追加:\s*1行/)).toBeVisible();
 		await expect(page.getByText(/削除:\s*1行/)).toBeVisible();
 	});
+
+	test('both textareas allow vertical resize with min/max height on desktop', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		for (const id of ['#text-diff-textarea-a', '#text-diff-textarea-b']) {
+			const textarea = page.locator(id);
+			const style = await textarea.evaluate((el) => {
+				const computed = getComputedStyle(el);
+				return {
+					resize: computed.resize,
+					minHeight: computed.minHeight,
+					maxHeight: computed.maxHeight,
+				};
+			});
+
+			expect(style.resize).toBe('vertical');
+			expect(style.minHeight).toBe('240px');
+			// 80dvh はビューポート高さ 900px の80% = 720px
+			expect(style.maxHeight).toBe('720px');
+		}
+	});
+
+	test('both textareas disable resize on mobile viewport', async ({ page }) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+
+		for (const id of ['#text-diff-textarea-a', '#text-diff-textarea-b']) {
+			const resize = await page
+				.locator(id)
+				.evaluate((el) => getComputedStyle(el).resize);
+			expect(resize).toBe('none');
+		}
+	});
 });


### PR DESCRIPTION
## Summary
- PR #228 で共通 `Textarea` に導入済みの opt-in `resize="vertical"` variant を、TextDiff / RegexTester / Masking の長文textareaへ横展開
- デスクトップ（`md:`以上）のみ縦方向リサイズ（最小 `240px` 〜 最大 `80dvh`）、モバイルは既存どおり固定高+内部スクロールを維持
- RegexTester／Maskingは、ハイライトオーバーレイをtextareaに`absolute inset-0`で重ねる構造だったため、textareaを通常フローに戻し、行番号ガター・オーバーレイがtextareaの実高さにFlex stretchで追従するレイアウトへ変更（JsonFormatter/SqlFormatterと同じ実装パターン）
- 2カラムレイアウト（TextDiffのA/B、Maskingの入力/出力、RegexTesterの置換UI）に `items-start` を追加し、片側のリサイズが反対側を強制的に同高にしないようにした
- 共通 `Textarea` 自体（既定値 `resize="none"`）や対象外ツールへの変更なし

## 対象ファイル
- `src/components/tools/TextDiff.tsx` — A/B両方のtextareaに `resize="vertical"` を適用、`items-start` を追加
- `src/components/tools/RegexTester.tsx` — テスト文字列テキストエリア（行番号ガター＋ハイライトオーバーレイ構造）と置換結果テキストエリアに適用。オーバーレイ構造をFlexベースに変更
- `src/components/tools/Masking.tsx` — 入力テキストエリア（ハイライトオーバーレイ構造）と出力テキストエリアに適用。同様にFlexベースへ変更
- `tests/e2e/text-diff.spec.ts` / `tests/e2e/regex-tester.spec.ts` / `tests/e2e/masking.spec.ts` — resize/min-height/max-heightのデスクトップ・モバイル検証テストを追加

## Test plan
- [x] `npm run check`（Astro型チェック + Biome lint）— エラー0（既存の無関係な警告のみ）
- [x] `npm run test:unit` — 638件全件成功
- [x] `npx playwright test tests/e2e/text-diff.spec.ts tests/e2e/regex-tester.spec.ts tests/e2e/masking.spec.ts` — 11件全件成功（新規resizeテスト含む）
- [x] `npx playwright test tests/e2e/json-formatter.spec.ts tests/e2e/sql-formatter.spec.ts` — 既存機能へのリグレッションなし（14件全件成功）
- [x] `npm run build` — ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzNsmAVGxXkLxnwzMXAGff)_