### PR TITLE
feat: add zoom/pan and full-width mode to image editing tools

### DIFF
--- a/src/components/common/ZoomableCanvasViewport.tsx
+++ b/src/components/common/ZoomableCanvasViewport.tsx
@@ -1,0 +1,161 @@
+// ZoomableCanvasViewport — 画像編集キャンバス共通のズーム＆パン・ビューポート
+// image-mosaic / image-text の CanvasEditor / TextCanvas から利用される。
+// canvas 内部解像度・座標変換（clientToImage）・%配置オーバーレイは無改修のまま、
+// スクロールコンテナ＋表示幅変更（CSSスケーリング）でズーム／パンを実現する。
+
+import { Hand, MousePointer2, ZoomIn, ZoomOut } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { MobilePanMode } from '@/lib/hooks/useZoomPan';
+import { useZoomPan } from '@/lib/hooks/useZoomPan';
+import { formatZoomPercent } from '@/lib/tools/zoom-pan';
+import { cn } from '@/lib/utils';
+
+const VIEWPORT_HEIGHT = {
+	normal: 'h-[420px] max-h-[60dvh] min-h-[240px]',
+	full: 'h-[70dvh] max-h-[70dvh] min-h-[320px]',
+} as const;
+
+type ZoomableCanvasViewportProps = {
+	/** コンテンツ（canvas）の原寸幅（内部解像度、px） */
+	contentWidth: number;
+	/** コンテンツ（canvas）の原寸高さ（内部解像度、px） */
+	contentHeight: number;
+	/** 値が変わるとフィット・編集モードへ戻す（新しい画像読み込み時に変える） */
+	resetKey: unknown;
+	/** フルサイズ表示（ページ幅上限解除）中か */
+	fullSize?: boolean;
+	/**
+	 * canvas とオーバーレイをレンダーする関数。
+	 * 返す要素は幅・高さ100%で親（このビューポートが用意する原寸ボックス）を満たすこと。
+	 */
+	children: (ctx: { mobileMode: MobilePanMode }) => React.ReactNode;
+};
+
+export function ZoomableCanvasViewport({
+	contentWidth,
+	contentHeight,
+	resetKey,
+	fullSize = false,
+	children,
+}: ZoomableCanvasViewportProps) {
+	const {
+		containerRef,
+		scale,
+		isFit,
+		displayWidth,
+		displayHeight,
+		offsetX,
+		offsetY,
+		mobileMode,
+		setMobileMode,
+		zoomIn,
+		zoomOut,
+		zoomTo100,
+		zoomToFit,
+		handleWheel,
+		isZoomOutDisabled,
+		isZoomInDisabled,
+	} = useZoomPan({ contentWidth, contentHeight, resetKey });
+
+	const percentLabel = isFit
+		? `フィット（${formatZoomPercent(scale)}）`
+		: formatZoomPercent(scale);
+
+	return (
+		<div className="space-y-2">
+			<div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/30 p-2">
+				<Button
+					variant={isFit ? 'secondary' : 'outline'}
+					size="sm"
+					onClick={zoomToFit}
+				>
+					フィット
+				</Button>
+				<Button
+					variant={!isFit && scale === 1 ? 'secondary' : 'outline'}
+					size="sm"
+					onClick={zoomTo100}
+				>
+					100%
+				</Button>
+				<Button
+					variant="outline"
+					size="icon-sm"
+					onClick={zoomOut}
+					disabled={isZoomOutDisabled}
+					aria-label="縮小"
+				>
+					<ZoomOut className="h-4 w-4" />
+				</Button>
+				<Button
+					variant="outline"
+					size="icon-sm"
+					onClick={zoomIn}
+					disabled={isZoomInDisabled}
+					aria-label="拡大"
+				>
+					<ZoomIn className="h-4 w-4" />
+				</Button>
+				<span
+					data-testid="zoom-percent-label"
+					className="text-xs text-muted-foreground tabular-nums"
+				>
+					{percentLabel}
+				</span>
+
+				{/* モバイル: 編集／パン切替（デスクトップでは常時ドラッグ選択のため非表示） */}
+				<div className="ml-auto flex items-center gap-1 sm:hidden">
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						aria-pressed={mobileMode === 'edit'}
+						aria-label="編集モード（ドラッグで選択・移動）"
+						className={cn(
+							mobileMode === 'edit' && 'border-primary text-primary',
+						)}
+						onClick={() => setMobileMode('edit')}
+					>
+						<MousePointer2 className="h-4 w-4" />
+						編集
+					</Button>
+					<Button
+						type="button"
+						variant="outline"
+						size="sm"
+						aria-pressed={mobileMode === 'pan'}
+						aria-label="パンモード（ドラッグで画像内を移動）"
+						className={cn(
+							mobileMode === 'pan' && 'border-primary text-primary',
+						)}
+						onClick={() => setMobileMode('pan')}
+					>
+						<Hand className="h-4 w-4" />
+						パン
+					</Button>
+				</div>
+			</div>
+
+			<div
+				ref={containerRef}
+				onWheel={handleWheel}
+				className={cn(
+					'relative w-full overflow-auto rounded-lg border border-border bg-muted/10',
+					fullSize ? VIEWPORT_HEIGHT.full : VIEWPORT_HEIGHT.normal,
+				)}
+			>
+				<div
+					style={{
+						width: displayWidth || undefined,
+						height: displayHeight || undefined,
+						marginLeft: offsetX,
+						marginTop: offsetY,
+					}}
+					className="relative"
+				>
+					{children({ mobileMode })}
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/src/components/common/ZoomableCanvasViewport.tsx
+++ b/src/components/common/ZoomableCanvasViewport.tsx
@@ -52,7 +52,6 @@ export function ZoomableCanvasViewport({
 		zoomOut,
 		zoomTo100,
 		zoomToFit,
-		handleWheel,
 		isZoomOutDisabled,
 		isZoomInDisabled,
 	} = useZoomPan({ contentWidth, contentHeight, resetKey });
@@ -138,7 +137,7 @@ export function ZoomableCanvasViewport({
 
 			<div
 				ref={containerRef}
-				onWheel={handleWheel}
+				data-testid="zoom-scroll-container"
 				className={cn(
 					'relative w-full overflow-auto rounded-lg border border-border bg-muted/10',
 					fullSize ? VIEWPORT_HEIGHT.full : VIEWPORT_HEIGHT.normal,

--- a/src/components/image-mosaic/CanvasEditor.tsx
+++ b/src/components/image-mosaic/CanvasEditor.tsx
@@ -5,6 +5,7 @@
 
 import { X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ZoomableCanvasViewport } from '@/components/common/ZoomableCanvasViewport';
 import { clientToImage } from '@/lib/tools/image-common';
 import {
 	isMaskEffectMode,
@@ -31,6 +32,8 @@ type CanvasEditorProps = {
 	onDeleteRegion: (id: string) => void;
 	drawingMode: MaskMode;
 	drawingShape: MaskShape;
+	/** フルサイズ表示（ページ幅上限解除）中か */
+	fullSize?: boolean;
 };
 
 type DragState = {
@@ -90,6 +93,7 @@ export function CanvasEditor({
 	onDeleteRegion,
 	drawingMode,
 	drawingShape,
+	fullSize,
 }: CanvasEditorProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const dragRef = useRef<DragState | null>(null);
@@ -249,60 +253,74 @@ export function CanvasEditor({
 	});
 
 	return (
-		<div className="relative inline-block max-w-full">
-			<canvas
-				ref={canvasRef}
-				data-testid="editor-canvas"
-				className="block h-auto max-h-[60vh] w-auto max-w-full cursor-crosshair touch-none rounded-lg border border-border"
-				onPointerDown={handlePointerDown}
-				onPointerMove={handlePointerMove}
-				onPointerUp={handlePointerUp}
-				onPointerCancel={handlePointerCancel}
-				onPointerLeave={() => setHoveredId(null)}
-			/>
-			{/* 既存領域のアウトライン（DOMオーバーレイ） */}
-			{regions.map((region) => {
-				const isSelected = region.id === selectedId;
-				const isHovered = region.id === hoveredId;
+		<ZoomableCanvasViewport
+			contentWidth={imageSize.width}
+			contentHeight={imageSize.height}
+			resetKey={source}
+			fullSize={fullSize}
+		>
+			{({ mobileMode }) => {
+				const isPanMode = mobileMode === 'pan';
 				return (
-					<div
-						key={region.id}
-						className={`pointer-events-none absolute border border-dashed transition-colors ${isMaskEffectRegion(region) && region.shape === 'ellipse' ? 'rounded-full' : ''} ${
-							isSelected
-								? 'border-primary border-2 bg-primary/10'
-								: isHovered
-									? 'border-primary/70'
-									: 'border-transparent'
-						}`}
-						style={pctStyle(region.rect)}
-					>
-						{isSelected && (
-							<button
-								type="button"
-								aria-label="領域を削除"
-								className="pointer-events-auto absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full bg-destructive text-white shadow-sm hover:opacity-80"
-								onClick={(e) => {
-									e.stopPropagation();
-									onDeleteRegion(region.id);
-								}}
-							>
-								<X className="h-4 w-4" />
-							</button>
+					<div className="relative h-full w-full">
+						<canvas
+							ref={canvasRef}
+							data-testid="editor-canvas"
+							className={`block h-full w-full rounded-lg border border-border ${
+								isPanMode ? 'cursor-grab' : 'cursor-crosshair touch-none'
+							}`}
+							onPointerDown={isPanMode ? undefined : handlePointerDown}
+							onPointerMove={isPanMode ? undefined : handlePointerMove}
+							onPointerUp={isPanMode ? undefined : handlePointerUp}
+							onPointerCancel={isPanMode ? undefined : handlePointerCancel}
+							onPointerLeave={() => setHoveredId(null)}
+						/>
+						{/* 既存領域のアウトライン（DOMオーバーレイ） */}
+						{regions.map((region) => {
+							const isSelected = region.id === selectedId;
+							const isHovered = region.id === hoveredId;
+							return (
+								<div
+									key={region.id}
+									className={`pointer-events-none absolute border border-dashed transition-colors ${isMaskEffectRegion(region) && region.shape === 'ellipse' ? 'rounded-full' : ''} ${
+										isSelected
+											? 'border-primary border-2 bg-primary/10'
+											: isHovered
+												? 'border-primary/70'
+												: 'border-transparent'
+									}`}
+									style={pctStyle(region.rect)}
+								>
+									{isSelected && (
+										<button
+											type="button"
+											aria-label="領域を削除"
+											className="pointer-events-auto absolute -top-3 -right-3 flex h-6 w-6 items-center justify-center rounded-full bg-destructive text-white shadow-sm hover:opacity-80"
+											onClick={(e) => {
+												e.stopPropagation();
+												onDeleteRegion(region.id);
+											}}
+										>
+											<X className="h-4 w-4" />
+										</button>
+									)}
+								</div>
+							);
+						})}
+						{/* ドラッグ中の選択矩形 */}
+						{dragRect && (
+							<div
+								className={`pointer-events-none absolute border-2 border-dashed border-primary bg-primary/10 ${
+									isMaskEffectMode(drawingMode) && drawingShape === 'ellipse'
+										? 'rounded-full'
+										: ''
+								}`}
+								style={pctStyle(dragRect)}
+							/>
 						)}
 					</div>
 				);
-			})}
-			{/* ドラッグ中の選択矩形 */}
-			{dragRect && (
-				<div
-					className={`pointer-events-none absolute border-2 border-dashed border-primary bg-primary/10 ${
-						isMaskEffectMode(drawingMode) && drawingShape === 'ellipse'
-							? 'rounded-full'
-							: ''
-					}`}
-					style={pctStyle(dragRect)}
-				/>
-			)}
-		</div>
+			}}
+		</ZoomableCanvasViewport>
 	);
 }

--- a/src/components/image-mosaic/ImageMosaicPage.tsx
+++ b/src/components/image-mosaic/ImageMosaicPage.tsx
@@ -1,13 +1,14 @@
 // ImageMosaicPage — 画像モザイク・ぼかしツールのオーケストレータ
 // 状態: 読み込みフェーズ / マスク領域（undo/redo履歴付き） / 選択 / モード / 強度
 
-import { ImagePlus, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { ImagePlus, Maximize2, Minimize2, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { ExportBar } from '@/components/common/ExportBar';
 import { ImageDropzone } from '@/components/common/ImageDropzone';
 import { useHistoryState } from '@/components/common/useHistoryState';
 import { Button } from '@/components/ui/button';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
+import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
 	createId,
 	DOWNSCALE_EDGE,
@@ -42,6 +43,10 @@ type Phase =
 
 export default function ImageMosaicPage() {
 	const { trackRun } = useToolAnalytics('image-mosaic');
+	const [settings, updateSettings] = useToolSettings('image-mosaic', {
+		isExpanded: false,
+	});
+	const { isExpanded } = settings;
 	const [phase, setPhase] = useState<Phase>({ kind: 'empty' });
 	const [error, setError] = useState<string | null>(null);
 	const [selectedId, setSelectedId] = useState<string | null>(null);
@@ -347,6 +352,36 @@ export default function ImageMosaicPage() {
 		setStampImageName(null);
 	}, [regions]);
 
+	const applyLayoutWidth = useCallback((expanded: boolean) => {
+		const container = document.getElementById('tool-layout-container');
+		if (!container) return;
+		if (expanded) {
+			container.classList.remove('max-w-[800px]', 'xl:max-w-5xl');
+			container.classList.add('max-w-full');
+		} else {
+			container.classList.remove('max-w-full');
+			container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
+		}
+	}, []);
+
+	const toggleExpand = () => {
+		updateSettings({ isExpanded: !isExpanded });
+	};
+
+	useEffect(() => {
+		applyLayoutWidth(isExpanded);
+	}, [isExpanded, applyLayoutWidth]);
+
+	useEffect(() => {
+		return () => {
+			const container = document.getElementById('tool-layout-container');
+			if (container) {
+				container.classList.remove('max-w-full');
+				container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
+			}
+		};
+	}, []);
+
 	return (
 		<div className="space-y-4">
 			{error && (
@@ -414,7 +449,7 @@ export default function ImageMosaicPage() {
 					<p className="text-xs text-muted-foreground">
 						キャンバス上をドラッグして、モザイク・ぼかし範囲またはスタンプ配置範囲を選択してください。モザイク・ぼかしは四角形/円形を切り替えられます。領域をクリックすると選択でき、Deleteキーまたは✕ボタンで削除できます。
 					</p>
-					<div className="text-center">
+					<div>
 						<CanvasEditor
 							source={phase.source}
 							regions={regions.state}
@@ -424,12 +459,26 @@ export default function ImageMosaicPage() {
 							onDeleteRegion={handleDeleteRegion}
 							drawingMode={activeMode}
 							drawingShape={activeShape}
+							fullSize={isExpanded}
 						/>
 					</div>
 					<div className="flex flex-wrap items-center justify-between gap-3">
 						<Button variant="outline" size="sm" onClick={handleClear}>
 							<ImagePlus className="h-4 w-4" />
 							別の画像を選ぶ
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={toggleExpand}
+							title={isExpanded ? '標準サイズに戻す' : '画面幅を広げる'}
+						>
+							{isExpanded ? (
+								<Minimize2 className="h-4 w-4" />
+							) : (
+								<Maximize2 className="h-4 w-4" />
+							)}
+							{isExpanded ? '標準幅' : 'フルサイズ'}
 						</Button>
 					</div>
 					<ExportBar

--- a/src/components/image-text/ImageTextPage.tsx
+++ b/src/components/image-text/ImageTextPage.tsx
@@ -1,12 +1,13 @@
 // ImageTextPage — 画像テキスト挿入ツールのオーケストレータ
 // 状態: 読み込みフェーズ / テキストレイヤー / 選択レイヤー
 
-import { ImagePlus, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { ImagePlus, Maximize2, Minimize2, X } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
 import { ExportBar } from '@/components/common/ExportBar';
 import { ImageDropzone } from '@/components/common/ImageDropzone';
 import { Button } from '@/components/ui/button';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
+import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
 	createId,
 	DOWNSCALE_EDGE,
@@ -41,6 +42,10 @@ function sourceSize(source: HTMLImageElement | HTMLCanvasElement) {
 
 export default function ImageTextPage() {
 	const { trackRun } = useToolAnalytics('image-text');
+	const [settings, updateSettings] = useToolSettings('image-text', {
+		isExpanded: false,
+	});
+	const { isExpanded } = settings;
 	const [phase, setPhase] = useState<Phase>({ kind: 'empty' });
 	const [error, setError] = useState<string | null>(null);
 	const [layers, setLayers] = useState<TextLayer[]>([]);
@@ -144,6 +149,36 @@ export default function ImageTextPage() {
 		setSelectedId(null);
 	}, []);
 
+	const applyLayoutWidth = useCallback((expanded: boolean) => {
+		const container = document.getElementById('tool-layout-container');
+		if (!container) return;
+		if (expanded) {
+			container.classList.remove('max-w-[800px]', 'xl:max-w-5xl');
+			container.classList.add('max-w-full');
+		} else {
+			container.classList.remove('max-w-full');
+			container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
+		}
+	}, []);
+
+	const toggleExpand = () => {
+		updateSettings({ isExpanded: !isExpanded });
+	};
+
+	useEffect(() => {
+		applyLayoutWidth(isExpanded);
+	}, [isExpanded, applyLayoutWidth]);
+
+	useEffect(() => {
+		return () => {
+			const container = document.getElementById('tool-layout-container');
+			if (container) {
+				container.classList.remove('max-w-full');
+				container.classList.add('max-w-[800px]', 'xl:max-w-5xl');
+			}
+		};
+	}, []);
+
 	const selectedLayer = layers.find((l) => l.id === selectedId) ?? null;
 
 	return (
@@ -196,13 +231,14 @@ export default function ImageTextPage() {
 						「テキストを追加」でテキストを配置し、キャンバス上のドラッグで位置を調整できます。
 					</p>
 					<div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_320px]">
-						<div className="text-center">
+						<div className="min-w-0">
 							<TextCanvas
 								source={phase.source}
 								layers={layers}
 								selectedId={selectedId}
 								onSelect={setSelectedId}
 								onMoveLayer={handleMovePosition}
+								fullSize={isExpanded}
 							/>
 						</div>
 						<div className="space-y-4">
@@ -227,6 +263,19 @@ export default function ImageTextPage() {
 						<Button variant="outline" size="sm" onClick={handleClear}>
 							<ImagePlus className="h-4 w-4" />
 							別の画像を選ぶ
+						</Button>
+						<Button
+							variant="outline"
+							size="sm"
+							onClick={toggleExpand}
+							title={isExpanded ? '標準サイズに戻す' : '画面幅を広げる'}
+						>
+							{isExpanded ? (
+								<Minimize2 className="h-4 w-4" />
+							) : (
+								<Maximize2 className="h-4 w-4" />
+							)}
+							{isExpanded ? '標準幅' : 'フルサイズ'}
 						</Button>
 					</div>
 					<ExportBar

--- a/src/components/image-text/TextCanvas.tsx
+++ b/src/components/image-text/TextCanvas.tsx
@@ -3,6 +3,7 @@
 // 選択レイヤーの破線バウンディングボックスは DOM オーバーレイで表示する
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ZoomableCanvasViewport } from '@/components/common/ZoomableCanvasViewport';
 import { clientToImage } from '@/lib/tools/image-common';
 import {
 	BG_PADDING,
@@ -17,6 +18,8 @@ type TextCanvasProps = {
 	selectedId: string | null;
 	onSelect: (id: string | null) => void;
 	onMoveLayer: (id: string, x: number, y: number) => void;
+	/** フルサイズ表示（ページ幅上限解除）中か */
+	fullSize?: boolean;
 };
 
 type DragState = {
@@ -56,6 +59,7 @@ export function TextCanvas({
 	selectedId,
 	onSelect,
 	onMoveLayer,
+	fullSize,
 }: TextCanvasProps) {
 	const canvasRef = useRef<HTMLCanvasElement>(null);
 	const dragRef = useRef<DragState | null>(null);
@@ -172,34 +176,48 @@ export function TextCanvas({
 	const selectedLayer = layers.find((l) => l.id === selectedId) ?? null;
 
 	return (
-		<div className="relative inline-block max-w-full">
-			<canvas
-				ref={canvasRef}
-				data-testid="text-canvas"
-				className={`block h-auto max-h-[60vh] w-auto max-w-full touch-none rounded-lg border border-border ${
-					isDragging ? 'cursor-grabbing' : 'cursor-pointer'
-				}`}
-				onPointerDown={handlePointerDown}
-				onPointerMove={handlePointerMove}
-				onPointerUp={handlePointerUp}
-				onPointerCancel={handlePointerCancel}
-			/>
-			{/* 選択レイヤーの破線バウンディングボックス（DOMオーバーレイ） */}
-			{selectedLayer &&
-				(() => {
-					const b = layerBounds(selectedLayer);
-					return (
-						<div
-							className="pointer-events-none absolute border-2 border-dashed border-primary"
-							style={{
-								left: `${(b.x / imageSize.width) * 100}%`,
-								top: `${(b.y / imageSize.height) * 100}%`,
-								width: `${(b.width / imageSize.width) * 100}%`,
-								height: `${(b.height / imageSize.height) * 100}%`,
-							}}
+		<ZoomableCanvasViewport
+			contentWidth={imageSize.width}
+			contentHeight={imageSize.height}
+			resetKey={source}
+			fullSize={fullSize}
+		>
+			{({ mobileMode }) => {
+				const isPanMode = mobileMode === 'pan';
+				return (
+					<div className="relative h-full w-full">
+						<canvas
+							ref={canvasRef}
+							data-testid="text-canvas"
+							className={`block h-full w-full rounded-lg border border-border ${
+								isPanMode
+									? 'cursor-grab'
+									: `touch-none ${isDragging ? 'cursor-grabbing' : 'cursor-pointer'}`
+							}`}
+							onPointerDown={isPanMode ? undefined : handlePointerDown}
+							onPointerMove={isPanMode ? undefined : handlePointerMove}
+							onPointerUp={isPanMode ? undefined : handlePointerUp}
+							onPointerCancel={isPanMode ? undefined : handlePointerCancel}
 						/>
-					);
-				})()}
-		</div>
+						{/* 選択レイヤーの破線バウンディングボックス（DOMオーバーレイ） */}
+						{selectedLayer &&
+							(() => {
+								const b = layerBounds(selectedLayer);
+								return (
+									<div
+										className="pointer-events-none absolute border-2 border-dashed border-primary"
+										style={{
+											left: `${(b.x / imageSize.width) * 100}%`,
+											top: `${(b.y / imageSize.height) * 100}%`,
+											width: `${(b.width / imageSize.width) * 100}%`,
+											height: `${(b.height / imageSize.height) * 100}%`,
+										}}
+									/>
+								);
+							})()}
+					</div>
+				);
+			}}
+		</ZoomableCanvasViewport>
 	);
 }

--- a/src/lib/hooks/useZoomPan.ts
+++ b/src/lib/hooks/useZoomPan.ts
@@ -2,7 +2,6 @@
 // 純粋な倍率計算は src/lib/tools/zoom-pan.ts に委譲し、ここでは
 // DOM参照（ResizeObserver・スクロール位置）と状態遷移のみを扱う。
 
-import type React from 'react';
 import {
 	useCallback,
 	useEffect,
@@ -15,8 +14,8 @@ import {
 	computeFitScale,
 	computeWheelZoom,
 	computeZoomScrollPosition,
-	MAX_ZOOM,
-	MIN_ZOOM,
+	isZoomInNoop,
+	isZoomOutNoop,
 	nextZoomInStep,
 	nextZoomOutStep,
 } from '@/lib/tools/zoom-pan';
@@ -82,6 +81,14 @@ export function useZoomPan(params: {
 	const scale = mode === 'fit' ? fitScale : mode;
 	const isFit = mode === 'fit';
 
+	// ホイールイベントは短時間に連続発火しうる。クロージャに閉じ込めた scale を
+	// 参照すると、React の再レンダー（＝リスナー再登録）が追いつかない間に
+	// 古い scale のまま計算し続けてしまい、25%クランプ後も倍率が下がり続ける
+	// といった不整合が生じる。ref には毎レンダー最新値を同期し、常に最新の
+	// scale を読めるようにする。
+	const scaleRef = useRef(scale);
+	scaleRef.current = scale;
+
 	const displayWidth = contentWidth * scale;
 	const displayHeight = contentHeight * scale;
 	const offsetX = computeContentOffset(containerSize.width, displayWidth);
@@ -132,20 +139,18 @@ export function useZoomPan(params: {
 		offsetY,
 	]);
 
-	const anchorAt = useCallback(
-		(pointerX: number, pointerY: number) => {
-			const el = containerRef.current;
-			if (!el) return;
-			pendingAnchorRef.current = {
-				pointerX,
-				pointerY,
-				scrollLeft: el.scrollLeft,
-				scrollTop: el.scrollTop,
-				oldScale: scale,
-			};
-		},
-		[scale],
-	);
+	// scaleRef を参照するため scale/mode に依存しない安定した関数にする
+	const anchorAt = useCallback((pointerX: number, pointerY: number) => {
+		const el = containerRef.current;
+		if (!el) return;
+		pendingAnchorRef.current = {
+			pointerX,
+			pointerY,
+			scrollLeft: el.scrollLeft,
+			scrollTop: el.scrollTop,
+			oldScale: scaleRef.current,
+		};
+	}, []);
 
 	const centerAnchor = useCallback(() => {
 		const el = containerRef.current;
@@ -155,13 +160,13 @@ export function useZoomPan(params: {
 
 	const zoomIn = useCallback(() => {
 		centerAnchor();
-		setMode(nextZoomInStep(scale));
-	}, [scale, centerAnchor]);
+		setMode(nextZoomInStep(scaleRef.current));
+	}, [centerAnchor]);
 
 	const zoomOut = useCallback(() => {
 		centerAnchor();
-		setMode(nextZoomOutStep(scale));
-	}, [scale, centerAnchor]);
+		setMode(nextZoomOutStep(scaleRef.current));
+	}, [centerAnchor]);
 
 	const zoomTo100 = useCallback(() => {
 		centerAnchor();
@@ -172,18 +177,25 @@ export function useZoomPan(params: {
 		setMode('fit');
 	}, []);
 
-	const handleWheel = useCallback(
-		(e: React.WheelEvent<HTMLDivElement>) => {
+	// 修飾キー付きホイールでズームする。React の合成 onWheel は passive
+	// リスナーとして登録されるため e.preventDefault() が効かず、ブラウザの
+	// 既定スクロール（あるいはページ全体のピンチズーム）が同時に発生してしまう。
+	// そのためネイティブの非passiveリスナーを直接addEventListenerする。
+	// scaleRef を参照することで、連続したホイールイベントが再レンダーより
+	// 速く発火しても常に最新の scale を基準に計算する（登録は初回のみでよい）。
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		const listener = (e: WheelEvent) => {
 			if (!(e.ctrlKey || e.metaKey)) return;
 			e.preventDefault();
-			const el = containerRef.current;
-			if (!el) return;
 			const rect = el.getBoundingClientRect();
 			anchorAt(e.clientX - rect.left, e.clientY - rect.top);
-			setMode(computeWheelZoom(scale, e.deltaY, e.deltaMode));
-		},
-		[scale, anchorAt],
-	);
+			setMode(computeWheelZoom(scaleRef.current, e.deltaY, e.deltaMode));
+		};
+		el.addEventListener('wheel', listener, { passive: false });
+		return () => el.removeEventListener('wheel', listener);
+	}, [anchorAt]);
 
 	return {
 		containerRef,
@@ -199,8 +211,7 @@ export function useZoomPan(params: {
 		zoomOut,
 		zoomTo100,
 		zoomToFit,
-		handleWheel,
-		isZoomOutDisabled: scale < MIN_ZOOM,
-		isZoomInDisabled: scale >= MAX_ZOOM,
+		isZoomOutDisabled: isZoomOutNoop(scale),
+		isZoomInDisabled: isZoomInNoop(scale),
 	};
 }

--- a/src/lib/hooks/useZoomPan.ts
+++ b/src/lib/hooks/useZoomPan.ts
@@ -1,0 +1,206 @@
+// useZoomPan — ZoomableCanvasViewport 用のズーム＆パン状態管理フック
+// 純粋な倍率計算は src/lib/tools/zoom-pan.ts に委譲し、ここでは
+// DOM参照（ResizeObserver・スクロール位置）と状態遷移のみを扱う。
+
+import type React from 'react';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react';
+import {
+	computeContentOffset,
+	computeFitScale,
+	computeWheelZoom,
+	computeZoomScrollPosition,
+	MAX_ZOOM,
+	MIN_ZOOM,
+	nextZoomInStep,
+	nextZoomOutStep,
+} from '@/lib/tools/zoom-pan';
+
+export type MobilePanMode = 'edit' | 'pan';
+
+type ContainerSize = { width: number; height: number };
+
+type PendingAnchor = {
+	pointerX: number;
+	pointerY: number;
+	scrollLeft: number;
+	scrollTop: number;
+	oldScale: number;
+} | null;
+
+export function useZoomPan(params: {
+	contentWidth: number;
+	contentHeight: number;
+	/** 値が変わるとフィット・編集モードへ戻す（新しい画像の読み込み時） */
+	resetKey: unknown;
+}) {
+	const { contentWidth, contentHeight, resetKey } = params;
+	const containerRef = useRef<HTMLDivElement | null>(null);
+	const [containerSize, setContainerSize] = useState<ContainerSize>({
+		width: 0,
+		height: 0,
+	});
+	const [mode, setMode] = useState<'fit' | number>('fit');
+	const [mobileMode, setMobileMode] = useState<MobilePanMode>('edit');
+	const pendingAnchorRef = useRef<PendingAnchor>(null);
+
+	// resetKey の変化のみを契機とする（本文内では参照しない）
+	// biome-ignore lint/correctness/useExhaustiveDependencies: resetKeyは識別子変更の検知にのみ使う
+	useEffect(() => {
+		setMode('fit');
+		setMobileMode('edit');
+		pendingAnchorRef.current = null;
+	}, [resetKey]);
+
+	useEffect(() => {
+		const el = containerRef.current;
+		if (!el || typeof ResizeObserver === 'undefined') return;
+		const observer = new ResizeObserver((entries) => {
+			const entry = entries[0];
+			if (!entry) return;
+			setContainerSize({
+				width: entry.contentRect.width,
+				height: entry.contentRect.height,
+			});
+		});
+		observer.observe(el);
+		setContainerSize({ width: el.clientWidth, height: el.clientHeight });
+		return () => observer.disconnect();
+	}, []);
+
+	const fitScale = computeFitScale(
+		containerSize.width,
+		containerSize.height,
+		contentWidth,
+		contentHeight,
+	);
+	const scale = mode === 'fit' ? fitScale : mode;
+	const isFit = mode === 'fit';
+
+	const displayWidth = contentWidth * scale;
+	const displayHeight = contentHeight * scale;
+	const offsetX = computeContentOffset(containerSize.width, displayWidth);
+	const offsetY = computeContentOffset(containerSize.height, displayHeight);
+
+	// カーソル/中心基準ズーム: スケール変更後にスクロール位置を補正して同じ画像内座標を維持する
+	useLayoutEffect(() => {
+		const anchor = pendingAnchorRef.current;
+		const el = containerRef.current;
+		if (!anchor || !el) return;
+		pendingAnchorRef.current = null;
+		const oldOffsetX = computeContentOffset(
+			containerSize.width,
+			contentWidth * anchor.oldScale,
+		);
+		const oldOffsetY = computeContentOffset(
+			containerSize.height,
+			contentHeight * anchor.oldScale,
+		);
+		el.scrollLeft = computeZoomScrollPosition({
+			pointerInViewport: anchor.pointerX,
+			scrollPosition: anchor.scrollLeft,
+			oldContentOffset: oldOffsetX,
+			newContentOffset: offsetX,
+			oldScale: anchor.oldScale,
+			newScale: scale,
+			containerSize: containerSize.width,
+			contentSize: contentWidth,
+		});
+		el.scrollTop = computeZoomScrollPosition({
+			pointerInViewport: anchor.pointerY,
+			scrollPosition: anchor.scrollTop,
+			oldContentOffset: oldOffsetY,
+			newContentOffset: offsetY,
+			oldScale: anchor.oldScale,
+			newScale: scale,
+			containerSize: containerSize.height,
+			contentSize: contentHeight,
+		});
+		// scale 変化のたびに保留中の補正があれば適用する
+	}, [
+		scale,
+		containerSize.width,
+		containerSize.height,
+		contentWidth,
+		contentHeight,
+		offsetX,
+		offsetY,
+	]);
+
+	const anchorAt = useCallback(
+		(pointerX: number, pointerY: number) => {
+			const el = containerRef.current;
+			if (!el) return;
+			pendingAnchorRef.current = {
+				pointerX,
+				pointerY,
+				scrollLeft: el.scrollLeft,
+				scrollTop: el.scrollTop,
+				oldScale: scale,
+			};
+		},
+		[scale],
+	);
+
+	const centerAnchor = useCallback(() => {
+		const el = containerRef.current;
+		if (!el) return;
+		anchorAt(el.clientWidth / 2, el.clientHeight / 2);
+	}, [anchorAt]);
+
+	const zoomIn = useCallback(() => {
+		centerAnchor();
+		setMode(nextZoomInStep(scale));
+	}, [scale, centerAnchor]);
+
+	const zoomOut = useCallback(() => {
+		centerAnchor();
+		setMode(nextZoomOutStep(scale));
+	}, [scale, centerAnchor]);
+
+	const zoomTo100 = useCallback(() => {
+		centerAnchor();
+		setMode(1);
+	}, [centerAnchor]);
+
+	const zoomToFit = useCallback(() => {
+		setMode('fit');
+	}, []);
+
+	const handleWheel = useCallback(
+		(e: React.WheelEvent<HTMLDivElement>) => {
+			if (!(e.ctrlKey || e.metaKey)) return;
+			e.preventDefault();
+			const el = containerRef.current;
+			if (!el) return;
+			const rect = el.getBoundingClientRect();
+			anchorAt(e.clientX - rect.left, e.clientY - rect.top);
+			setMode(computeWheelZoom(scale, e.deltaY, e.deltaMode));
+		},
+		[scale, anchorAt],
+	);
+
+	return {
+		containerRef,
+		scale,
+		isFit,
+		displayWidth,
+		displayHeight,
+		offsetX,
+		offsetY,
+		mobileMode,
+		setMobileMode,
+		zoomIn,
+		zoomOut,
+		zoomTo100,
+		zoomToFit,
+		handleWheel,
+		isZoomOutDisabled: scale < MIN_ZOOM,
+		isZoomInDisabled: scale >= MAX_ZOOM,
+	};
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -1,0 +1,157 @@
+// zoom-pan.ts — 画像編集ツール共通のズーム＆パン計算ロジック（純粋関数）
+// スクロールコンテナ方式のズーム（`ZoomableCanvasViewport`）が利用する。
+// DOM・React に依存しない値の計算のみを担う。
+
+/** ＋／−ボタンのスナップ倍率系列（1 = 100%） */
+export const ZOOM_STEPS = [0.25, 0.5, 1, 2, 4] as const;
+
+export const MIN_ZOOM = 0.25;
+export const MAX_ZOOM = 4;
+
+/** ホイールズームの感度定数（1イベントあたりの変化量の基準） */
+export const WHEEL_SENSITIVITY = 0.0015;
+
+/** ホイール1イベントで許容する正規化後delta絶対値の上限（過大な一回転を抑制） */
+export const WHEEL_MAX_NORMALIZED_DELTA = 100;
+
+/** WheelEvent.deltaMode ごとの1行/1ページあたりの概算px */
+const LINE_HEIGHT_PX = 16;
+const PAGE_HEIGHT_PX = 800;
+
+export function clampZoom(scale: number): number {
+	return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, scale));
+}
+
+/**
+ * フィット倍率を算出する（コンテナより小さい画像はフィット時に拡大しない）。
+ * どちらかの寸法が0以下の場合は 1（等倍）を返す。
+ */
+export function computeFitScale(
+	containerWidth: number,
+	containerHeight: number,
+	contentWidth: number,
+	contentHeight: number,
+): number {
+	if (
+		containerWidth <= 0 ||
+		containerHeight <= 0 ||
+		contentWidth <= 0 ||
+		contentHeight <= 0
+	) {
+		return 1;
+	}
+	return Math.min(
+		containerWidth / contentWidth,
+		containerHeight / contentHeight,
+		1,
+	);
+}
+
+/**
+ * ＋ボタン押下時の次の倍率（現在値より大きい最初のスナップ値）。
+ * 現在値が25%未満の場合は25%へ直接遷移する。
+ */
+export function nextZoomInStep(currentScale: number): number {
+	if (currentScale < MIN_ZOOM) return MIN_ZOOM;
+	const next = ZOOM_STEPS.find((step) => step > currentScale + 1e-9);
+	return next ?? MAX_ZOOM;
+}
+
+/**
+ * −ボタン押下時の次の倍率（現在値より小さい最初のスナップ値）。
+ * 現在値が25%未満の場合は無効操作として現在値を維持する。
+ */
+export function nextZoomOutStep(currentScale: number): number {
+	if (currentScale < MIN_ZOOM) return currentScale;
+	const steps = [...ZOOM_STEPS].reverse();
+	const next = steps.find((step) => step < currentScale - 1e-9);
+	return next ?? MIN_ZOOM;
+}
+
+/** WheelEvent.deltaMode を考慮して deltaY をピクセル相当に正規化する */
+export function normalizeWheelDelta(deltaY: number, deltaMode: number): number {
+	if (deltaMode === 1) return deltaY * LINE_HEIGHT_PX;
+	if (deltaMode === 2) return deltaY * PAGE_HEIGHT_PX;
+	return deltaY;
+}
+
+/**
+ * 修飾キー付きホイール操作による次の倍率を計算する。
+ * 現在値が25%未満の場合（フィット遷移直後）は25%へクランプせず、
+ * 連続ズームの結果25%へ到達するまで実効倍率を維持する。
+ */
+export function computeWheelZoom(
+	currentScale: number,
+	deltaY: number,
+	deltaMode: number,
+): number {
+	const normalized = normalizeWheelDelta(deltaY, deltaMode);
+	const clampedDelta = Math.max(
+		-WHEEL_MAX_NORMALIZED_DELTA,
+		Math.min(WHEEL_MAX_NORMALIZED_DELTA, normalized),
+	);
+	const factor = Math.exp(-clampedDelta * WHEEL_SENSITIVITY);
+	const next = currentScale * factor;
+	if (currentScale >= MIN_ZOOM) {
+		return clampZoom(next);
+	}
+	// フィット実効倍率が25%未満からの遷移中: 25%へ到達するまで自由に動かす
+	return Math.min(MAX_ZOOM, Math.max(0.01, next));
+}
+
+/**
+ * コンテンツがコンテナより小さい場合の中央配置オフセット（px）。
+ * コンテンツがコンテナ以上の場合は 0（スクロールに委ねる）。
+ */
+export function computeContentOffset(
+	containerSize: number,
+	contentDisplaySize: number,
+): number {
+	return Math.max(0, (containerSize - contentDisplaySize) / 2);
+}
+
+export type ZoomScrollParams = {
+	/** ポインタのビューポート内座標（コンテナ左上を原点とするCSS px） */
+	pointerInViewport: number;
+	/** ズーム前のスクロール位置（px） */
+	scrollPosition: number;
+	/** ズーム前の中央配置オフセット（px） */
+	oldContentOffset: number;
+	/** ズーム後の中央配置オフセット（px） */
+	newContentOffset: number;
+	oldScale: number;
+	newScale: number;
+	containerSize: number;
+	/** コンテンツの原寸（スケール適用前、px） */
+	contentSize: number;
+};
+
+/**
+ * カーソル基準ズームの補正後スクロール位置を計算する（1軸分）。
+ * (1) 画像内座標を求める → (2) 倍率を更新する → (3) 同じ画像内座標が
+ * 同じビューポート位置に来るようスクロール位置を補正する、という手順に対応。
+ * 結果は [0, maxScroll] にクランプする。
+ */
+export function computeZoomScrollPosition(params: ZoomScrollParams): number {
+	const {
+		pointerInViewport,
+		scrollPosition,
+		oldContentOffset,
+		newContentOffset,
+		oldScale,
+		newScale,
+		containerSize,
+		contentSize,
+	} = params;
+	const imagePoint =
+		(pointerInViewport + scrollPosition - oldContentOffset) / oldScale;
+	const rawScroll =
+		imagePoint * newScale + newContentOffset - pointerInViewport;
+	const maxScroll = Math.max(0, contentSize * newScale - containerSize);
+	return Math.min(maxScroll, Math.max(0, rawScroll));
+}
+
+/** 実効倍率を表示用文字列に変換する（例: "18%", "100%"） */
+export function formatZoomPercent(scale: number): string {
+	return `${Math.round(scale * 100)}%`;
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -155,3 +155,17 @@ export function computeZoomScrollPosition(params: ZoomScrollParams): number {
 export function formatZoomPercent(scale: number): string {
 	return `${Math.round(scale * 100)}%`;
 }
+
+/**
+ * −ボタン押下が実質的に無効（倍率が変化しない）かどうか。
+ * ちょうど25%のときは `nextZoomOutStep` が同じ値を返すため、単純な
+ * `scale <= MIN_ZOOM` 比較ではなく、次の値との実質的な同一性で判定する。
+ */
+export function isZoomOutNoop(scale: number): boolean {
+	return Math.abs(nextZoomOutStep(scale) - scale) < 1e-9;
+}
+
+/** ＋ボタン押下が実質的に無効（倍率が変化しない）かどうか。400%上限で成立する。 */
+export function isZoomInNoop(scale: number): boolean {
+	return Math.abs(nextZoomInStep(scale) - scale) < 1e-9;
+}

--- a/tests/e2e/helpers/canvas.ts
+++ b/tests/e2e/helpers/canvas.ts
@@ -149,3 +149,139 @@ export async function dragOnCanvas(
 	await page.mouse.move(p2.x, p2.y, { steps: 5 });
 	await page.mouse.up();
 }
+
+export type ZoomGeometry = {
+	/** 現在の実効倍率（1 = 100%） */
+	scale: number;
+	scrollLeft: number;
+	scrollTop: number;
+	/** 中央配置オフセット（px） */
+	offsetX: number;
+	offsetY: number;
+	/** スクロールコンテナのビューポート座標（ページ絶対座標→コンテナ内座標の変換に使う） */
+	containerLeft: number;
+	containerTop: number;
+	containerWidth: number;
+	containerHeight: number;
+	canvasWidth: number;
+	canvasHeight: number;
+};
+
+/**
+ * ZoomableCanvasViewport のDOM構造からズーム幾何情報を読み取る。
+ * 構造: canvas → (relative h-full w-full ラッパー) → (原寸ボックス, インライン
+ * style で width/height/margin を持つ) → (overflow-auto スクロールコンテナ)。
+ * `useZoomPan` の内部実装を呼ばず、実際のDOM値のみから幾何を再構成する。
+ */
+export async function getZoomGeometry(
+	page: Page,
+	testId: string,
+): Promise<ZoomGeometry> {
+	const geometry = await page.evaluate((testId) => {
+		const canvas = document.querySelector(
+			`[data-testid="${testId}"]`,
+		) as HTMLCanvasElement | null;
+		const wrapper = canvas?.parentElement ?? null;
+		const contentBox = (wrapper?.parentElement ?? null) as HTMLElement | null;
+		const scrollContainer = (contentBox?.parentElement ??
+			null) as HTMLElement | null;
+		if (!canvas || !wrapper || !contentBox || !scrollContainer) return null;
+		const containerRect = scrollContainer.getBoundingClientRect();
+		return {
+			scale: contentBox.getBoundingClientRect().width / canvas.width,
+			scrollLeft: scrollContainer.scrollLeft,
+			scrollTop: scrollContainer.scrollTop,
+			offsetX: contentBox.offsetLeft,
+			offsetY: contentBox.offsetTop,
+			containerLeft: containerRect.left,
+			containerTop: containerRect.top,
+			containerWidth: scrollContainer.clientWidth,
+			containerHeight: scrollContainer.clientHeight,
+			canvasWidth: canvas.width,
+			canvasHeight: canvas.height,
+		};
+	}, testId);
+	if (!geometry) {
+		throw new Error(`ズームジオメトリを取得できません: ${testId}`);
+	}
+	return geometry;
+}
+
+/**
+ * ページ絶対座標（clientX/clientY、Playwrightのマウス座標系）が指す画像内座標を、
+ * ズーム幾何情報から算出する。「カーソル直下の画像座標」を実装非依存に定義するための
+ * 純粋な幾何計算であり、アプリ側の補正ロジックは呼び出さない。
+ */
+export function imagePointFromClientPoint(
+	geometry: ZoomGeometry,
+	clientX: number,
+	clientY: number,
+): { x: number; y: number } {
+	const pointerX = clientX - geometry.containerLeft;
+	const pointerY = clientY - geometry.containerTop;
+	return {
+		x: (pointerX + geometry.scrollLeft - geometry.offsetX) / geometry.scale,
+		y: (pointerY + geometry.scrollTop - geometry.offsetY) / geometry.scale,
+	};
+}
+
+/**
+ * スクロールコンテナ自体の可視範囲（ページ絶対座標）を返す。
+ * canvas 自身の boundingBox はコンテナの overflow で隠れている部分も含む
+ * フルサイズを返してしまう（ズームでコンテンツがコンテナより大きくなった場合、
+ * 画面外の座標を含みうる）ため、マウス操作の目標座標には必ずこちらを使う。
+ */
+export async function getContainerBox(
+	page: Page,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+	const container = page.getByTestId('zoom-scroll-container');
+	// ページレイアウトによってはビューポート下端より下に位置することがあるため、
+	// 座標計算の前に確実にビューポート内へスクロールしておく
+	await container.scrollIntoViewIfNeeded();
+	const box = await container.boundingBox();
+	if (!box) throw new Error('zoom-scroll-container が表示されていません');
+	return box;
+}
+
+/** 指定のページ絶対座標にカーソルを置き、修飾キー付きホイールでズームする */
+export async function zoomAtClientPoint(
+	page: Page,
+	clientX: number,
+	clientY: number,
+	deltaY: number,
+	modifier: 'Control' | 'Meta' = 'Control',
+): Promise<void> {
+	await page.mouse.move(clientX, clientY);
+	await page.keyboard.down(modifier);
+	await page.mouse.wheel(0, deltaY);
+	await page.keyboard.up(modifier);
+}
+
+/**
+ * 指定サイズの単色パターンPNGをブラウザのcanvasで生成しBufferとして返す。
+ * 縦長・横長・巨大画像でのフィット倍率／中央配置オフセット挙動を検証するために使う
+ * （新規npm依存を追加せず、Canvas APIのみでフィクスチャを都度生成する）。
+ */
+export async function generateSyntheticImage(
+	page: Page,
+	width: number,
+	height: number,
+): Promise<Buffer> {
+	const dataUrl = await page.evaluate(
+		({ width, height }) => {
+			const canvas = document.createElement('canvas');
+			canvas.width = width;
+			canvas.height = height;
+			const ctx = canvas.getContext('2d');
+			if (!ctx) throw new Error('2D context取得に失敗しました');
+			ctx.fillStyle = '#ffffff';
+			ctx.fillRect(0, 0, width, height);
+			ctx.fillStyle = '#dc2828';
+			ctx.fillRect(0, 0, Math.min(40, width), Math.min(40, height));
+			return canvas.toDataURL('image/png');
+		},
+		{ width, height },
+	);
+	const base64 = dataUrl.split(',')[1] ?? '';
+	return Buffer.from(base64, 'base64');
+}

--- a/tests/e2e/image-mosaic.spec.ts
+++ b/tests/e2e/image-mosaic.spec.ts
@@ -257,8 +257,10 @@ test.describe('画像モザイク・ぼかし', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 		const canvas = page.getByTestId('editor-canvas');
 		await expect(canvas).toBeVisible();
-		const boxMobile = await canvas.boundingBox();
-		expect(boxMobile?.width).toBeLessThanOrEqual(375);
+		// ズームビューポートのフィット再計算は ResizeObserver 経由の非同期のため poll で待つ
+		await expect
+			.poll(async () => (await canvas.boundingBox())?.width)
+			.toBeLessThanOrEqual(375);
 		await expect(page.getByRole('tab', { name: 'モザイク' })).toBeVisible();
 
 		await page.setViewportSize({ width: 1440, height: 900 });
@@ -266,6 +268,113 @@ test.describe('画像モザイク・ぼかし', () => {
 		await expect(
 			page.getByRole('button', { name: 'ダウンロード' }),
 		).toBeVisible();
+	});
+});
+
+test.describe('ズーム＆パン・フルサイズ表示', () => {
+	test.beforeEach(async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('image-mosaic');
+		await toolPage.goto();
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+	});
+
+	test('アップロード直後はフィット表示で、ズームコントロールが揃っている', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
+		await expect(page.getByRole('button', { name: 'フィット' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '100%' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '縮小' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '拡大' })).toBeVisible();
+	});
+
+	test('100%ボタンで等倍表示になり、canvas内部解像度は変わらない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('editor-canvas');
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+		const size = await canvas.evaluate((el) => [
+			(el as HTMLCanvasElement).width,
+			(el as HTMLCanvasElement).height,
+		]);
+		expect(size).toEqual([400, 300]);
+	});
+
+	test('＋ボタンで拡大した後もドラッグ選択が正しい画像座標に適用される', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('editor-canvas');
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		const before = await percentLabel.textContent();
+		// 表示領域内に収まる範囲でズームする（拡大しすぎるとスクロールで対象領域が
+		// 見切れるため、可視範囲を保ったまま座標変換の正しさを検証する）
+		await page.getByRole('button', { name: '拡大' }).click();
+		await expect(percentLabel).not.toHaveText(before ?? '');
+
+		// 拡大後も画像座標ベースのドラッグ選択が正しく機能する（境界をまたぐ領域）
+		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
+		await expect
+			.poll(() => getCanvasPixel(page, 'editor-canvas', 96, 100))
+			.not.toEqual(WHITE);
+		expect(await getCanvasPixel(page, 'editor-canvas', 96, 100)).not.toEqual(
+			RED,
+		);
+		// 領域外は不変（ズームしてもエクスポート対象のピクセルは影響を受けない）
+		expect(await getCanvasPixel(page, 'editor-canvas', 300, 200)).toEqual(
+			WHITE,
+		);
+	});
+
+	test('Ctrl+ホイールでカーソル位置基準にズームできる', async ({ page }) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('editor-canvas');
+		await canvas.scrollIntoViewIfNeeded();
+		const box = await canvas.boundingBox();
+		if (!box) throw new Error('canvas が表示されていません');
+
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		const before = await percentLabel.textContent();
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.keyboard.down('Control');
+		await page.mouse.wheel(0, -200);
+		await page.keyboard.up('Control');
+
+		await expect.poll(() => percentLabel.textContent()).not.toBe(before);
+	});
+
+	test('フルサイズ切替でページ幅上限が解除され、ズーム状態は維持される', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		const container = page.locator('#tool-layout-container');
+		await expect(container).toHaveClass(/max-w-\[800px\]/);
+
+		await page.getByRole('button', { name: 'フルサイズ' }).click();
+		await expect(container).toHaveClass(/max-w-full/);
+		// フルサイズ切替でズーム倍率は再初期化されない
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		await page.getByRole('button', { name: '標準幅' }).click();
+		await expect(container).toHaveClass(/max-w-\[800px\]/);
+	});
+
+	test('別の画像を選び直すとフィット表示に戻る', async ({ page }) => {
+		await uploadSample(page);
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
+		await uploadSample(page);
+		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
 	});
 });
 

--- a/tests/e2e/image-mosaic.spec.ts
+++ b/tests/e2e/image-mosaic.spec.ts
@@ -4,7 +4,10 @@ import { expect, test } from './fixtures/base';
 import {
 	countDiffFromFixture,
 	dragOnCanvas,
+	generateSyntheticImage,
 	getCanvasPixel,
+	getContainerBox,
+	getZoomGeometry,
 	imagePointToPage,
 } from './helpers/canvas';
 
@@ -412,5 +415,145 @@ test.describe('stackBlur フォールバック実装', () => {
 		expect(r(2, 4)).toBe(r(6, 4));
 		expect(r(4, 3)).toBe(r(4, 5));
 		expect(r(3, 4)).toBeLessThanOrEqual(r(4, 4));
+	});
+});
+
+test.describe('モバイル編集／パンモード', () => {
+	test.beforeEach(async ({ page, createToolPage }) => {
+		// モバイル用の編集／パン切替ボタンは sm:hidden のため、
+		// どの Playwright project で実行してもボタンが見えるよう明示的に狭める
+		await page.setViewportSize({ width: 375, height: 812 });
+		const toolPage = createToolPage('image-mosaic');
+		await toolPage.goto();
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+	});
+
+	const editButton = (page: import('@playwright/test').Page) =>
+		page.getByRole('button', { name: '編集モード（ドラッグで選択・移動）' });
+	const panButton = (page: import('@playwright/test').Page) =>
+		page.getByRole('button', { name: 'パンモード（ドラッグで画像内を移動）' });
+
+	test('アップロード直後は編集モードで、Accessible Nameとaria-pressedが正しい', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'false');
+	});
+
+	test('編集モードでは既存のドラッグ選択が機能する', async ({ page }) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('editor-canvas');
+		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
+		await expect
+			.poll(() => getCanvasPixel(page, 'editor-canvas', 96, 100))
+			.not.toEqual(WHITE);
+	});
+
+	test('パンモードに切り替えるとドラッグ選択が発火しない', async ({ page }) => {
+		await uploadSample(page);
+		await panButton(page).click();
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
+
+		const canvas = page.getByTestId('editor-canvas');
+		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
+		// パンモードでは領域が追加されないため、canvasはフィクスチャ原画のまま
+		expect(await countDiffFromFixture(page, 'editor-canvas')).toBe(0);
+	});
+
+	test('パンモードでは画像の四隅へ移動でき、ページの横スクロールは発生しない', async ({
+		page,
+	}) => {
+		// フィクスチャ(400x300)は100%表示でもコンテナ内に収まってしまいパンの
+		// 余地がないため、縦横ともコンテナよりはっきり大きい画像を使う
+		const buffer = await generateSyntheticImage(page, 2400, 1800);
+		await page
+			.locator('input[type="file"]')
+			.setInputFiles({ name: 'large.png', mimeType: 'image/png', buffer });
+		await expect(page.getByTestId('editor-canvas')).toBeVisible();
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+		await panButton(page).click();
+
+		const containerBox = await getContainerBox(page);
+		const cx = containerBox.x + containerBox.width / 2;
+		const cy = containerBox.y + containerBox.height / 2;
+		await page.mouse.move(cx, cy);
+
+		// 左上へ（負方向いっぱいにスクロール）
+		await page.mouse.wheel(-5000, -5000);
+		await expect
+			.poll(
+				async () => (await getZoomGeometry(page, 'editor-canvas')).scrollLeft,
+			)
+			.toBe(0);
+		expect((await getZoomGeometry(page, 'editor-canvas')).scrollTop).toBe(0);
+
+		// 右下へ（正方向いっぱいにスクロール）
+		await page.mouse.wheel(5000, 5000);
+		await expect
+			.poll(
+				async () => (await getZoomGeometry(page, 'editor-canvas')).scrollLeft,
+			)
+			.toBeGreaterThan(0);
+		const afterBottomRight = await getZoomGeometry(page, 'editor-canvas');
+		expect(afterBottomRight.scrollTop).toBeGreaterThan(0);
+
+		// ページ全体に不要な横スクロールが発生していないこと
+		const hasHorizontalOverflow = await page.evaluate(
+			() =>
+				document.documentElement.scrollWidth >
+				document.documentElement.clientWidth,
+		);
+		expect(hasHorizontalOverflow).toBe(false);
+	});
+
+	test('ズームビューポート外ではページの縦スクロールが阻害されない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const scrollYBefore = await page.evaluate(() => window.scrollY);
+		// パンくずリスト付近（ズームビューポートより確実に上）にカーソルを置く
+		await page.mouse.move(10, 5);
+		await page.mouse.wheel(0, 400);
+		await expect
+			.poll(() => page.evaluate(() => window.scrollY))
+			.toBeGreaterThan(scrollYBefore);
+	});
+
+	test('新しい画像を読み込むと編集モードへ戻る', async ({ page }) => {
+		await uploadSample(page);
+		await panButton(page).click();
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
+
+		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
+		await uploadSample(page);
+		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('編集／パンの切替でズーム倍率や編集内容が失われない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('editor-canvas');
+		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
+		await page.getByRole('button', { name: '100%' }).click();
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		await expect(percentLabel).toHaveText('100%');
+		const pixelBefore = await getCanvasPixel(page, 'editor-canvas', 96, 100);
+
+		await panButton(page).click();
+		await expect(percentLabel).toHaveText('100%');
+		expect(await getCanvasPixel(page, 'editor-canvas', 96, 100)).toEqual(
+			pixelBefore,
+		);
+
+		await editButton(page).click();
+		await expect(percentLabel).toHaveText('100%');
+		expect(await getCanvasPixel(page, 'editor-canvas', 96, 100)).toEqual(
+			pixelBefore,
+		);
 	});
 });

--- a/tests/e2e/image-text.spec.ts
+++ b/tests/e2e/image-text.spec.ts
@@ -157,8 +157,10 @@ test.describe('画像テキスト挿入', () => {
 		await page.setViewportSize({ width: 375, height: 667 });
 		const canvas = page.getByTestId('text-canvas');
 		await expect(canvas).toBeVisible();
-		const boxMobile = await canvas.boundingBox();
-		expect(boxMobile?.width).toBeLessThanOrEqual(375);
+		// ズームビューポートのフィット再計算は ResizeObserver 経由の非同期のため poll で待つ
+		await expect
+			.poll(async () => (await canvas.boundingBox())?.width)
+			.toBeLessThanOrEqual(375);
 		await expect(
 			page.getByRole('button', { name: 'テキストを追加' }),
 		).toBeVisible();
@@ -168,5 +170,112 @@ test.describe('画像テキスト挿入', () => {
 		await expect(
 			page.getByRole('button', { name: 'ダウンロード' }),
 		).toBeVisible();
+	});
+});
+
+test.describe('ズーム＆パン・フルサイズ表示', () => {
+	test.beforeEach(async ({ page, createToolPage }) => {
+		const toolPage = createToolPage('image-text');
+		await toolPage.goto();
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+	});
+
+	test('アップロード直後はフィット表示で、ズームコントロールが揃っている', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
+		await expect(page.getByRole('button', { name: 'フィット' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '100%' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '縮小' })).toBeVisible();
+		await expect(page.getByRole('button', { name: '拡大' })).toBeVisible();
+	});
+
+	test('100%表示でもcanvas内部解像度は変わらない', async ({ page }) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('text-canvas');
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+		const size = await canvas.evaluate((el) => [
+			(el as HTMLCanvasElement).width,
+			(el as HTMLCanvasElement).height,
+		]);
+		expect(size).toEqual([400, 300]);
+	});
+
+	test('拡大した後もレイヤーのドラッグ移動が正しい画像座標で機能する', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await addLayer(page);
+		const canvas = page.getByTestId('text-canvas');
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		const before = await percentLabel.textContent();
+		// 表示領域内に収まる範囲でズームする（拡大しすぎるとスクロールで対象領域が
+		// 見切れるため、可視範囲を保ったまま座標変換の正しさを検証する）
+		await page.getByRole('button', { name: '拡大' }).click();
+		await expect(percentLabel).not.toHaveText(before ?? '');
+
+		const from = await imagePointToPage(canvas, 200, 148);
+		const to = await imagePointToPage(canvas, 200, 248);
+		await page.mouse.move(from.x, from.y);
+		await page.mouse.down();
+		await page.mouse.move(to.x, to.y, { steps: 5 });
+		await page.mouse.up();
+
+		await expect
+			.poll(() => countDiffFromFixture(page, 'text-canvas', TEXT_REGION))
+			.toBe(0);
+		const movedRegion = { x: 120, y: 200, width: 200, height: 90 };
+		expect(
+			await countDiffFromFixture(page, 'text-canvas', movedRegion),
+		).toBeGreaterThan(0);
+	});
+
+	test('Ctrl+ホイールでカーソル位置基準にズームできる', async ({ page }) => {
+		await uploadSample(page);
+		const canvas = page.getByTestId('text-canvas');
+		await canvas.scrollIntoViewIfNeeded();
+		const box = await canvas.boundingBox();
+		if (!box) throw new Error('canvas が表示されていません');
+
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		const before = await percentLabel.textContent();
+		await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+		await page.keyboard.down('Control');
+		await page.mouse.wheel(0, -200);
+		await page.keyboard.up('Control');
+
+		await expect.poll(() => percentLabel.textContent()).not.toBe(before);
+	});
+
+	test('フルサイズ切替でページ幅上限が解除され、ズーム状態は維持される', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		const container = page.locator('#tool-layout-container');
+		await expect(container).toHaveClass(/max-w-\[800px\]/);
+
+		await page.getByRole('button', { name: 'フルサイズ' }).click();
+		await expect(container).toHaveClass(/max-w-full/);
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		await page.getByRole('button', { name: '標準幅' }).click();
+		await expect(container).toHaveClass(/max-w-\[800px\]/);
+	});
+
+	test('別の画像を選び直すとフィット表示に戻る', async ({ page }) => {
+		await uploadSample(page);
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+
+		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
+		await uploadSample(page);
+		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
 	});
 });

--- a/tests/e2e/image-text.spec.ts
+++ b/tests/e2e/image-text.spec.ts
@@ -3,7 +3,10 @@ import { expect, test } from './fixtures/base';
 import {
 	countDiffFromFixture,
 	countMatchingPixels,
+	generateSyntheticImage,
 	getCanvasPixel,
+	getContainerBox,
+	getZoomGeometry,
 	imagePointToPage,
 } from './helpers/canvas';
 
@@ -277,5 +280,166 @@ test.describe('ズーム＆パン・フルサイズ表示', () => {
 		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
 		await uploadSample(page);
 		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
+	});
+});
+
+test.describe('モバイル編集／パンモード', () => {
+	test.beforeEach(async ({ page, createToolPage }) => {
+		// モバイル用の編集／パン切替ボタンは sm:hidden のため、
+		// どの Playwright project で実行してもボタンが見えるよう明示的に狭める
+		await page.setViewportSize({ width: 375, height: 812 });
+		const toolPage = createToolPage('image-text');
+		await toolPage.goto();
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+	});
+
+	const editButton = (page: import('@playwright/test').Page) =>
+		page.getByRole('button', { name: '編集モード（ドラッグで選択・移動）' });
+	const panButton = (page: import('@playwright/test').Page) =>
+		page.getByRole('button', { name: 'パンモード（ドラッグで画像内を移動）' });
+
+	test('アップロード直後は編集モードで、Accessible Nameとaria-pressedが正しい', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'false');
+	});
+
+	test('編集モードでは既存のレイヤードラッグ移動が機能する', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await addLayer(page);
+		const canvas = page.getByTestId('text-canvas');
+
+		const from = await imagePointToPage(canvas, 200, 148);
+		const to = await imagePointToPage(canvas, 200, 248);
+		await page.mouse.move(from.x, from.y);
+		await page.mouse.down();
+		await page.mouse.move(to.x, to.y, { steps: 5 });
+		await page.mouse.up();
+
+		await expect
+			.poll(() => countDiffFromFixture(page, 'text-canvas', TEXT_REGION))
+			.toBe(0);
+	});
+
+	test('パンモードに切り替えるとレイヤードラッグ移動が発火しない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await addLayer(page);
+		await panButton(page).click();
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
+
+		const canvas = page.getByTestId('text-canvas');
+		const from = await imagePointToPage(canvas, 200, 148);
+		const to = await imagePointToPage(canvas, 200, 248);
+		await page.mouse.move(from.x, from.y);
+		await page.mouse.down();
+		await page.mouse.move(to.x, to.y, { steps: 5 });
+		await page.mouse.up();
+
+		// パンモードではレイヤーが移動しないため、元の位置に留まる
+		expect(
+			await countDiffFromFixture(page, 'text-canvas', TEXT_REGION),
+		).toBeGreaterThan(0);
+		const movedRegion = { x: 120, y: 200, width: 200, height: 90 };
+		expect(await countDiffFromFixture(page, 'text-canvas', movedRegion)).toBe(
+			0,
+		);
+	});
+
+	test('パンモードでは画像の四隅へ移動でき、ページの横スクロールは発生しない', async ({
+		page,
+	}) => {
+		// フィクスチャ(400x300)は100%表示でもコンテナ内に収まってしまいパンの
+		// 余地がないため、縦横ともコンテナよりはっきり大きい画像を使う
+		const buffer = await generateSyntheticImage(page, 2400, 1800);
+		await page
+			.locator('input[type="file"]')
+			.setInputFiles({ name: 'large.png', mimeType: 'image/png', buffer });
+		await expect(page.getByTestId('text-canvas')).toBeVisible();
+		await page.getByRole('button', { name: '100%' }).click();
+		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+		await panButton(page).click();
+
+		const containerBox = await getContainerBox(page);
+		const cx = containerBox.x + containerBox.width / 2;
+		const cy = containerBox.y + containerBox.height / 2;
+		await page.mouse.move(cx, cy);
+
+		await page.mouse.wheel(-5000, -5000);
+		await expect
+			.poll(async () => (await getZoomGeometry(page, 'text-canvas')).scrollLeft)
+			.toBe(0);
+		expect((await getZoomGeometry(page, 'text-canvas')).scrollTop).toBe(0);
+
+		await page.mouse.wheel(5000, 5000);
+		await expect
+			.poll(async () => (await getZoomGeometry(page, 'text-canvas')).scrollLeft)
+			.toBeGreaterThan(0);
+		const afterBottomRight = await getZoomGeometry(page, 'text-canvas');
+		expect(afterBottomRight.scrollTop).toBeGreaterThan(0);
+
+		const hasHorizontalOverflow = await page.evaluate(
+			() =>
+				document.documentElement.scrollWidth >
+				document.documentElement.clientWidth,
+		);
+		expect(hasHorizontalOverflow).toBe(false);
+	});
+
+	test('ズームビューポート外ではページの縦スクロールが阻害されない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const scrollYBefore = await page.evaluate(() => window.scrollY);
+		await page.mouse.move(10, 5);
+		await page.mouse.wheel(0, 400);
+		await expect
+			.poll(() => page.evaluate(() => window.scrollY))
+			.toBeGreaterThan(scrollYBefore);
+	});
+
+	test('新しい画像を読み込むと編集モードへ戻る', async ({ page }) => {
+		await uploadSample(page);
+		await panButton(page).click();
+		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
+
+		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
+		await uploadSample(page);
+		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
+	});
+
+	test('編集／パンの切替でズーム倍率や編集内容が失われない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		await addLayer(page);
+		await page.getByRole('button', { name: '100%' }).click();
+		const percentLabel = page.getByTestId('zoom-percent-label');
+		await expect(percentLabel).toHaveText('100%');
+		const diffBefore = await countDiffFromFixture(
+			page,
+			'text-canvas',
+			TEXT_REGION,
+		);
+		expect(diffBefore).toBeGreaterThan(0);
+
+		await panButton(page).click();
+		await expect(percentLabel).toHaveText('100%');
+		expect(await countDiffFromFixture(page, 'text-canvas', TEXT_REGION)).toBe(
+			diffBefore,
+		);
+
+		await editButton(page).click();
+		await expect(percentLabel).toHaveText('100%');
+		expect(await countDiffFromFixture(page, 'text-canvas', TEXT_REGION)).toBe(
+			diffBefore,
+		);
 	});
 });

--- a/tests/e2e/image-tools-full-size.spec.ts
+++ b/tests/e2e/image-tools-full-size.spec.ts
@@ -1,0 +1,151 @@
+// image-mosaic / image-text のフルサイズ設定（isExpanded）が、
+// SQLフォーマッターと同一パターン（useToolSettings）を通じて
+// 「共有URLパラメーター → localStorage → 既定値」の優先順位・
+// ツール間の設定キー非衝突・不正値への耐性を満たすことを検証する。
+//
+// 判断事項: 本PRでは「共有URLからの復元」のみを対象とし、SQLフォーマッターの
+// ような「設定を共有」ボタン（共有URL生成UI）は追加していない。isExpanded は
+// ツールごとに1つのbool値のみで、ユーザーが意図的に共有する価値のある設定
+// （SQLフォーマッターの方言・インデント等）と性質が異なるため、既存パターンの
+// 「状態永続化の仕組み」だけを再利用し、UI追加はスコープ外と判断した。
+import path from 'node:path';
+import { expect, test } from './fixtures/base';
+
+const FIXTURE = path.join(
+	process.cwd(),
+	'tests',
+	'e2e',
+	'fixtures',
+	'sample-400x300.png',
+);
+
+type ToolId = 'image-mosaic' | 'image-text';
+
+const TOOLS: { id: ToolId; storageKey: string; canvasTestId: string }[] = [
+	{
+		id: 'image-mosaic',
+		storageKey: 'tool_settings_image-mosaic',
+		canvasTestId: 'editor-canvas',
+	},
+	{
+		id: 'image-text',
+		storageKey: 'tool_settings_image-text',
+		canvasTestId: 'text-canvas',
+	},
+];
+
+function encodeSettings(settings: Record<string, unknown>): string {
+	return Buffer.from(JSON.stringify(settings)).toString('base64');
+}
+
+for (const tool of TOOLS) {
+	test.describe(`${tool.id}: フルサイズ設定の優先順位`, () => {
+		test('共有URLパラメーターでフルサイズ状態が復元され、ページ幅とズームビューポートの高さが同期する', async ({
+			page,
+		}) => {
+			const settings = encodeSettings({ isExpanded: true });
+			await page.goto(`/${tool.id}?settings=${settings}`);
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+
+			await expect(page.locator('#tool-layout-container')).toHaveClass(
+				/max-w-full/,
+			);
+
+			// フルサイズ／標準幅トグルとズームビューポートは画像読み込み後（編集フェーズ）
+			// にのみ表示されるため、画像を読み込んでから両方の同期を確認する
+			await page.locator('input[type="file"]').setInputFiles(FIXTURE);
+			await expect(page.getByTestId(tool.canvasTestId)).toBeVisible();
+			await expect(page.getByRole('button', { name: '標準幅' })).toBeVisible();
+			await expect(page.getByTestId('zoom-scroll-container')).toHaveClass(
+				/h-\[70dvh\]/,
+			);
+		});
+
+		test('不正なsettingsパラメーターでもページは壊れず既定値で表示される', async ({
+			page,
+		}) => {
+			await page.goto(`/${tool.id}?settings=___not-valid-base64___`);
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+
+			// 復元に失敗した場合は既定値（標準幅）にフォールバックする
+			await expect(page.locator('#tool-layout-container')).toHaveClass(
+				/max-w-\[800px\]/,
+			);
+			await page.locator('input[type="file"]').setInputFiles(FIXTURE);
+			await expect(page.getByTestId(tool.canvasTestId)).toBeVisible();
+			await expect(
+				page.getByRole('button', { name: 'フルサイズ' }),
+			).toBeVisible();
+		});
+
+		test('localStorageに保存された前回設定が復元される', async ({ page }) => {
+			await page.goto(`/${tool.id}`);
+			await page.evaluate(
+				({ key }) => {
+					localStorage.setItem(key, JSON.stringify({ isExpanded: true }));
+				},
+				{ key: tool.storageKey },
+			);
+			await page.reload();
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+
+			await expect(page.locator('#tool-layout-container')).toHaveClass(
+				/max-w-full/,
+			);
+		});
+
+		test('共有URLパラメーターはlocalStorageより優先される', async ({
+			page,
+		}) => {
+			await page.goto(`/${tool.id}`);
+			await page.evaluate(
+				({ key }) => {
+					localStorage.setItem(key, JSON.stringify({ isExpanded: false }));
+				},
+				{ key: tool.storageKey },
+			);
+
+			const settings = encodeSettings({ isExpanded: true });
+			await page.goto(`/${tool.id}?settings=${settings}`);
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+
+			await expect(page.locator('#tool-layout-container')).toHaveClass(
+				/max-w-full/,
+			);
+		});
+	});
+}
+
+test.describe('image-mosaic / image-text の設定キーは衝突しない', () => {
+	test('image-mosaicのフルサイズ設定がimage-textに漏れない', async ({
+		page,
+	}) => {
+		await page.goto('/image-mosaic');
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+		await page.locator('input[type="file"]').setInputFiles(FIXTURE);
+		await expect(page.getByTestId('editor-canvas')).toBeVisible();
+		await page.getByRole('button', { name: 'フルサイズ' }).click();
+		await expect(page.locator('#tool-layout-container')).toHaveClass(
+			/max-w-full/,
+		);
+
+		await page.goto('/image-text');
+		await expect(
+			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+		).toBeVisible({ timeout: 10000 });
+		// image-mosaic 側で有効化したフルサイズ設定が image-text 側に漏れていないこと
+		await expect(page.locator('#tool-layout-container')).toHaveClass(
+			/max-w-\[800px\]/,
+		);
+	});
+});

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -1,0 +1,412 @@
+// image-mosaic / image-text 共通のズーム＆パン機構（ZoomableCanvasViewport）を
+// 対象にした、実装非依存の幾何検証。
+// 「倍率表示が変わったこと」ではなく「カーソル直下の画像内座標が維持されること」
+// をDOMから直接測定して検証する（tests/e2e/helpers/canvas.ts の getZoomGeometry /
+// imagePointFromClientPoint を参照）。
+import path from 'node:path';
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures/base';
+import {
+	generateSyntheticImage,
+	getContainerBox,
+	getZoomGeometry,
+	imagePointFromClientPoint,
+	type ZoomGeometry,
+	zoomAtClientPoint,
+} from './helpers/canvas';
+
+const SAMPLE = path.join(
+	process.cwd(),
+	'tests',
+	'e2e',
+	'fixtures',
+	'sample-400x300.png',
+);
+
+type Tool = {
+	id: 'image-mosaic' | 'image-text';
+	canvasTestId: string;
+};
+
+const TOOLS: Tool[] = [
+	{ id: 'image-mosaic', canvasTestId: 'editor-canvas' },
+	{ id: 'image-text', canvasTestId: 'text-canvas' },
+];
+
+/**
+ * ResizeObserver によるコンテナ実測（フィット倍率・中央配置オフセット）が
+ * 安定するまで待つ。アップロード直後や倍率操作直後は、初回の観測が届く前の
+ * 過渡値を読んでしまうことがあるため、2回連続で同じ値になるまでポーリングする。
+ */
+async function waitForStableGeometry(
+	page: Page,
+	canvasTestId: string,
+): Promise<ZoomGeometry> {
+	let previous: ZoomGeometry | null = null;
+	await expect
+		.poll(
+			async () => {
+				const current = await getZoomGeometry(page, canvasTestId);
+				const stable =
+					previous !== null &&
+					previous.scale === current.scale &&
+					previous.offsetX === current.offsetX &&
+					previous.offsetY === current.offsetY &&
+					previous.containerWidth === current.containerWidth &&
+					previous.containerHeight === current.containerHeight;
+				previous = current;
+				return stable;
+			},
+			{ intervals: [50, 50, 100], timeout: 5000 },
+		)
+		.toBe(true);
+	return getZoomGeometry(page, canvasTestId);
+}
+
+async function uploadFixture(page: Page, canvasTestId: string) {
+	await page.locator('input[type="file"]').setInputFiles(SAMPLE);
+	await expect(page.getByTestId(canvasTestId)).toBeVisible();
+	await waitForStableGeometry(page, canvasTestId);
+}
+
+async function uploadBuffer(
+	page: Page,
+	canvasTestId: string,
+	buffer: Buffer,
+	name: string,
+) {
+	await page
+		.locator('input[type="file"]')
+		.setInputFiles({ name, mimeType: 'image/png', buffer });
+	await expect(page.getByTestId(canvasTestId)).toBeVisible();
+	await waitForStableGeometry(page, canvasTestId);
+}
+
+/** 画像px単位の許容誤差。低倍率ほど1 CSS px の丸め誤差が画像px換算で拡大するため、
+ * 実効倍率に応じて許容量を広げる（無限に緩めないよう下限3pxで打ち止め）。 */
+function toleranceFor(geometry: ZoomGeometry): number {
+	return Math.max(3, 3 / geometry.scale);
+}
+
+async function waitForScaleChange(
+	page: Page,
+	canvasTestId: string,
+	previousScale: number,
+): Promise<ZoomGeometry> {
+	await expect
+		.poll(async () => (await getZoomGeometry(page, canvasTestId)).scale)
+		.not.toBe(previousScale);
+	return getZoomGeometry(page, canvasTestId);
+}
+
+/**
+ * コンテナよりはっきり大きい画像を100%表示にして、確実に実スクロール可能な
+ * （コンテンツ＞コンテナの）状態を作る。コンテンツがコンテナ内に収まる場合、
+ * カーソル基準の位置は「中央配置」に吸収されてしまい、カーソル追従の検証が
+ * 意味を持たないため（スクロール余地がなければ、どの点を基準にズームしても
+ * 中央寄せが優先されるのは仕様として正しい）。
+ */
+async function uploadLargePannableImage(page: Page, canvasTestId: string) {
+	const buffer = await generateSyntheticImage(page, 2400, 1800);
+	await uploadBuffer(page, canvasTestId, buffer, 'large.png');
+	await page.getByRole('button', { name: '100%' }).click();
+	await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
+	await waitForStableGeometry(page, canvasTestId);
+}
+
+/**
+ * クリック対象のページ絶対座標と、その時点の幾何情報を対にして返す。
+ * `getContainerBox` はコンテナをビューポート内へスクロールしうるため、
+ * 座標計算より前に幾何情報を読んでしまうと `containerTop` 等が古い値のまま
+ * ずれる。必ずスクロール確定後に幾何情報を読み直す。
+ */
+async function getClientPointAndGeometry(
+	page: Page,
+	canvasTestId: string,
+	xRatio: number,
+	yRatio: number,
+): Promise<{ clientX: number; clientY: number; geometry: ZoomGeometry }> {
+	const containerBox = await getContainerBox(page);
+	const geometry = await waitForStableGeometry(page, canvasTestId);
+	return {
+		clientX: containerBox.x + containerBox.width * xRatio,
+		clientY: containerBox.y + containerBox.height * yRatio,
+		geometry,
+	};
+}
+
+for (const tool of TOOLS) {
+	test.describe(`${tool.id}: カーソル基準ズームで画像内座標が維持される`, () => {
+		test.beforeEach(async ({ page, createToolPage }) => {
+			const toolPage = createToolPage(tool.id);
+			await toolPage.goto();
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+		});
+
+		const anchors: { name: string; xRatio: number; yRatio: number }[] = [
+			{ name: '中央', xRatio: 0.5, yRatio: 0.5 },
+			{ name: '左上寄り', xRatio: 0.12, yRatio: 0.12 },
+			{ name: '右下寄り', xRatio: 0.88, yRatio: 0.88 },
+		];
+
+		for (const anchor of anchors) {
+			test(`${anchor.name}を基準にCtrl+ホイールでズームしても画像内座標が維持される`, async ({
+				page,
+			}) => {
+				await uploadLargePannableImage(page, tool.canvasTestId);
+				const {
+					clientX,
+					clientY,
+					geometry: before,
+				} = await getClientPointAndGeometry(
+					page,
+					tool.canvasTestId,
+					anchor.xRatio,
+					anchor.yRatio,
+				);
+				const beforePoint = imagePointFromClientPoint(before, clientX, clientY);
+
+				await zoomAtClientPoint(page, clientX, clientY, -200, 'Control');
+				const after = await waitForScaleChange(
+					page,
+					tool.canvasTestId,
+					before.scale,
+				);
+				const afterPoint = imagePointFromClientPoint(after, clientX, clientY);
+
+				const tolerance = toleranceFor(after);
+				expect(
+					Math.abs(beforePoint.x - afterPoint.x),
+					`x座標のずれ（許容${tolerance.toFixed(1)}px）`,
+				).toBeLessThanOrEqual(tolerance);
+				expect(
+					Math.abs(beforePoint.y - afterPoint.y),
+					`y座標のずれ（許容${tolerance.toFixed(1)}px）`,
+				).toBeLessThanOrEqual(tolerance);
+			});
+		}
+
+		test('metaKey(⌘)+ホイールでもカーソル位置基準にズームできる', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const {
+				clientX,
+				clientY,
+				geometry: before,
+			} = await getClientPointAndGeometry(page, tool.canvasTestId, 0.7, 0.3);
+			const beforePoint = imagePointFromClientPoint(before, clientX, clientY);
+
+			await zoomAtClientPoint(page, clientX, clientY, -150, 'Meta');
+			const after = await waitForScaleChange(
+				page,
+				tool.canvasTestId,
+				before.scale,
+			);
+			const afterPoint = imagePointFromClientPoint(after, clientX, clientY);
+
+			const tolerance = toleranceFor(after);
+			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
+				tolerance,
+			);
+		});
+
+		test('修飾キーなしのホイールはズームせず、通常のスクロールとして扱われる', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const percentLabel = page.getByTestId('zoom-percent-label');
+			const containerBox = await getContainerBox(page);
+			const before = await waitForStableGeometry(page, tool.canvasTestId);
+
+			await page.mouse.move(
+				containerBox.x + containerBox.width / 2,
+				containerBox.y + containerBox.height / 2,
+			);
+			// 修飾キーなしホイール: ズームは発生せず、コンテナが縦スクロールする
+			await page.mouse.wheel(0, 300);
+
+			await expect
+				.poll(
+					async () =>
+						(await getZoomGeometry(page, tool.canvasTestId)).scrollTop,
+				)
+				.toBeGreaterThan(before.scrollTop);
+			await expect(percentLabel).toHaveText('100%');
+		});
+
+		test('縦長画像でも中央配置オフセットを含めカーソル位置が維持される', async ({
+			page,
+		}) => {
+			const buffer = await generateSyntheticImage(page, 300, 2200);
+			await uploadBuffer(page, tool.canvasTestId, buffer, 'tall.png');
+			const canvas = page.getByTestId(tool.canvasTestId);
+			await canvas.scrollIntoViewIfNeeded();
+			const box = await canvas.boundingBox();
+			if (!box) throw new Error('canvas が表示されていません');
+			const clientX = box.x + box.width * 0.5;
+			const clientY = box.y + box.height * 0.3;
+
+			const before = await getZoomGeometry(page, tool.canvasTestId);
+			// 縦長画像はフィット時、横方向に大きな中央配置オフセットが生じる
+			expect(before.offsetX).toBeGreaterThan(10);
+			const beforePoint = imagePointFromClientPoint(before, clientX, clientY);
+
+			await zoomAtClientPoint(page, clientX, clientY, -200, 'Control');
+			const after = await waitForScaleChange(
+				page,
+				tool.canvasTestId,
+				before.scale,
+			);
+			const afterPoint = imagePointFromClientPoint(after, clientX, clientY);
+			const tolerance = toleranceFor(after);
+			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
+				tolerance,
+			);
+		});
+
+		test('横長画像でも中央配置オフセットを含めカーソル位置が維持される', async ({
+			page,
+		}) => {
+			const buffer = await generateSyntheticImage(page, 4000, 300);
+			await uploadBuffer(page, tool.canvasTestId, buffer, 'wide.png');
+			const canvas = page.getByTestId(tool.canvasTestId);
+			await canvas.scrollIntoViewIfNeeded();
+			const box = await canvas.boundingBox();
+			if (!box) throw new Error('canvas が表示されていません');
+			const clientX = box.x + box.width * 0.5;
+			const clientY = box.y + box.height * 0.5;
+
+			const before = await getZoomGeometry(page, tool.canvasTestId);
+			// 横長の巨大画像はフィット時、縦方向に大きな中央配置オフセットが生じる
+			expect(before.offsetY).toBeGreaterThan(10);
+			const beforePoint = imagePointFromClientPoint(before, clientX, clientY);
+
+			await zoomAtClientPoint(page, clientX, clientY, -200, 'Control');
+			const after = await waitForScaleChange(
+				page,
+				tool.canvasTestId,
+				before.scale,
+			);
+			const afterPoint = imagePointFromClientPoint(after, clientX, clientY);
+			const tolerance = toleranceFor(after);
+			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
+				tolerance,
+			);
+		});
+
+		test('フィット倍率25%未満からの連続ズームは不自然にジャンプせず、25%到達後は25〜400%にクランプされる', async ({
+			page,
+		}) => {
+			// 横方向のフィット比率が確実に25%を下回るよう、十分に横長の画像を使う
+			const buffer = await generateSyntheticImage(page, 4000, 300);
+			await uploadBuffer(page, tool.canvasTestId, buffer, 'wide.png');
+			const percentLabel = page.getByTestId('zoom-percent-label');
+			await expect(percentLabel).toContainText('フィット');
+
+			const readPercent = async () => {
+				const text = (await percentLabel.textContent()) ?? '';
+				const match = text.match(/(\d+)%/);
+				if (!match) throw new Error(`倍率表示を解析できません: ${text}`);
+				return Number(match[1]);
+			};
+			const initialPercent = await readPercent();
+			expect(initialPercent).toBeLessThan(25);
+
+			const containerBox = await getContainerBox(page);
+			const clientX = containerBox.x + containerBox.width / 2;
+			const clientY = containerBox.y + containerBox.height / 2;
+
+			// 25%未満の間は「25%へ即時ジャンプ」せず、連続的に増加することを確認する。
+			// 丸め表示（整数%）は1回の操作では変化しないことがあるため、
+			// 「単調に非減少」かつ「複数回の操作を要する」ことで検証する
+			// （厳密な数値クランプは zoom-pan.test.ts の単体テストで担保する）。
+			// 30%まで続けるのは、表示は25%へ丸められていても内部値はまだ25%未満の
+			// ことがあり（例: 24.6%→表示"25%"）、その状態で次のクランプ検証に入ると
+			// 「25%未満は自由に動く」分岐のままズームアウトを続けてしまうため。
+			let previousPercent = initialPercent;
+			let percent = initialPercent;
+			let steps = 0;
+			for (let i = 0; i < 200 && percent < 30; i++) {
+				await zoomAtClientPoint(page, clientX, clientY, -60, 'Control');
+				await page.waitForTimeout(20);
+				percent = await readPercent();
+				expect(percent, '倍率表示は減少しないはず').toBeGreaterThanOrEqual(
+					previousPercent,
+				);
+				previousPercent = percent;
+				steps++;
+			}
+			expect(percent).toBeGreaterThanOrEqual(30);
+			expect(
+				steps,
+				'1回の操作で25%へ到達（急激なジャンプ）していないこと',
+			).toBeGreaterThan(1);
+
+			// 25%以上へ到達した後は、さらにズームアウトしても25%を下回らない
+			for (let i = 0; i < 15; i++) {
+				await zoomAtClientPoint(page, clientX, clientY, 300, 'Control');
+			}
+			await expect(percentLabel).toHaveText('25%');
+			await expect(page.getByRole('button', { name: '縮小' })).toBeDisabled();
+
+			// さらにズームインしても400%を超えない
+			for (let i = 0; i < 60; i++) {
+				await zoomAtClientPoint(page, clientX, clientY, -300, 'Control');
+			}
+			await expect(percentLabel).toHaveText('400%');
+			await expect(page.getByRole('button', { name: '拡大' })).toBeDisabled();
+		});
+	});
+
+	test.describe(`${tool.id}: ズームボタンの境界動作`, () => {
+		test.beforeEach(async ({ page, createToolPage }) => {
+			const toolPage = createToolPage(tool.id);
+			await toolPage.goto();
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+		});
+
+		test('ちょうど25%では縮小ボタンが無効になる（押しても倍率が変わらないため）', async ({
+			page,
+		}) => {
+			await uploadFixture(page, tool.canvasTestId);
+			await page.getByRole('button', { name: '100%' }).click();
+			const percentLabel = page.getByTestId('zoom-percent-label');
+			await expect(percentLabel).toHaveText('100%');
+
+			const zoomOutButton = page.getByRole('button', { name: '縮小' });
+			// 100% → 50% → 25% とスナップ系列を下って25%に到達させる
+			await zoomOutButton.click();
+			await expect(percentLabel).toHaveText('50%');
+			await expect(zoomOutButton).toBeEnabled();
+			await zoomOutButton.click();
+			await expect(percentLabel).toHaveText('25%');
+			await expect(zoomOutButton).toBeDisabled();
+		});
+
+		test('400%では拡大ボタンが無効になる', async ({ page }) => {
+			await uploadFixture(page, tool.canvasTestId);
+			const percentLabel = page.getByTestId('zoom-percent-label');
+			const zoomInButton = page.getByRole('button', { name: '拡大' });
+			for (let i = 0; i < 6; i++) {
+				if (await zoomInButton.isDisabled()) break;
+				await zoomInButton.click();
+			}
+			await expect(percentLabel).toHaveText('400%');
+			await expect(zoomInButton).toBeDisabled();
+		});
+	});
+}

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -10,6 +10,8 @@ import {
 	computeWheelZoom,
 	computeZoomScrollPosition,
 	formatZoomPercent,
+	isZoomInNoop,
+	isZoomOutNoop,
 	MAX_ZOOM,
 	MIN_ZOOM,
 	nextZoomInStep,
@@ -190,4 +192,39 @@ test('formatZoomPercent: 倍率を%表示に変換する', () => {
 	assert.equal(formatZoomPercent(1), '100%');
 	assert.equal(formatZoomPercent(0.18), '18%');
 	assert.equal(formatZoomPercent(2), '200%');
+});
+
+test('isZoomOutNoop: ちょうど25%では無効（押しても倍率が変わらない）', () => {
+	assert.equal(isZoomOutNoop(MIN_ZOOM), true);
+});
+
+test('isZoomOutNoop: 25%を超える数値倍率では有効', () => {
+	assert.equal(isZoomOutNoop(0.26), false);
+	assert.equal(isZoomOutNoop(1), false);
+	assert.equal(isZoomOutNoop(MAX_ZOOM), false);
+});
+
+test('isZoomOutNoop: フィット実効倍率が25%未満では無効（現在値を維持する無効操作）', () => {
+	assert.equal(isZoomOutNoop(0.18), true);
+	assert.equal(isZoomOutNoop(0.05), true);
+});
+
+test('isZoomOutNoop: 浮動小数点誤差を含む25%相当でも無効と判定する', () => {
+	// 0.1 + 0.15 は浮動小数点演算で 0.25 と厳密には一致しない典型例
+	assert.equal(isZoomOutNoop(0.1 + 0.15), true);
+});
+
+test('50%からの縮小は25%になる（isZoomOutNoopはfalse）', () => {
+	assert.equal(isZoomOutNoop(0.5), false);
+	assert.equal(nextZoomOutStep(0.5), MIN_ZOOM);
+});
+
+test('isZoomInNoop: 400%上限では無効', () => {
+	assert.equal(isZoomInNoop(MAX_ZOOM), true);
+});
+
+test('isZoomInNoop: 400%未満では有効', () => {
+	assert.equal(isZoomInNoop(2), false);
+	assert.equal(isZoomInNoop(MIN_ZOOM), false);
+	assert.equal(isZoomInNoop(0.05), false);
 });

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -1,0 +1,193 @@
+// 実行方法: npm run test:unit
+// ズーム＆パンの倍率計算・クランプ・カーソル基準スクロール補正を検証する。
+// DOM描画自体は E2E（image-mosaic.spec.ts / image-text.spec.ts）で検証する。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	clampZoom,
+	computeContentOffset,
+	computeFitScale,
+	computeWheelZoom,
+	computeZoomScrollPosition,
+	formatZoomPercent,
+	MAX_ZOOM,
+	MIN_ZOOM,
+	nextZoomInStep,
+	nextZoomOutStep,
+	normalizeWheelDelta,
+} from '../../src/lib/tools/zoom-pan.ts';
+
+test('computeFitScale: コンテナより大きい画像は縮小フィットする', () => {
+	assert.equal(computeFitScale(800, 600, 4000, 3000), 0.2);
+});
+
+test('computeFitScale: コンテナより小さい画像は拡大しない（上限1）', () => {
+	assert.equal(computeFitScale(800, 600, 200, 100), 1);
+});
+
+test('computeFitScale: 縦横比が異なる場合は小さい方の比率を採用する', () => {
+	// 幅基準なら 800/1000=0.8, 高さ基準なら 600/2000=0.3 → 0.3 を採用
+	assert.equal(computeFitScale(800, 600, 1000, 2000), 0.3);
+});
+
+test('computeFitScale: 寸法が0以下の場合は1を返す', () => {
+	assert.equal(computeFitScale(0, 600, 400, 300), 1);
+	assert.equal(computeFitScale(800, 600, 0, 300), 1);
+});
+
+test('clampZoom: 範囲外の値を25%〜400%へ丸める', () => {
+	assert.equal(clampZoom(0.1), MIN_ZOOM);
+	assert.equal(clampZoom(10), MAX_ZOOM);
+	assert.equal(clampZoom(1), 1);
+});
+
+test('nextZoomInStep: スナップ系列の次の値へ進む', () => {
+	assert.equal(nextZoomInStep(0.25), 0.5);
+	assert.equal(nextZoomInStep(0.6), 1);
+	assert.equal(nextZoomInStep(1), 2);
+	assert.equal(nextZoomInStep(4), 4); // 上限で維持
+});
+
+test('nextZoomInStep: フィット実効倍率が25%未満なら25%へ直接遷移する', () => {
+	assert.equal(nextZoomInStep(0.05), MIN_ZOOM);
+	assert.equal(nextZoomInStep(0.18), MIN_ZOOM);
+});
+
+test('nextZoomOutStep: スナップ系列の前の値へ戻る', () => {
+	assert.equal(nextZoomOutStep(4), 2);
+	assert.equal(nextZoomOutStep(1.2), 1);
+	assert.equal(nextZoomOutStep(0.25), MIN_ZOOM); // 下限で維持
+});
+
+test('nextZoomOutStep: フィット実効倍率が25%未満なら現在値を維持（無効操作）', () => {
+	assert.equal(nextZoomOutStep(0.18), 0.18);
+	assert.equal(nextZoomOutStep(0.05), 0.05);
+});
+
+test('normalizeWheelDelta: deltaMode によってpx換算が変わる', () => {
+	assert.equal(normalizeWheelDelta(10, 0), 10); // pixel
+	assert.equal(normalizeWheelDelta(2, 1), 32); // line (16px/line)
+	assert.equal(normalizeWheelDelta(1, 2), 800); // page
+});
+
+test('computeWheelZoom: 上方向スクロール(負のdeltaY)で拡大する', () => {
+	const next = computeWheelZoom(1, -100, 0);
+	assert.ok(next > 1, `拡大するはずが ${next}`);
+});
+
+test('computeWheelZoom: 下方向スクロール(正のdeltaY)で縮小する', () => {
+	const next = computeWheelZoom(1, 100, 0);
+	assert.ok(next < 1, `縮小するはずが ${next}`);
+});
+
+test('computeWheelZoom: 微小なホイール入力でも変化が生じる', () => {
+	const next = computeWheelZoom(1, -1, 0);
+	assert.ok(next > 1 && next < 1.01, `${next} は微小変化の範囲外`);
+});
+
+test('computeWheelZoom: 1イベント当たりの変化量はクランプされる（巨大delta）', () => {
+	const next = computeWheelZoom(1, -1_000_000, 0);
+	// クランプ後の最大 factor = exp(100 * 0.0015)
+	const expectedMax = Math.exp(100 * WHEEL_SENSITIVITY_FOR_TEST());
+	assert.ok(next <= expectedMax + 1e-9);
+});
+function WHEEL_SENSITIVITY_FOR_TEST() {
+	return 0.0015;
+}
+
+test('computeWheelZoom: 通常時（25%以上）は25〜400%にクランプされる', () => {
+	assert.equal(computeWheelZoom(0.26, 1_000_000, 0), MIN_ZOOM);
+	assert.equal(computeWheelZoom(3.9, -1_000_000, 0), MAX_ZOOM);
+});
+
+test('computeWheelZoom: フィット実効倍率25%未満からは25%未満を許容する', () => {
+	// 現在18%からわずかに縮小 → 25%未満のまま自由に動く（即座に25%へ丸めない）
+	const next = computeWheelZoom(0.18, 10, 0);
+	assert.ok(next < MIN_ZOOM, `${next} はクランプされず25%未満のはず`);
+});
+
+test('computeWheelZoom: フィット実効倍率25%未満から拡大を続けると25%以上でクランプ域に入る', () => {
+	let scale = 0.1;
+	for (let i = 0; i < 200 && scale < MIN_ZOOM; i++) {
+		scale = computeWheelZoom(scale, -50, 0);
+	}
+	assert.ok(scale >= MIN_ZOOM);
+	assert.ok(scale <= MAX_ZOOM);
+});
+
+test('computeContentOffset: コンテンツがコンテナより小さい場合は中央配置オフセットを返す', () => {
+	assert.equal(computeContentOffset(800, 400), 200);
+});
+
+test('computeContentOffset: コンテンツがコンテナ以上の場合は0を返す', () => {
+	assert.equal(computeContentOffset(800, 1200), 0);
+	assert.equal(computeContentOffset(800, 800), 0);
+});
+
+test('computeZoomScrollPosition: 中央固定でズームすると中心を維持する補正値になる', () => {
+	// コンテナ800、コンテンツ1000（フィットなし・オフセット0）、中心400をポインタに
+	const scroll = computeZoomScrollPosition({
+		pointerInViewport: 400,
+		scrollPosition: 100,
+		oldContentOffset: 0,
+		newContentOffset: 0,
+		oldScale: 1,
+		newScale: 2,
+		containerSize: 800,
+		contentSize: 1000,
+	});
+	// imagePoint = (400+100-0)/1 = 500 → newScroll = 500*2+0-400 = 600
+	assert.equal(scroll, 600);
+});
+
+test('computeZoomScrollPosition: 結果は0未満にならない', () => {
+	const scroll = computeZoomScrollPosition({
+		pointerInViewport: 0,
+		scrollPosition: 0,
+		oldContentOffset: 0,
+		newContentOffset: 0,
+		oldScale: 2,
+		newScale: 1,
+		containerSize: 800,
+		contentSize: 1000,
+	});
+	assert.ok(scroll >= 0);
+});
+
+test('computeZoomScrollPosition: 結果は最大スクロール量を超えない', () => {
+	const scroll = computeZoomScrollPosition({
+		pointerInViewport: 799,
+		scrollPosition: 5000,
+		oldContentOffset: 0,
+		newContentOffset: 0,
+		oldScale: 1,
+		newScale: 4,
+		containerSize: 800,
+		contentSize: 1000,
+	});
+	const maxScroll = 1000 * 4 - 800;
+	assert.ok(scroll <= maxScroll);
+});
+
+test('computeZoomScrollPosition: 中央配置オフセットがある場合も中心を維持する', () => {
+	// コンテンツ(400)がコンテナ(800)より小さい → オフセット200で中央配置
+	const oldOffset = computeContentOffset(800, 400 * 1);
+	const newOffset = computeContentOffset(800, 400 * 2);
+	const scroll = computeZoomScrollPosition({
+		pointerInViewport: 300, // オフセット200～600の範囲内（コンテンツ上）
+		scrollPosition: 0,
+		oldContentOffset: oldOffset,
+		newContentOffset: newOffset,
+		oldScale: 1,
+		newScale: 2,
+		containerSize: 800,
+		contentSize: 400,
+	});
+	assert.ok(scroll >= 0);
+});
+
+test('formatZoomPercent: 倍率を%表示に変換する', () => {
+	assert.equal(formatZoomPercent(1), '100%');
+	assert.equal(formatZoomPercent(0.18), '18%');
+	assert.equal(formatZoomPercent(2), '200%');
+});


### PR DESCRIPTION
## 課題と妥当性

高解像度画像（4000px級）を編集する際、表示がCSS縮小一択（`max-h-[60vh]`）で拡大手段がなく、マウス1pxの移動が画像上の数px相当になり精密な矩形選択が困難だった。競合リサーチ（PEKO STEP / SAVE EDITOR / EveryTool / Photopea / Squoosh）では拡大率メニューやCtrl+ホイールズームが標準搭載されており、精密編集ツールのテーブルステークスと判断（詳細はNotionタスク参照）。

## 採用した設計判断

- **スクロールコンテナ方式**: ズーム＝canvasラッパーの表示幅変更（CSSスケーリング）、パン＝ネイティブスクロール。canvas内部解像度・`clientToImage`座標変換・%配置オーバーレイ・`renderMasked`/`renderTextLayers`は無改修。
- 代替案として検討した**ビューポート再描画方式**（Konva等の導入）は不採用。新規npm依存を増やし、既存のE2Eピクセル検証・座標変換ロジックを作り直す必要があり、スコープに対して過大なためスクロールコンテナ方式を選んだ。
- フルサイズ（幅上限解除）はSQLフォーマッターの既存パターン（`useToolSettings` + `#tool-layout-container`のクラス切替）をそのまま踏襲。

## レビュー指摘への対応（今回の更新分）

| # | 指摘 | 対応 | 対応コミット |
|---|------|------|------|
| 1 | カーソル基準ズームE2Eが「倍率表示の変化」しか見ていない | `tests/e2e/zoom-pan.spec.ts` を新規追加し、ズーム前後のcanvas幾何（scale/scrollLeft/scrollTop/offset）からカーソル直下の画像内座標を実測し、左上／中央／右下・縦長／横長画像・中央配置オフセット・25%未満からの連続ズーム・25%以上クランプ・Ctrl/Metaの両経路・修飾キーなしホイールの非ズームを検証 | `86972eb` |
| 2 | モバイル編集／パンモードのE2Eがない | image-mosaic / image-text 両方に「モバイル編集／パンモード」describeブロックを追加。初期モード、編集操作の可否、四隅へのパン、ページの不要な横／縦スクロール抑止、Accessible Name・aria-pressed、新規画像での復帰、モード切替での状態保持を検証 | `ecfe2f5` |
| 3 | 25%ちょうどで縮小ボタンが有効なまま（押しても倍率が変わらない） | `isZoomOutDisabled`/`isZoomInDisabled` を「次の倍率が現在値と実質的に同一か」で判定する `isZoomOutNoop`/`isZoomInNoop` に変更（浮動小数点誤差を1e-9で許容）。単体・E2E双方に回帰テストを追加 | `3a611fc` |
| 4 | フルサイズ設定の共有URL仕様確認 | `tests/e2e/image-tools-full-size.spec.ts` を追加し、共有URL→localStorage→既定値の優先順位、ツール間の設定キー非衝突、不正なsettingsパラメーターでの非破壊を検証。判断事項は下記参照 | `ecfe2f5` |

### 追加で見つけた実装バグ（レビュー強化の過程で発覆）

E2Eを「倍率表示」ベースから「実座標」ベースに強化した過程で、以下の実バグを検出・修正した（`3a611fc`）。

- **`preventDefault`が効いていなかった**: ホイールズームをReactの合成`onWheel`で実装していたため、React 17+がwheelイベントをpassiveリスナーとして登録し`e.preventDefault()`が無効化されていた。結果、Ctrl+ホイールでアプリのズームと同時にブラウザ既定のスクロール／ページズームが発生しうる状態だった。ネイティブ`addEventListener('wheel', ..., { passive: false })`に変更して解消。
- **連続ホイールイベントでのscale取り違え**: 上記の修正の過程で、短時間に連続発火するホイールイベントがReactの再レンダーより速く届くと、クロージャに閉じ込めた古い`scale`を基準に計算し続け、25%クランプ後も倍率が下がり続ける不整合を発見。`scaleRef`で常に最新値を参照するよう修正。

## 変更ファイルと役割

- `src/lib/tools/zoom-pan.ts`: フィット倍率・スナップ倍率・ホイールズーム・カーソル基準スクロール補正の純粋関数群（`isZoomOutNoop`/`isZoomInNoop`を追加）
- `src/lib/hooks/useZoomPan.ts`: ResizeObserver・スクロール位置などDOM連携を扱うReactフック（ネイティブwheelリスナー・scaleRefに変更）
- `src/components/common/ZoomableCanvasViewport.tsx`: 共通ズームビューポート（`data-testid="zoom-scroll-container"`を追加）
- `src/components/image-mosaic/CanvasEditor.tsx`, `src/components/image-mosaic/ImageMosaicPage.tsx`: image-mosaicへの適用＋フルサイズトグル
- `src/components/image-text/TextCanvas.tsx`, `src/components/image-text/ImageTextPage.tsx`: image-textへの適用＋フルサイズトグル（`min-w-0`によるグリッドブローアウト修正込み）
- `tests/unit/zoom-pan.test.ts`: 純粋関数の単体テスト（`isZoomOutNoop`/`isZoomInNoop`含む）
- `tests/e2e/helpers/canvas.ts`: `getZoomGeometry` / `imagePointFromClientPoint` / `getContainerBox` / `zoomAtClientPoint` / `generateSyntheticImage` を追加
- `tests/e2e/zoom-pan.spec.ts`: カーソル基準ズームの座標検証・ズームボタン境界動作（新規）
- `tests/e2e/image-tools-full-size.spec.ts`: フルサイズ設定の優先順位・非衝突・非破壊検証（新規）
- `tests/e2e/image-mosaic.spec.ts`, `tests/e2e/image-text.spec.ts`: ズーム＆パンの基本E2E、モバイル編集／パンモードE2E追加

## 実行した自動検証コマンドと結果（今回の更新分）

- `npm run lint` → 0 errors（warning 14件はいずれも既存ファイル由来で本変更と無関係。個別確認済み）
- `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0` → 現ブランチで0 errors。**参考**: セッション序盤の実行時は既存の環境起因エラー3件（`astro:content`型解決、`ImportMeta.env`、wasm URL import）が出たが、`origin/main`（8e357b8）でも同一の3件が再現することを別途確認済み（本PRの変更とは無関係）
- `npm run test:unit` → 863 tests, 0 fail
- `npm run build` → 成功
- `npx playwright test tests/e2e/image-mosaic.spec.ts tests/e2e/image-text.spec.ts tests/e2e/zoom-pan.spec.ts tests/e2e/image-tools-full-size.spec.ts`（chromium + mobile-chrome）→ **152 passed, 0 failed**
- `npx playwright test`（全specファイル、chromium + mobile-chrome、約1030件）→ 1003 passed / 2 failed（下記の通り事前確認済みの無関係flaky） / 11 skipped / 16件は検証作業中の設定ファイル削除タイミングによる自己都合の見かけ上の失敗（実体は上記の152件個別再実行で全通過を確認済み）

### ベースブランチとの比較（既存失敗の切り分け）

| 失敗テスト | 本ブランチでの再現 | `origin/main`(8e357b8)での再現 | 判定 |
|---|---|---|---|
| `sql-formatter.spec.ts` "狭い画面ではレイアウト切替を表示せず…"（横スクロール許容5px、実測7px） | 3回中2回失敗（flaky） | 3回中2回失敗（flaky、同一挙動） | 既存のflakyテスト。本PRと無関係と確認済み |
| `upscale.spec.ts` "極小画像を4xアップスケールし…"（AI推論タイムアウト） | 発生 | 前回PR作成時に同一の無関係タイムアウトを確認済み（AI推論・本PRの変更ファイルと無関係） | 既存の環境依存タイムアウト。本PRと無関係 |

いずれも image-mosaic / image-text / zoom-pan 関連ファイルとは無関係であり、本PRの変更が原因ではないことを両ブランチでの再現性一致により確認した。

## 未実施の「要人間確認」チェックリスト

- [ ] 4000px級の実画像で、細かい文字へのモザイク指定が容易になっている
- [ ] カーソル基準ズームの追従に違和感がない（Chrome / Firefox / Safari）
- [ ] トラックパッドのピンチ（Ctrl+wheelイベント）で自然にズームできる
- [ ] ライト／ダークテーマ、ブラウザズーム200%でUIが破綻しない
- [ ] モバイル実機で編集／パン切替、ページ縦スクロール、画像四隅への移動に回帰がない（iOS Safari / Android Chrome）
  - 備考: 自動E2Eでは「パンモードで編集操作が発火しないこと」「スクロールコンテナが四隅まで到達できること（マウスホイール操作で検証）」までは確認済み。実機のタッチジェスチャ固有の挙動（慣性スクロール等）はPlaywrightで安定再現できないため、引き続き実機確認が必要

## 仕様上の判断事項

- **共有URL生成UI（「設定を共有」ボタン）は追加していない**。詳細設計書の「SQLフォーマッターの幅上限解除トグルと同一パターンを再利用する」は、`useToolSettings`による状態永続化と優先順位（共有URL→localStorage→既定値）の再利用を指すと判断し、そちらは`useToolSettings`をそのまま使うことで自動的に満たしている（`tests/e2e/image-tools-full-size.spec.ts`で検証済み）。一方、SQLフォーマッターの「設定を共有」ボタンはdialect/indent/layout等の複数設定をまとめて共有する機能であり、image-mosaic/image-textの`isExpanded`（単一bool値）に対して同種のUIを追加する必然性は薄いと判断し、スコープ外とした。この判断に異論があれば追加実装する。
- **`#tool-layout-container`のページ遷移時のクラス復元**について: 本リポジトリはAstroの静的MPA構成でView Transitions（`astro:transitions`）を使用していないため、ツールページ間の遷移は常にフルページロードであり、`#tool-layout-container`は毎回新規にレンダーされる。したがって「遷移時にクラスが残留する」問題は構造的に発生しない（念のためコードベースを確認し、`ClientRouter`/`transition:persist`の使用がないことを確認済み）。

## 残件（意図的にスコープ外）

- モバイルのピンチズーム・二本指パン、スペースキー＋ドラッグパン（別タスク候補）
- image-crop等、他の画像ツールへの横展開（効果検証後に判断）
- 4096px作業解像度上限（`DOWNSCALE_EDGE`）の変更
