### PR TITLE
fix(ui): textareaの縦リサイズに視覚ヒントを追加

### DIFF
--- a/src/components/phone-formatter/BulkInput.tsx
+++ b/src/components/phone-formatter/BulkInput.tsx
@@ -7,6 +7,7 @@ import { FileText, Loader2, Upload } from 'lucide-react';
 import Papa from 'papaparse';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
 import { parseCsvColumn, processBulk } from '@/lib/phone-formatter/bulk';
 import type { BulkResult } from '@/lib/phone-formatter/types';
 import { validateCsvFile } from '@/lib/phone-formatter/validation';
@@ -238,11 +239,12 @@ export default function BulkInput({ onBulkResult }: BulkInputProps) {
 			{inputMode === 'text' && (
 				<div className="space-y-2">
 					<div className="relative">
-						<textarea
+						<Textarea
 							value={textValue}
 							onChange={(e) => setTextValue(e.target.value)}
 							placeholder={`1行に1つの電話番号を入力\n03-1234-5678\n090-1234-5678\n+81312345678`}
-							className="w-full min-h-[200px] rounded-lg border border-border bg-background px-4 py-3 text-sm font-mono resize-y focus:outline-none focus:ring-2 focus:ring-ring/20 placeholder:text-muted-foreground"
+							resize="vertical"
+							className="min-h-[200px] rounded-lg border-border bg-background px-4 py-3 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring/20 placeholder:text-muted-foreground"
 							aria-label="電話番号一覧（1行1件）"
 						/>
 						{lineCount > 0 && (

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -109,7 +109,8 @@ export default function UrlEncoder() {
 								? 'https://example.com/検索?q=東京 天気\nまたは\n検索クエリ'
 								: 'https://example.com/%E6%A4%9C%E7%B4%A2?q=%E6%9D%B1%E4%BA%AC%20%E5%A4%A9%E6%B0%97'
 						}
-						className="min-h-[240px] h-full font-mono-tool resize-y rounded-xl focus:ring-2 focus:ring-primary/50 text-base"
+						resize="vertical"
+						className="min-h-[240px] h-full font-mono-tool rounded-xl focus:ring-2 focus:ring-primary/50 text-base"
 					/>
 				</div>
 
@@ -164,7 +165,8 @@ export default function UrlEncoder() {
 						value={textResult.error ? textResult.error : textResult.output}
 						readOnly
 						placeholder="変換結果がここに表示されます..."
-						className={`min-h-[240px] h-full font-mono-tool resize-y rounded-xl bg-muted/30 text-base ${
+						resize="vertical"
+						className={`min-h-[240px] h-full font-mono-tool rounded-xl bg-muted/30 text-base ${
 							textResult.error
 								? 'text-red-500 font-bold border-red-200 bg-red-50 dark:bg-red-950/20'
 								: ''

--- a/src/components/tools/cipher/InputPanel.tsx
+++ b/src/components/tools/cipher/InputPanel.tsx
@@ -26,7 +26,8 @@ export function InputPanel({
 	return (
 		<div className="relative flex flex-col h-full min-h-[200px]">
 			<Textarea
-				className="flex-1 font-mono resize-y p-4 text-base"
+				resize="vertical"
+				className="flex-1 font-mono p-4 text-base"
 				placeholder={placeholders[algorithm]}
 				value={value}
 				onChange={(e) => onChange(e.target.value)}

--- a/src/components/tools/cipher/OutputPanel.tsx
+++ b/src/components/tools/cipher/OutputPanel.tsx
@@ -9,7 +9,8 @@ export function OutputPanel({ value }: OutputPanelProps) {
 	return (
 		<div className="relative flex flex-col h-full min-h-[200px]">
 			<Textarea
-				className="flex-1 font-mono resize-y p-4 text-base bg-muted/50 transition-opacity duration-200"
+				resize="vertical"
+				className="flex-1 font-mono p-4 text-base bg-muted/50 transition-opacity duration-200"
 				style={{ opacity: value ? 1 : 0.7 }}
 				readOnly
 				placeholder="変換結果がここに表示されます"

--- a/src/components/tools/markdown/MarkdownPreviewPage.tsx
+++ b/src/components/tools/markdown/MarkdownPreviewPage.tsx
@@ -217,7 +217,8 @@ function MarkdownEditor({
 			value={value}
 			onChange={(e) => onChange(e.target.value)}
 			placeholder="# 見出し&#10;&#10;Markdownを入力すると右側にプレビューが表示されます。"
-			className="min-h-96 font-mono text-sm resize-y"
+			resize="vertical"
+			className="min-h-96 font-mono text-sm"
 			aria-label="Markdown入力"
 		/>
 	);

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,3 +1,4 @@
+import { MoveDiagonal2 } from 'lucide-react';
 import type * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -13,11 +14,14 @@ const resizeClasses: Record<TextareaResize, string> = {
 function Textarea({
 	className,
 	resize,
+	disabled,
 	...props
 }: React.ComponentProps<'textarea'> & { resize?: TextareaResize }) {
-	return (
+	const textareaEl = (
 		<textarea
 			data-slot="textarea"
+			data-resize={resize}
+			disabled={disabled}
 			className={cn(
 				'border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
 				resize && resizeClasses[resize],
@@ -25,6 +29,26 @@ function Textarea({
 			)}
 			{...props}
 		/>
+	);
+
+	// vertical以外（none／未指定）はグリップ用ラッパーを生成しない
+	if (resize !== 'vertical') {
+		return textareaEl;
+	}
+
+	return (
+		<div className="group/textarea relative flex min-h-0 w-full flex-1">
+			{textareaEl}
+			{!disabled && (
+				<span
+					aria-hidden="true"
+					data-slot="textarea-resize-handle"
+					className="pointer-events-none absolute bottom-1 right-1 hidden cursor-ns-resize items-center justify-center text-muted-foreground/50 transition-colors duration-150 motion-reduce:transition-none md:flex md:group-hover/textarea:text-muted-foreground md:group-focus-within/textarea:text-muted-foreground"
+				>
+					<MoveDiagonal2 className="h-3.5 w-3.5" />
+				</span>
+			)}
+		</div>
 	);
 }
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -117,6 +117,11 @@
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
     }
+
+    /* 縦リサイズ可能なtextareaのWebKit標準グリップは、独自グリップアイコンと重ならないよう配色のみ調整する */
+    textarea[data-resize='vertical']::-webkit-resizer {
+        background-color: transparent;
+    }
 }
 
 /* ===== Custom Utilities ===== */

--- a/tests/e2e/textarea-resize-affordance.spec.ts
+++ b/tests/e2e/textarea-resize-affordance.spec.ts
@@ -1,0 +1,123 @@
+import { expect, test } from './fixtures/base';
+
+const GRIP_SELECTOR = '[data-slot="textarea-resize-handle"]';
+const DESKTOP_VIEWPORT = { width: 1280, height: 900 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+test.describe('textareaのリサイズ視覚ヒント（グリップ）', () => {
+	test('resize="vertical"のtextareaはデスクトップでグリップが常時表示される', async ({
+		createToolPage,
+		page,
+	}) => {
+		await page.setViewportSize(DESKTOP_VIEWPORT);
+		const toolPage = createToolPage('sql-formatter');
+		await toolPage.goto();
+
+		const textarea = page.locator('textarea[data-resize="vertical"]').first();
+		await expect(textarea).toHaveCount(1);
+
+		const grip = page.locator(GRIP_SELECTOR).first();
+		await expect(grip).toBeVisible();
+	});
+
+	test('resize="vertical"のtextareaはモバイル幅ではグリップが非表示になる', async ({
+		createToolPage,
+		page,
+	}) => {
+		await page.setViewportSize(MOBILE_VIEWPORT);
+		const toolPage = createToolPage('sql-formatter');
+		await toolPage.goto();
+
+		const grip = page.locator(GRIP_SELECTOR).first();
+		await expect(grip).toBeHidden();
+	});
+
+	test('resizeプロパティを指定しないtextareaにはグリップが描画されない', async ({
+		createToolPage,
+		page,
+	}) => {
+		await page.setViewportSize(DESKTOP_VIEWPORT);
+		const toolPage = createToolPage('char-count');
+		await toolPage.goto();
+
+		await expect(page.locator(GRIP_SELECTOR)).toHaveCount(0);
+	});
+
+	test('グリップ付近からドラッグすると従来どおり縦方向にリサイズできる', async ({
+		createToolPage,
+		page,
+	}) => {
+		await page.setViewportSize(DESKTOP_VIEWPORT);
+		const toolPage = createToolPage('text-diff');
+		await toolPage.goto();
+
+		const textarea = page.locator('#text-diff-textarea-a');
+		const before = await textarea.evaluate((el) => el.getBoundingClientRect());
+
+		const box = await textarea.boundingBox();
+		if (!box) throw new Error('textarea bounding box not found');
+
+		// ネイティブのリサイズグリップは右下角の数px四方にあるため、その付近からドラッグする
+		const startX = box.x + box.width - 3;
+		const startY = box.y + box.height - 3;
+
+		await page.mouse.move(startX, startY);
+		await page.mouse.down();
+		await page.mouse.move(startX, startY + 120, { steps: 10 });
+		await page.mouse.up();
+
+		const after = await textarea.evaluate((el) => el.getBoundingClientRect());
+		expect(after.height).toBeGreaterThan(before.height);
+	});
+
+	test.describe('resize-y直書きから共通Textareaへ移行した箇所でもグリップが表示される', () => {
+		test('URLエンコーダー', async ({ createToolPage, page }) => {
+			await page.setViewportSize(DESKTOP_VIEWPORT);
+			const toolPage = createToolPage('url-encoder');
+			await toolPage.goto();
+
+			await expect(page.locator(GRIP_SELECTOR).first()).toBeVisible();
+		});
+
+		test('Markdownプレビュー', async ({ createToolPage, page }) => {
+			await page.setViewportSize(DESKTOP_VIEWPORT);
+			const toolPage = createToolPage('markdown');
+			await toolPage.goto();
+
+			await expect(page.locator(GRIP_SELECTOR).first()).toBeVisible();
+		});
+
+		test('暗号化ツール（入力・出力）', async ({ createToolPage, page }) => {
+			await page.setViewportSize(DESKTOP_VIEWPORT);
+			const toolPage = createToolPage('cipher');
+			await toolPage.goto();
+
+			await expect(page.locator(GRIP_SELECTOR)).toHaveCount(2);
+		});
+
+		test('電話番号一括入力', async ({ createToolPage, page }) => {
+			await page.setViewportSize(DESKTOP_VIEWPORT);
+			const toolPage = createToolPage('phone-formatter');
+			await toolPage.goto();
+			await page.getByRole('tab', { name: '一括入力' }).click();
+
+			await expect(page.locator(GRIP_SELECTOR).first()).toBeVisible();
+		});
+	});
+
+	test('TextDiffの2つのtextareaはラッパー導入後も高さが揃う（レイアウト回帰なし）', async ({
+		createToolPage,
+		page,
+	}) => {
+		await page.setViewportSize(DESKTOP_VIEWPORT);
+		const toolPage = createToolPage('text-diff');
+		await toolPage.goto();
+
+		const boxA = await page.locator('#text-diff-textarea-a').boundingBox();
+		const boxB = await page.locator('#text-diff-textarea-b').boundingBox();
+		expect(boxA).not.toBeNull();
+		expect(boxB).not.toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: 直前でnullチェック済み
+		expect(boxA!.height).toBe(boxB!.height);
+	});
+});


### PR DESCRIPTION
## 課題・根本原因

縦リサイズ可能なtextareaが、ブラウザ標準のリサイズグリップ（右下数px角）のみに依存しており、リサイズできることがユーザーに伝わらない問題（Notionタスク「textareaのサイズ可変UIが分かりづらい問題」）。

- 共通 `Textarea`（`src/components/ui/textarea.tsx`）の `resize="vertical"` は `md:resize-y` を付与するのみで、視覚的ヒント（アイコン・ツールチップ等）が一切なかった。
- `resize-y` を直書きしている5箇所は共通コンポーネントを経由していなかった。

## 解決策と設計判断

ブラウザ標準の縦リサイズ機能は維持し、その上に独立した視覚ヒント（グリップアイコン）を追加した。

- `resize="vertical"` のときのみ、textareaを `relative` なラッパーで囲み、右下に `pointer-events-none` のグリップアイコン（`MoveDiagonal2`、lucide-react）を配置。ネイティブのリサイズ操作を一切妨げない。
- **W1**: アイコンをネイティブグリップと同じ右下角（`bottom-1 right-1`）に重ね、`cursor-ns-resize` を付与して操作対象を示す。
- **W2**: 今回の対象コンポーネントに独自のシンタックスハイライトオーバーレイ（SQLフォーマッター含む）は存在しなかったため、パディング整合の対応は不要だった（入力欄はプレーンなtextareaで、ハイライトはCodeBlockによる読み取り専用の出力側のみ）。
- **W3**: ラッパー導入によるflex/grid内でのレイアウト回帰を防ぐため、ラッパー自身にも `flex flex-1 min-h-0` を付与し、`h-full`/`flex-1` 等の高さ継承チェーンが壊れないようにした。TextDiff・SQLフォーマッター・UrlEncoderで検証済み（後述テスト）。
- 表示状態: 通常＝低コントラスト常時表示、ホバー／フォーカス（`group-hover`/`group-focus-within`）＝強調、disabled・`resize="none"`・`md`未満＝非表示。
- `transition-colors` は `motion-reduce:transition-none` でアニメーションを無効化（I3）。
- `::-webkit-resizer` はWebKit系ブラウザの既定グリップ色を透過にする微調整のみに限定（`global.css`）。
- `data-resize` 属性をテスト用セレクタとして付与（I1）。

## 変更ファイル

- `src/components/ui/textarea.tsx`: グリップ表示ロジックを追加（既存API `resize?: 'none' | 'vertical'` は変更なし）
- `src/styles/global.css`: `::-webkit-resizer` の配色微調整
- `src/components/tools/UrlEncoder.tsx`, `src/components/tools/markdown/MarkdownPreviewPage.tsx`, `src/components/tools/cipher/InputPanel.tsx`, `src/components/tools/cipher/OutputPanel.tsx`: `resize-y` 直書きを `resize="vertical"` へ移行
- `src/components/phone-formatter/BulkInput.tsx`: 生の `<textarea>` を共通 `Textarea` コンポーネントへ移行
- `tests/e2e/textarea-resize-affordance.spec.ts`: グリップ表示条件のE2Eテストを新規追加

直書き5箇所すべてを共通コンポーネントへ移行済み（I4の残件なし）。SQLフォーマッター・TextDiff・RegexTester・Masking・JsonFormatterは既に `resize="vertical"` を使用していたため、共通コンポーネント修正のみで自動的にグリップが反映される（追加のコード変更不要）。

## 自動検証済み項目

このリポジトリには React コンポーネントテストの基盤（jsdom/testing-library等）が存在せず、`development-guide.md` でも未宣言の外部テストフレームワーク導入が禁止されているため、コンポーネントテストは既存のPlaywright（E2E）基盤で代替した。

- [x] `resize="vertical"` のときのみグリップが描画される（SQLフォーマッター、URLエンコーダー、Markdown、暗号化ツール、電話番号一括入力で確認）
- [x] `resize` 未指定のtextareaにはグリップが描画されない（文字数カウントツールで確認）
- [x] `md` 未満（モバイル幅）ではグリップが非表示になる
- [x] グリップ付近からのドラッグで従来どおり縦方向にリサイズできる（実際のマウスドラッグでtextareaの高さが増加することを確認）
- [x] TextDiffの2ペインでラッパー導入後も高さが揃う（レイアウト回帰なし）
- [x] `ref`・属性・イベントのtextareaへのフォワード（既存の各ツールE2Eテストが引き続き全てパスすることで間接的に確認。value/onChange/onScroll/onDrop等が正しく機能）
- [x] `npm run lint`、`npm run check`（astro check + biome）、`npm run test:unit`（638件）、影響範囲のE2E（61件 + 新規9件、計70件）すべて通過
- [x] `npm run build` 成功

disabled状態でのグリップ非表示はコード実装・レビューで確認したが、現時点でこのリポジトリ内に `disabled` な `Textarea` の実使用箇所が存在しないため、E2Eでの実機検証はできていない（要人間確認に含む）。

## 要人間確認チェックリスト（未実施・マージ前に確認が必要）

- [ ] Chrome／Safari／Firefox実機でのドラッグ操作
- [ ] ライト／ダークテーマでのグリップのコントラスト
- [ ] 200%ズームでのグリップの欠け・本文との重なり
- [ ] `prefers-reduced-motion` 設定時にアニメーションが無効化されること
- [ ] SQLフォーマッターの入力・選択・スクロール・ハイライト同期の目視確認
- [ ] TextDiff等flex/grid・高さ揃えレイアウトの目視確認（自動テストでは高さ一致のみ確認、崩れの目視は未実施）
- [ ] cipher/InputPanelの文字数カウント表示（`bottom-2 right-4`）とグリップ（`bottom-1 right-1`）の視覚的な近接・重なりの確認
- [ ] disabled状態のTextareaでグリップが表示されないことの実機確認（現状disabled使用箇所なし）

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QfGsHt44CUDnWYBRoYTvaD)_