### PR TITLE
feat: add resizable and vertical layouts to SQL formatter

### DIFF
--- a/src/components/common/CodeBlock.tsx
+++ b/src/components/common/CodeBlock.tsx
@@ -1,3 +1,4 @@
+import { MoveDiagonal2 } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/lib/utils';
 
@@ -16,6 +17,10 @@ interface CodeBlockProps {
 	highlightLines?: Set<number>;
 	/** 最小高さ */
 	minHeight?: string;
+	/** 最大高さ(resize="vertical" と併用してリサイズ上限を設定する) */
+	maxHeight?: string;
+	/** デスクトップ幅で縦方向にリサイズ可能にする */
+	resize?: 'vertical';
 }
 
 export default function CodeBlock({
@@ -26,6 +31,8 @@ export default function CodeBlock({
 	showLineNumbers = true,
 	highlightLines,
 	minHeight = '200px',
+	maxHeight,
+	resize,
 }: CodeBlockProps) {
 	const contentRef = useRef<HTMLPreElement>(null);
 	const gutterRef = useRef<HTMLDivElement>(null);
@@ -47,10 +54,13 @@ export default function CodeBlock({
 	return (
 		<div
 			className={cn(
-				'flex rounded-xl border border-border bg-card overflow-hidden font-mono-tool text-sm',
+				'group/codeblock relative flex rounded-xl border border-border bg-card font-mono-tool text-sm',
+				resize === 'vertical'
+					? 'resize-none md:resize-y overflow-auto'
+					: 'overflow-hidden',
 				className,
 			)}
-			style={{ minHeight }}
+			style={{ minHeight, ...(maxHeight ? { maxHeight } : {}) }}
 		>
 			{/* 行番号ガター */}
 			{showLineNumbers && (
@@ -91,6 +101,15 @@ export default function CodeBlock({
 					<code>{content}</code>
 				)}
 			</pre>
+			{resize === 'vertical' && (
+				<span
+					aria-hidden="true"
+					data-slot="codeblock-resize-handle"
+					className="pointer-events-none absolute bottom-1 right-1 hidden items-center justify-center text-muted-foreground/50 transition-colors duration-150 motion-reduce:transition-none md:flex md:group-hover/codeblock:text-muted-foreground md:group-focus-within/codeblock:text-muted-foreground"
+				>
+					<MoveDiagonal2 className="h-3.5 w-3.5" />
+				</span>
+			)}
 		</div>
 	);
 }

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -1,8 +1,10 @@
 import {
 	Code2,
+	Columns2,
 	Download,
 	Maximize2,
 	Minimize2,
+	Rows2,
 	Share2,
 	Trash2,
 } from 'lucide-react';
@@ -20,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -28,6 +31,7 @@ import {
 	type SqlDialect,
 	type SqlFormatOptions,
 } from '@/lib/tools/sql-formatter';
+import { cn } from '@/lib/utils';
 
 const SQL_KEYWORDS = [
 	'SELECT',
@@ -85,10 +89,22 @@ export default function SqlFormatter() {
 			uppercase: true,
 			compress: false,
 			isExpanded: false,
+			layout: 'horizontal' as 'horizontal' | 'vertical',
 		},
 	);
 	const { autoFormat, dialect, indent, uppercase, compress, isExpanded } =
 		settings;
+	// 不正値や旧形式の共有設定を受け取った場合は左右レイアウトへ安全にフォールバックする
+	const layout: 'horizontal' | 'vertical' =
+		settings.layout === 'vertical' ? 'vertical' : 'horizontal';
+	const setLayout = useCallback(
+		(value: string) => {
+			if (value === 'horizontal' || value === 'vertical') {
+				updateSettings({ layout: value });
+			}
+		},
+		[updateSettings],
+	);
 	const [shareCopied, setShareCopied] = useState(false);
 
 	const [manualOutput, setManualOutput] = useState('');
@@ -356,6 +372,30 @@ export default function SqlFormatter() {
 
 					<div className="w-px h-6 bg-border mx-2 hidden sm:block"></div>
 
+					<ToggleGroup
+						type="single"
+						value={layout}
+						onValueChange={setLayout}
+						aria-label="入力・出力のレイアウト"
+						variant="outline"
+						className="hidden sm:flex"
+					>
+						<ToggleGroupItem
+							value="horizontal"
+							aria-label="左右に並べて表示"
+							title="左右レイアウト"
+						>
+							<Columns2 className="h-4 w-4" />
+						</ToggleGroupItem>
+						<ToggleGroupItem
+							value="vertical"
+							aria-label="上下に並べて表示"
+							title="上下レイアウト"
+						>
+							<Rows2 className="h-4 w-4" />
+						</ToggleGroupItem>
+					</ToggleGroup>
+
 					<Button
 						variant="outline"
 						size="sm"
@@ -412,7 +452,13 @@ export default function SqlFormatter() {
 				</Button>
 			</div>
 
-			<div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
+			<div
+				id="sql-formatter-panels"
+				className={cn(
+					'grid grid-cols-1 gap-6 items-start',
+					layout === 'horizontal' && 'lg:grid-cols-2',
+				)}
+			>
 				{/* Input */}
 				<div>
 					<div className="flex items-center justify-between mb-2">
@@ -487,7 +533,7 @@ export default function SqlFormatter() {
 						</div>
 					</div>
 					{error ? (
-						<div className="rounded-xl border-2 border-red-500 shadow-sm h-[400px] overflow-auto bg-card">
+						<div className="rounded-xl border-2 border-red-500 shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card">
 							<div className="p-4 text-red-500 font-medium font-mono-tool text-sm whitespace-pre-wrap flex items-start gap-2 max-w-full">
 								<Code2 className="h-5 w-5 mt-0.5 flex-shrink-0" />
 								<div className="break-all">{error}</div>
@@ -497,12 +543,14 @@ export default function SqlFormatter() {
 						<CodeBlock
 							content={output}
 							className="h-[400px] shimmer"
-							minHeight="400px"
+							minHeight="240px"
+							maxHeight="80dvh"
+							resize="vertical"
 						>
 							{highlightedNodes}
 						</CodeBlock>
 					) : (
-						<div className="rounded-xl border shadow-sm h-[400px] overflow-auto bg-card flex items-center justify-center text-muted-foreground p-6 text-center">
+						<div className="rounded-xl border shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card flex items-center justify-center text-muted-foreground p-6 text-center">
 							<div>
 								<Code2 className="h-10 w-10 mx-auto mb-3 opacity-20" />
 								<p className="text-sm">

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -4,6 +4,7 @@ import {
 	Download,
 	Maximize2,
 	Minimize2,
+	MoveDiagonal2,
 	Rows2,
 	Share2,
 	Trash2,
@@ -533,11 +534,17 @@ export default function SqlFormatter() {
 						</div>
 					</div>
 					{error ? (
-						<div className="rounded-xl border-2 border-red-500 shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card">
+						<div className="group/codeblock relative rounded-xl border-2 border-red-500 shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card">
 							<div className="p-4 text-red-500 font-medium font-mono-tool text-sm whitespace-pre-wrap flex items-start gap-2 max-w-full">
 								<Code2 className="h-5 w-5 mt-0.5 flex-shrink-0" />
 								<div className="break-all">{error}</div>
 							</div>
+							<span
+								aria-hidden="true"
+								className="pointer-events-none absolute bottom-1 right-1 hidden items-center justify-center text-muted-foreground/50 transition-colors duration-150 motion-reduce:transition-none md:flex md:group-hover/codeblock:text-muted-foreground md:group-focus-within/codeblock:text-muted-foreground"
+							>
+								<MoveDiagonal2 className="h-3.5 w-3.5" />
+							</span>
 						</div>
 					) : output && (autoFormat || manualOutput) ? (
 						<CodeBlock
@@ -550,7 +557,7 @@ export default function SqlFormatter() {
 							{highlightedNodes}
 						</CodeBlock>
 					) : (
-						<div className="rounded-xl border shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card flex items-center justify-center text-muted-foreground p-6 text-center">
+						<div className="group/codeblock relative rounded-xl border shadow-sm h-[400px] min-h-[240px] max-h-[80dvh] resize-none md:resize-y overflow-auto bg-card flex items-center justify-center text-muted-foreground p-6 text-center">
 							<div>
 								<Code2 className="h-10 w-10 mx-auto mb-3 opacity-20" />
 								<p className="text-sm">
@@ -559,6 +566,12 @@ export default function SqlFormatter() {
 									整形されたコードが表示されます
 								</p>
 							</div>
+							<span
+								aria-hidden="true"
+								className="pointer-events-none absolute bottom-1 right-1 hidden items-center justify-center text-muted-foreground/50 transition-colors duration-150 motion-reduce:transition-none md:flex md:group-hover/codeblock:text-muted-foreground md:group-focus-within/codeblock:text-muted-foreground"
+							>
+								<MoveDiagonal2 className="h-3.5 w-3.5" />
+							</span>
 						</div>
 					)}
 				</div>

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -1,0 +1,62 @@
+import type { VariantProps } from 'class-variance-authority';
+import { ToggleGroup as ToggleGroupPrimitive } from 'radix-ui';
+import type * as React from 'react';
+import { createContext, useContext } from 'react';
+
+import { toggleVariants } from '@/components/ui/toggle';
+import { cn } from '@/lib/utils';
+
+const ToggleGroupContext = createContext<VariantProps<typeof toggleVariants>>({
+	size: 'default',
+	variant: 'default',
+});
+
+function ToggleGroup({
+	className,
+	variant,
+	size,
+	children,
+	...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Root> &
+	VariantProps<typeof toggleVariants>) {
+	return (
+		<ToggleGroupPrimitive.Root
+			data-slot="toggle-group"
+			className={cn('flex items-center gap-1', className)}
+			{...props}
+		>
+			<ToggleGroupContext.Provider value={{ variant, size }}>
+				{children}
+			</ToggleGroupContext.Provider>
+		</ToggleGroupPrimitive.Root>
+	);
+}
+
+function ToggleGroupItem({
+	className,
+	children,
+	variant,
+	size,
+	...props
+}: React.ComponentProps<typeof ToggleGroupPrimitive.Item> &
+	VariantProps<typeof toggleVariants>) {
+	const context = useContext(ToggleGroupContext);
+
+	return (
+		<ToggleGroupPrimitive.Item
+			data-slot="toggle-group-item"
+			className={cn(
+				toggleVariants({
+					variant: context.variant || variant,
+					size: context.size || size,
+				}),
+				className,
+			)}
+			{...props}
+		>
+			{children}
+		</ToggleGroupPrimitive.Item>
+	);
+}
+
+export { ToggleGroup, ToggleGroupItem };

--- a/tests/e2e/sql-formatter.spec.ts
+++ b/tests/e2e/sql-formatter.spec.ts
@@ -184,3 +184,169 @@ test.describe('SQL Formatter Tool', () => {
 		await freshContext.close();
 	});
 });
+
+test.describe('SQL Formatter Tool - レイアウト切替と出力欄リサイズ', () => {
+	test.beforeEach(async ({ createToolPage }) => {
+		const toolPage = createToolPage('sql-formatter');
+		await toolPage.goto();
+	});
+
+	test('初期状態は左右レイアウトで、左右トグルが選択されている', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		const panels = page.locator('#sql-formatter-panels');
+		await expect(panels).toHaveClass(/lg:grid-cols-2/);
+		await expect(
+			page.getByRole('radio', { name: '左右に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'true');
+		await expect(
+			page.getByRole('radio', { name: '上下に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'false');
+	});
+
+	test('上下レイアウトに切り替えると入力・出力が全幅で縦に並ぶ', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		await page.getByRole('radio', { name: '上下に並べて表示' }).click();
+		await page.locator('textarea').fill('select id from users');
+		await expect(page.locator('.shimmer code')).toBeVisible();
+
+		const panels = page.locator('#sql-formatter-panels');
+		await expect(panels).not.toHaveClass(/lg:grid-cols-2/);
+		await expect(
+			page.getByRole('radio', { name: '上下に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'true');
+
+		const panelColumns = page.locator('#sql-formatter-panels > div');
+		const inputColumnBox = await panelColumns.nth(0).boundingBox();
+		const outputColumnBox = await panelColumns.nth(1).boundingBox();
+		expect(inputColumnBox).not.toBeNull();
+		expect(outputColumnBox).not.toBeNull();
+		// biome-ignore lint/style/noNonNullAssertion: 直前でnullチェック済み
+		const widthDiff = Math.abs(inputColumnBox!.width - outputColumnBox!.width);
+		expect(widthDiff).toBeLessThan(2);
+
+		// 左右レイアウトへ戻せる
+		await page.getByRole('radio', { name: '左右に並べて表示' }).click();
+		await expect(panels).toHaveClass(/lg:grid-cols-2/);
+	});
+
+	test('標準表示⇔フルサイズ表示を切り替えてもレイアウト選択が維持される', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		await page.getByRole('radio', { name: '上下に並べて表示' }).click();
+		await page.getByRole('button', { name: 'フルサイズ' }).click();
+
+		const panels = page.locator('#sql-formatter-panels');
+		await expect(panels).not.toHaveClass(/lg:grid-cols-2/);
+		await expect(
+			page.getByRole('radio', { name: '上下に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'true');
+
+		await page.getByRole('button', { name: '標準幅' }).click();
+		await expect(panels).not.toHaveClass(/lg:grid-cols-2/);
+		await expect(
+			page.getByRole('radio', { name: '上下に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'true');
+	});
+
+	test('狭い画面ではレイアウト切替を表示せず、常に縦積みでページの横スクロールが発生しない', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+
+		await expect(
+			page.getByRole('radio', { name: '左右に並べて表示' }),
+		).toBeHidden();
+
+		await page
+			.locator('textarea')
+			.fill(
+				'select a_very_long_column_name_that_could_overflow, another_long_identifier_name from a_table_with_a_long_name',
+			);
+		await expect(page.locator('.shimmer code')).toBeVisible();
+
+		// 数px程度の誤差はスクロールバー計算のブラウザ差異として許容する
+		const overflow = await page.evaluate(
+			() =>
+				document.documentElement.scrollWidth -
+				document.documentElement.clientWidth,
+		);
+		expect(overflow).toBeLessThanOrEqual(5);
+	});
+
+	test('不正なレイアウト設定値を共有URLから読み込んでも左右レイアウトへフォールバックする', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		const invalidSettingsUrl = await page.evaluate(() => {
+			const encoded = btoa(
+				unescape(encodeURIComponent(JSON.stringify({ layout: 'diagonal' }))),
+			);
+			const url = new URL(window.location.href);
+			url.searchParams.set('settings', encoded);
+			return url.toString();
+		});
+
+		await page.goto(invalidSettingsUrl);
+
+		const panels = page.locator('#sql-formatter-panels');
+		await expect(panels).toHaveClass(/lg:grid-cols-2/);
+		await expect(
+			page.getByRole('radio', { name: '左右に並べて表示' }),
+		).toHaveAttribute('aria-checked', 'true');
+	});
+
+	test('出力欄はデスクトップで縦方向にリサイズでき、最小値・最大値の範囲を持つ', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		await page.locator('textarea').fill('select id from users');
+		await expect(page.locator('.shimmer code')).toBeVisible();
+
+		const outputBox = page.locator('.shimmer');
+		const style = await outputBox.evaluate((el) => {
+			const computed = getComputedStyle(el);
+			return {
+				resize: computed.resize,
+				minHeight: computed.minHeight,
+				maxHeight: computed.maxHeight,
+			};
+		});
+
+		expect(style.resize).toBe('vertical');
+		expect(style.minHeight).toBe('240px');
+		// 80dvh はビューポート高さ 900px の80% = 720px
+		expect(style.maxHeight).toBe('720px');
+
+		await expect(
+			page.locator('[data-slot="codeblock-resize-handle"]'),
+		).toBeVisible();
+	});
+
+	test('出力欄はモバイル幅ではリサイズもグリップも無効になる', async ({
+		page,
+	}) => {
+		await page.setViewportSize({ width: 390, height: 844 });
+
+		await page.locator('textarea').fill('select id from users');
+		await expect(page.locator('.shimmer code')).toBeVisible();
+
+		const resize = await page
+			.locator('.shimmer')
+			.evaluate((el) => getComputedStyle(el).resize);
+		expect(resize).toBe('none');
+
+		await expect(
+			page.locator('[data-slot="codeblock-resize-handle"]'),
+		).toBeHidden();
+	});
+});


### PR DESCRIPTION
## 課題の要約
SQL整形ツールは整形後SQLの表示領域が固定サイズで、長いSQLや横に長いフィールド名を確認しづらかった。また入力・出力が左右配置のみで、十分な横幅を割り当てられなかった。

## 採用した設計判断
- **出力欄のリサイズ**: 既存の `Textarea` コンポーネントが持つ `resize="vertical"` 規約（デスクトップのみ・`min-h-[240px]`/`max-h-[80dvh]`・グリップアイコンの視覚ヒント）を、共通 `CodeBlock` コンポーネントにも同じ形で追加した。ネイティブCSSの `resize` プロパティを使うことで、JSでのドラッグ処理を自前実装せず既存の慣習を再利用している。
  - 代替案として「JSでドラッグ処理を自作する」ことも検討したが、入力欄と挙動・見た目が異なってしまうため不採用。
- **レイアウト切替**: `radix-ui` の `ToggleGroup`（type="single"）をラップした `ToggleGroup` UIコンポーネントを新規追加し、「左右」「上下」をアイコンボタンで切り替えられるようにした。`role="radio"` + `aria-checked` により、アイコンのみでもアクセシブルな相互排他コントロールになる。
  - 代替案として既存の `Tabs` コンポーネント流用も検討したが、`Tabs` は「表示中のパネルを切り替える」意味論（`role="tablist"`）であり、常に両方表示されたままレイアウトだけ変わる本機能には意味的に合わないため不採用。
- **状態管理**: レイアウト値は既存の `useToolSettings`（localStorage・共有URLと統合）にキー追加する形で管理し、独自の永続化機構は追加していない。不正/未知の値は描画時に `horizontal` へ安全にフォールバックする（永続化データ自体は書き換えない）。
- **レスポンシブ**: モバイル幅ではレイアウト切替コントロール自体を非表示にし、既存の `grid-cols-1 lg:grid-cols-2` の仕組みをそのまま利用して縦積みにフォールバックする（`vertical` 設定時は常に `grid-cols-1`）。

## 変更ファイル一覧と役割
- `src/components/ui/toggle-group.tsx`（新規）: radix-uiのToggleGroupをラップしたshadcn/ui流の共通コンポーネント。
- `src/components/common/CodeBlock.tsx`: `resize` / `maxHeight` プロップを追加し、デスクトップでの縦方向リサイズとグリップ表示に対応（`resize` 未指定時は既存挙動のまま。JsonFormatterなど他の呼び出し元に影響なし）。
- `src/components/tools/SqlFormatter.tsx`: レイアウト状態（`horizontal`/`vertical`）の追加、ToggleGroupによる切替UI、出力欄（CodeBlock/エラー表示/プレースホルダー）のリサイズ対応、グリッドレイアウトの動的切替。
- `tests/e2e/sql-formatter.spec.ts`: レイアウト初期値・切替・全幅表示・標準/フルサイズ間での維持・モバイルフォールバック・不正値フォールバック・出力欄リサイズのE2Eテストを追加。

## 実行した自動検証コマンドと結果
- `npm run lint` → 既存のwarning（本変更と無関係な既存ファイル由来）のみ、error 0件
- `npm run check`（astro check + biome check）→ error 0件
- `npm run build` → 成功
- `npm run test:unit` → 708 tests pass（既存のみ、本機能はロジック変更なしのため新規単体テストなし）
- `npm test` 相当として `npx playwright test tests/e2e/sql-formatter.spec.ts tests/e2e/json-formatter.spec.ts tests/e2e/textarea-resize-affordance.spec.ts`（chromium/mobile-chrome）→ 64 tests pass（既存10件＋新規7件を含む）

## 要人間確認（詳細設計書 8. 人間確認対象）
- [ ] リサイズハンドルの発見性とドラッグ操作に違和感がない
- [ ] 長いフィールド名を含むSQLが上下配置で確認しやすい
- [ ] 標準幅・フルサイズ表示の双方でレイアウトが破綻しない
- [ ] ライト／ダークテーマでコントロールと境界が判別できる
- [ ] キーボード操作、フォーカス表示、スクリーンリーダー向けラベルが適切
- [ ] ブラウザズーム200%でも主要操作が利用できる

## 残件・既知の制約
- レイアウトの ToggleGroup 自体は `sm`（640px）以上で表示されるが、実際にグリッドが2カラムになるのは `lg`（1024px）以上のため、640〜1023px幅では切替操作をしてもグリッド自体は変化しない（既存の「フルサイズ」ボタンと同じ表示閾値の慣習に合わせた）。UI/UX上の違和感がないか要人間確認。
- 出力欄のリサイズ高さはブラウザネイティブの `resize` によるセッション中のみの保持であり、入力欄のリサイズと同様に永続化・共有URLへの反映は行っていない（詳細設計書6の「既存の永続化方式がある場合のみ」に基づき、既存の入力欄リサイズと同じ扱いとした）。


---
_Generated by [Claude Code](https://claude.ai/code/session_011J8VbdHUMSSHEZNT26PMzT)_