### PR TITLE
SQLフォーマッター: フルサイズ表示状態を設定共有URLに含める

### DIFF
--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -84,11 +84,12 @@ export default function SqlFormatter() {
 			indent: '2spaces' as IndentStyle,
 			uppercase: true,
 			compress: false,
+			isExpanded: false,
 		},
 	);
-	const { autoFormat, dialect, indent, uppercase, compress } = settings;
+	const { autoFormat, dialect, indent, uppercase, compress, isExpanded } =
+		settings;
 	const [shareCopied, setShareCopied] = useState(false);
-	const [isExpanded, setIsExpanded] = useState(false);
 
 	const [manualOutput, setManualOutput] = useState('');
 	const [manualError, setManualError] = useState<string | null>(null);
@@ -148,20 +149,25 @@ export default function SqlFormatter() {
 		setTimeout(() => setShareCopied(false), 2000);
 	}, [generateShareUrl]);
 
-	const toggleExpand = () => {
-		const newExpanded = !isExpanded;
-		setIsExpanded(newExpanded);
+	const applyLayoutWidth = useCallback((expanded: boolean) => {
 		const container = document.getElementById('tool-layout-container');
-		if (container) {
-			if (newExpanded) {
-				container.classList.remove('max-w-[800px]', 'xl:max-w-5xl');
-				container.classList.add('max-w-full');
-			} else {
-				container.classList.remove('max-w-full');
-				container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
-			}
+		if (!container) return;
+		if (expanded) {
+			container.classList.remove('max-w-[800px]', 'xl:max-w-5xl');
+			container.classList.add('max-w-full');
+		} else {
+			container.classList.remove('max-w-full');
+			container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
 		}
+	}, []);
+
+	const toggleExpand = () => {
+		updateSettings({ isExpanded: !isExpanded });
 	};
+
+	useEffect(() => {
+		applyLayoutWidth(isExpanded);
+	}, [isExpanded, applyLayoutWidth]);
 
 	useEffect(() => {
 		return () => {

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -132,6 +132,7 @@ test.describe('SQL Formatter Tool', () => {
 	test('restores full-size layout from a shared settings URL', async ({
 		page,
 		context,
+		browser,
 	}) => {
 		await page.setViewportSize({ width: 1280, height: 900 });
 		await context.grantPermissions(['clipboard-read', 'clipboard-write']);
@@ -146,12 +147,40 @@ test.describe('SQL Formatter Tool', () => {
 		await page.getByRole('button', { name: '設定を共有' }).click();
 		const shareUrl = await page.evaluate(() => navigator.clipboard.readText());
 
-		// Open the shared URL in a fresh page and confirm full-size is restored
-		const newPage = await context.newPage();
+		// localStorage を共有しない完全に新しいコンテキストで開き、
+		// フルサイズ状態が URL のみから復元されることを検証する
+		const freshContext = await browser.newContext({
+			viewport: { width: 1280, height: 900 },
+		});
+		const newPage = await freshContext.newPage();
 		await newPage.goto(shareUrl);
 		await expect(newPage.locator('#tool-layout-container')).toHaveClass(
 			/max-w-full/,
 		);
-		await newPage.close();
+		await freshContext.close();
+	});
+
+	test('keeps standard-width layout from a shared settings URL', async ({
+		page,
+		context,
+		browser,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+		// フルサイズを有効化せずに共有 URL を生成する（isExpanded: false）
+		await page.getByRole('button', { name: '設定を共有' }).click();
+		const shareUrl = await page.evaluate(() => navigator.clipboard.readText());
+
+		const freshContext = await browser.newContext({
+			viewport: { width: 1280, height: 900 },
+		});
+		const newPage = await freshContext.newPage();
+		await newPage.goto(shareUrl);
+		const newContainer = newPage.locator('#tool-layout-container');
+		await expect(newContainer).not.toHaveClass(/max-w-full/);
+		await expect(newContainer).toHaveClass(/max-w-\[800px\]/);
+		await expect(newContainer).toHaveClass(/xl:max-w-5xl/);
+		await freshContext.close();
 	});
 });

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -128,4 +128,30 @@ test.describe('SQL Formatter Tool', () => {
 		);
 		expect(resize).toBe('none');
 	});
+
+	test('restores full-size layout from a shared settings URL', async ({
+		page,
+		context,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+		await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+
+		const container = page.locator('#tool-layout-container');
+		await expect(container).not.toHaveClass(/max-w-full/);
+
+		// Enable full-size mode and copy the share URL
+		await page.getByRole('button', { name: 'フルサイズ' }).click();
+		await expect(container).toHaveClass(/max-w-full/);
+
+		await page.getByRole('button', { name: '設定を共有' }).click();
+		const shareUrl = await page.evaluate(() => navigator.clipboard.readText());
+
+		// Open the shared URL in a fresh page and confirm full-size is restored
+		const newPage = await context.newPage();
+		await newPage.goto(shareUrl);
+		await expect(newPage.locator('#tool-layout-container')).toHaveClass(
+			/max-w-full/,
+		);
+		await newPage.close();
+	});
 });


### PR DESCRIPTION
## Summary

- SQL整形ツールの「フルサイズ」表示状態（`isExpanded`）を `useToolSettings` の `settings` に統合し、他の設定項目（方言・インデント・大文字化・圧縮・自動整形）と同様にURL/localStorage経由で復元・共有できるようにした
- 「設定を共有」ボタンで生成されるURLを開いた際にも、フルサイズ表示のレイアウト幅（`max-w-full`）が正しく反映されるよう `useEffect` を追加

## Changes

- `src/components/tools/SqlFormatter.tsx`
  - ローカルの `useState(false)` による `isExpanded` 管理を廃止し、`settings.isExpanded` に統合
  - `toggleExpand` を `updateSettings` 経由に変更
  - `isExpanded` の変化（マウント時の復元含む）をレイアウトコンテナの幅クラスに反映する `useEffect` を追加
- `tests/e2e/sql-formatter.spec.ts`
  - フルサイズ表示を有効化 → 「設定を共有」でURL生成 → 別ページでそのURLを開いてフルサイズ状態が復元されることを検証するE2Eテストを追加

## Test plan

- [x] `npm run build` が成功することを確認
- [x] `npm run check`（Astro型チェック + Biome）でエラーがないことを確認（既存の無関係なテストファイルの警告のみ）
- [x] `npx playwright test tests/e2e/sql-formatter.spec.ts` の全9件（新規テスト含む）がパスすることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01H1JzdRv8g3RQ1T6H63SASP)_