### PR TITLE
fix(transcribe): 配信検証スクリプトをエッジ圧縮に対応させる

### DIFF
--- a/scripts/verify-transcribe-delivery.mjs
+++ b/scripts/verify-transcribe-delivery.mjs
@@ -97,7 +97,13 @@ for (const target of targets) {
 	const problems = [];
 	let head;
 	try {
-		head = await fetch(target.url, { method: 'HEAD', redirect: 'manual' });
+		head = await fetch(target.url, {
+			method: 'HEAD',
+			redirect: 'manual',
+			// 圧縮されると Content-Length が実体サイズと合わなくなる（Cloudflare は
+			// HEAD で 0 や欠落を返すことがある）。素のサイズを見るため identity を要求する。
+			headers: { 'Accept-Encoding': 'identity' },
+		});
 	} catch (error) {
 		failures.push(`${target.label}: HEAD 失敗 ${String(error)}`);
 		console.log(`  NG   ${target.label}`);
@@ -106,11 +112,18 @@ for (const target of targets) {
 
 	if (head.status !== 200) problems.push(`status=${head.status}`);
 
-	const length = Number(head.headers.get('content-length'));
-	if (!Number.isFinite(length)) {
-		problems.push('Content-Length なし');
-	} else if (length !== target.bytes) {
-		problems.push(`Content-Length=${length} 期待=${target.bytes}`);
+	const rawLength = head.headers.get('content-length');
+	let lengthVerified = false;
+	if (rawLength === null || rawLength === '' || rawLength === '0') {
+		// Pages の静的配信は圧縮・チャンク転送で Content-Length を返さないことがある。
+		// その場合は SHA-256 照合（実体を GET する）でサイズも確認する。
+		if (!target.sha) {
+			problems.push('Content-Length なし（SHA-256 照合の対象外）');
+		}
+	} else if (Number(rawLength) !== target.bytes) {
+		problems.push(`Content-Length=${rawLength} 期待=${target.bytes}`);
+	} else {
+		lengthVerified = true;
 	}
 
 	const contentType = head.headers.get('content-type') ?? '';
@@ -146,7 +159,12 @@ for (const target of targets) {
 		failures.push(`${target.label}: ${problems.join(' / ')}`);
 		console.log(`  NG   ${target.label} — ${problems.join(' / ')}`);
 	} else {
-		console.log(`  OK   ${target.label}${target.sha ? ' (sha256)' : ''}`);
+		const how = target.sha
+			? 'sha256'
+			: lengthVerified
+				? 'content-length'
+				: 'headers';
+		console.log(`  OK   ${target.label} (${how})`);
 	}
 }
 


### PR DESCRIPTION
#256 マージ後の追随修正です。`scripts/verify-transcribe-delivery.mjs` のみを変更します。

## 課題

Phase A2 の本番検証で `npm run transcribe:verify` を実行したところ、31 件中 19 件が `Content-Length=0 期待=...` で NG になりました。

調べたところ**配信側は正常**で、検証スクリプト側の問題でした。

- undici（Node の `fetch`）は既定で `Accept-Encoding: gzip, deflate` を送る
- Cloudflare が JSON などを圧縮すると、HEAD レスポンスの `Content-Length` が 0 または欠落する
- 非圧縮の `.onnx`（`application/octet-stream`）だけが正しい値を返していたため、JSON と `/vendor/` の WASM だけが NG になっていた

`curl -I` では正しい値が返っていたことから切り分けました。

```
$ curl -sI https://tools.codelife.cafe/models/transcribe/whisper-tiny/<revision>/config.json
HTTP/1.1 200 OK
Content-Type: application/json; charset=utf-8
Content-Length: 2243
Accept-Ranges: none
Cache-Control: public, max-age=31536000, immutable
```

## 変更内容

- HEAD に `Accept-Encoding: identity` を付け、圧縮されていない素のサイズを取得する
- それでも `Content-Length` を返さない配信（Pages の静的アセット。`/vendor/` の `.mjs` / `.wasm` が該当）は、**SHA-256 照合の対象なら実体を GET して確認するので合格**とし、対象外なら NG とする
- **ヘッダーに問題があっても SHA-256 照合をスキップしない**（ヘッダー不備で完全性チェックを飛ばさないため）
- 各行に判定根拠（`sha256` / `content-length` / `headers`）を表示する

## 検証結果

修正後、本番に対して実行して全件合格しました。

```
Base   : https://tools.codelife.cafe
Targets: 31
SHA-256: tiny + runtime

  OK   tiny/webgpu config.json (sha256)
  ...
  OK   runtime ort-wasm-simd-threaded.wasm (sha256)

HEAD 合格 31/31 / SHA-256 照合 13 件
[verify-transcribe-delivery] すべて合格しました
```

- 全 31 ターゲット（モデル 27 + WASM ランタイム 4）が `200`
- `Content-Type` と `Cache-Control: public, max-age=31536000, immutable` がすべて一致
- tiny の全 9 ファイル + WASM ランタイム 4 ファイル = **13 件を SHA-256 照合し全一致**
- base / small の 18 件は `Content-Length` 一致で確認

`scripts/` は Biome の対象外（`npm run lint` は `src/` と `tests/`）のため、静的解析の差分はありません。既存テストへの影響もありません。

## 補足

このスクリプトは、レビューで合意したリリース条件（tiny の実配信 SHA-256 確認をリリース条件、残りは最低限 `Content-Length` 一致）を実行可能にしたものです。この修正で、その条件を本番に対して実際に判定できるようになりました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
