### PR TITLE
fix(analytics): unify tool_run debounce, sync docs, instrument image-merge

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -13,19 +13,25 @@ CODE:LIFE Tools はクライアントサイド完結のツール集であり、�
 
 ## 収集イベント一覧 (Cloudflare Analytics Engine)
 
-改善効果を判定するため、以下の 5 つの完全匿名イベントを Cloudflare Analytics Engine 経由で収集する。
+改善効果を判定するため、以下の 6 つの完全匿名イベントを Cloudflare Analytics Engine 経由で収集する。
 
 | イベント名 | 発火条件 | 収集プロパティ (Allowlist) | 目的 |
 |---|---|---|---|
-| `tool_run` | ツール実行・変換処理が走った時 | `{ tool: string }` (ツールslug) | ツールの利用頻度の計測 |
+| `tool_run` | ツール実行・変換処理が走った時（発火タイミングの定義は下記） | `{ tool: string }` (ツールslug) | ツールの利用頻度の計測 |
 | `tool_engage` | 個別ツールで初めて入力・操作があった時（タブ単位で1回） | `{ tool: string }` (ツールslug) | ツールごとの実活用セッション数の計測 |
 | `search_empty` | トップ検索でヒットが0件だった時 | `{ lengthBucket: string, hasJapanese: boolean, tokenCount: number, q_redacted?: boolean }` | 未対応ツール需要の把握（生検索語は非送信） |
 | `related_click` | 関連ツール回遊カードのクリック時 | `{ from: string, to: string, setId?: string, position: number }` (ツールslug, セットID, リスト内位置) | ツール間回遊の導線効果の検証 |
-| `shared_url_open` | 共有URL経由で初期状態が復元された時 | `{ tool: string }` (ツールslug) | 共有機能の利用状況の検証 |
+| `shared_url_open` | 共有URL（`?settings=`）経由でツールページが開かれた時 | `{ tool: string }` (ツールslug) | 共有機能の利用状況の検証 |
+| `settings_restore` | ツール設定を URL または localStorage から復元した時 | `{ tool: string, source: 'localStorage' \| 'url' }` | 設定保持・共有導線の利用状況の検証 |
 
 ### 特記事項・マスクルール
+- **`tool_run` の発火タイミング（2種類）**: 呼び出し元の性質に応じて2つの発火方法を使い分ける（`src/lib/hooks/useToolAnalytics.ts`）。
+  - **即時発火 `trackRun()`**: ボタン押下・ファイル投入・ダウンロード実行など、ユーザーの明確な1アクションにつき1回実行される呼び出し元で使う。呼び出しごとに即座に1回発火する。
+  - **デバウンス発火 `trackRunDebounced()`**: テキスト入力などライブな値を `useEffect` の依存配列に含み、入力・再計算のたびに実行される呼び出し元で使う。`DEBOUNCE_MS`（500ms）以内の連続呼び出しを1回にまとめ、「入力が止まってから1回」だけ発火する。デバウンスのタイマーはフック内で一元管理し（`scheduleDebounced` / `cancelDebounced`）、各コンポーネント側で個別に `setTimeout` を書かない。アンマウント時は保留中のタイマーを解除する。
+  - どちらも内部的には共通の `trackRun` 実装を呼ぶため、`tool_engage` の保険発火（未発火時に確定させる処理）も同様に働く。
 - **`tool_engage` の発火タイミングと「初回」の定義**: マウント時（＝擬似ページビュー）には発火させない。ツールページ上で最初に発生したユーザー操作（`pointerdown` / `keydown`）を捕捉した時点、または最初の `trackRun()` 実行時のいずれか早い方で 1 回だけ発火する（`src/lib/hooks/useToolAnalytics.ts`）。実行は明確なエンゲージメントであるため、`trackRun()` は保険として `tool_engage` 未発火時に engage を確定させる。重複発火は React の `useRef` フラグと、`src/lib/analytics.ts` のモジュールスコープ `Set`（タブ単位・永続化なし）の二段で防止する。
 - **`search_empty` のマスクルール**: 検索語の生テキストは送信せず、集計用メタ情報（文字数バケット・日本語の有無・トークン数）のみを送信する。メールアドレスやURL、電話番号などの個人情報らしき文字列が含まれる場合は `q_redacted: true` フラグのみを付与する。
+- **`settings_restore` の実装箇所**: `useToolAnalytics.ts` は `trackSettingsRestore()` を公開しているが、実際の発火は `src/lib/hooks/useToolSettings.ts` が設定復元時に `track()` を直接呼び出す形で行っている（URL 復元・localStorage 復元のそれぞれで1回ずつ）。`?settings=` 付き URL を開いた場合、そのツールが `useToolSettings` を使っていれば `shared_url_open`（「共有URLで開かれた」）と `settings_restore`（`source: 'url'`、「設定が実際に復元された」）の両方が発火し得る。意味が異なる別イベントとして意図的に併存させている。
 - **slug の導出**: `tool`, `from`, `to` に渡す slug は、`src/lib/tools/catalog.ts` の定義を正本として利用し、文字列の手書きによる表記揺れを防止する。
 
 ### 匿名セッションID（プライバシー方針との整合性）

--- a/src/components/image-base64/ImageBase64Page.tsx
+++ b/src/components/image-base64/ImageBase64Page.tsx
@@ -43,7 +43,7 @@ function truncate(s: string): string {
 }
 
 export function ImageBase64Page() {
-	const { trackRun } = useToolAnalytics('image-base64');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('image-base64');
 	const [mode, setMode] = useState<Mode>('encode');
 
 	const [file, setFile] = useState<File | null>(null);
@@ -144,7 +144,7 @@ export function ImageBase64Page() {
 				setDecodedBlob(blob);
 				setDecodeError(null);
 				// Base64→画像 デコード成功の分析計測
-				trackRun();
+				trackRunDebounced();
 			} catch (err) {
 				if (decodedUrlRef.current) {
 					URL.revokeObjectURL(decodedUrlRef.current);
@@ -161,7 +161,7 @@ export function ImageBase64Page() {
 		}, 300);
 
 		return () => clearTimeout(timer);
-	}, [mode, decodeInput, trackRun]);
+	}, [mode, decodeInput, trackRunDebounced]);
 
 	useEffect(() => {
 		return () => {

--- a/src/components/image-merge/ImageMergePage.tsx
+++ b/src/components/image-merge/ImageMergePage.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
 import { useSingleResultProcessing } from '@/lib/hooks/useSingleResultProcessing.ts';
+import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
 import {
 	buildMergedFilename,
@@ -29,6 +30,7 @@ const ACCEPT = 'image/jpeg,image/png,image/webp,image/gif';
 type LoadedItem = MergeImageItem & { bitmap: ImageBitmap };
 
 export function ImageMergePage() {
+	const { trackRun } = useToolAnalytics('image-merge');
 	const [items, setItems] = useState<LoadedItem[]>([]);
 	const [options, setOptions] = useState<MergeOptions>(DEFAULT_MERGE_OPTIONS);
 	const [outputSize, setOutputSize] = useState<{
@@ -40,6 +42,7 @@ export function ImageMergePage() {
 	// 結果（結合画像）はダウンロード後にUIで参照しないため、React状態に保持しない
 	const { processing, error, setError, run } = useSingleResultProcessing<void>({
 		fallbackErrorMessage: '画像の書き出しに失敗しました。',
+		onRunComplete: trackRun,
 	});
 	const busy = loadingFiles || processing;
 

--- a/src/components/tools/AiSpreadsheetPrompt.tsx
+++ b/src/components/tools/AiSpreadsheetPrompt.tsx
@@ -20,7 +20,7 @@ import {
 const SAMPLE_DATA = `商品名\tカテゴリ\t売上\t粗利率\nコーヒー豆A\t食品\t128000\t32%\nマグカップ\t雑貨\t54000\t45%\nギフトセット\t食品\t212000\t38%`;
 
 export function AiSpreadsheetPrompt() {
-	const { trackRun } = useToolAnalytics('ai-spreadsheet-prompt');
+	const { trackRunDebounced } = useToolAnalytics('ai-spreadsheet-prompt');
 	const [input, setInput] = useState(SAMPLE_DATA);
 	const [format, setFormat] = useState<SpreadsheetInputFormat>('auto');
 	const [task, setTask] = useState<PromptTask>('analyze');
@@ -51,9 +51,9 @@ export function AiSpreadsheetPrompt() {
 			return;
 		}
 		if (input.trim() && result.prompt) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [input, result.prompt, trackRun]);
+	}, [input, result.prompt, trackRunDebounced]);
 
 	const copyPrompt = async () => {
 		if (!result.prompt) return;

--- a/src/components/tools/Base64Converter.tsx
+++ b/src/components/tools/Base64Converter.tsx
@@ -23,7 +23,7 @@ import {
 } from '@/lib/tools/base64';
 
 export default function Base64Converter() {
-	const { trackRun } = useToolAnalytics('base64');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('base64');
 	const [tab, setTab] = useState('text');
 
 	// Text Tab State
@@ -60,9 +60,9 @@ export default function Base64Converter() {
 	// エンコード/デコードが成功して変換結果が得られた時点で実行を計測（空入力・エラー時は発火しない）
 	useEffect(() => {
 		if (textResult.output && !textResult.error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [textResult, trackRun]);
+	}, [textResult, trackRunDebounced]);
 
 	// Handlers for File Drop
 	const handleDrop = useCallback(

--- a/src/components/tools/CharCount.tsx
+++ b/src/components/tools/CharCount.tsx
@@ -110,7 +110,7 @@ function ServiceProgressCard({ service }: { service: ServiceCountResult }) {
 }
 
 export default function CharCount() {
-	const { trackRun } = useToolAnalytics('char-count');
+	const { trackRunDebounced } = useToolAnalytics('char-count');
 	const [text, setText] = useState('');
 	const [secondarySnsOpen, setSecondarySnsOpen] = useState(false);
 
@@ -120,9 +120,9 @@ export default function CharCount() {
 	// テキストが実際に入力された（非空）時点でカウント実行を計測
 	useEffect(() => {
 		if (text) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [text, trackRun]);
+	}, [text, trackRunDebounced]);
 
 	const snsPrimary = services.filter(
 		(s) => s.category === 'sns' && s.group === 'primary',

--- a/src/components/tools/CronChecker.tsx
+++ b/src/components/tools/CronChecker.tsx
@@ -79,7 +79,7 @@ function severityBadgeVariant(
 }
 
 export default function CronChecker() {
-	const { trackRun } = useToolAnalytics('cron-checker');
+	const { trackRunDebounced } = useToolAnalytics('cron-checker');
 	const [settings, updateSettings] = useToolSettings<Settings>('cron-checker', {
 		extraTimeZone: 'UTC',
 	});
@@ -151,10 +151,9 @@ export default function CronChecker() {
 	const scheduleRaw = schedule?.raw;
 	useEffect(() => {
 		if (!scheduleRaw) return;
-		// キーストロークごとの計上を避けるため、入力が落ち着いてから計測する
-		const timer = setTimeout(() => trackRun(), 500);
-		return () => clearTimeout(timer);
-	}, [scheduleRaw, trackRun]);
+		// キーストロークごとの計上を避けるため、入力が落ち着いてから計測する（フック側で500msデバウンス）
+		trackRunDebounced();
+	}, [scheduleRaw, trackRunDebounced]);
 
 	const crontabCopy = schedule ? toCrontabLine(schedule) : null;
 	const githubCopy = schedule ? toGithubActionsSchedule(schedule) : null;

--- a/src/components/tools/DummyDataGenerator.tsx
+++ b/src/components/tools/DummyDataGenerator.tsx
@@ -54,7 +54,7 @@ const ALL_FIELDS: FieldItem[] = [
 ];
 
 export default function DummyDataGenerator() {
-	const { trackRun } = useToolAnalytics('dummy-data');
+	const { trackRunDebounced } = useToolAnalytics('dummy-data');
 	const [fields, setFields] = useState<FieldItem[]>(ALL_FIELDS);
 	const [selectedFields, setSelectedFields] = useState<Set<FieldType>>(
 		new Set(['name', 'kana', 'email', 'phone']),
@@ -86,14 +86,21 @@ export default function DummyDataGenerator() {
 		const timer = setTimeout(() => {
 			try {
 				setOutputData(generateDummyData(activeFields, count, format));
-				trackRun();
+				trackRunDebounced();
 			} catch (_e) {
 				setOutputData('');
 			}
 			setIsGenerating(false);
 		}, 50);
 		return () => clearTimeout(timer);
-	}, [activeFields, count, format, refreshKey, validationError, trackRun]);
+	}, [
+		activeFields,
+		count,
+		format,
+		refreshKey,
+		validationError,
+		trackRunDebounced,
+	]);
 
 	const previewData = useMemo(() => {
 		if (!outputData) return [];

--- a/src/components/tools/JwtDecoder.tsx
+++ b/src/components/tools/JwtDecoder.tsx
@@ -29,15 +29,15 @@ function ResultCard({ title, value }: { title: string; value: string }) {
 }
 
 export function JwtDecoder() {
-	const { trackRun } = useToolAnalytics('jwt-decoder');
+	const { trackRunDebounced } = useToolAnalytics('jwt-decoder');
 	const [input, setInput] = useState(SAMPLE_JWT);
 	const result = useMemo(() => decodeJwt(input), [input]);
 
 	useEffect(() => {
 		if (input.trim() && !result.error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [input, result.error, trackRun]);
+	}, [input, result.error, trackRunDebounced]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/tools/Masking.tsx
+++ b/src/components/tools/Masking.tsx
@@ -31,7 +31,7 @@ const TARGET_TYPES: { id: MaskTarget; label: string }[] = [
 ];
 
 export default function Masking() {
-	const { trackRun } = useToolAnalytics('masking');
+	const { trackRunDebounced } = useToolAnalytics('masking');
 	const [text, setText] = useState('');
 	const [targets, setTargets] = useState<Set<MaskTarget>>(
 		new Set(['email', 'phone', 'zipcode', 'card', 'mynumber']),
@@ -60,9 +60,9 @@ export default function Masking() {
 
 	useEffect(() => {
 		if (text.trim() && maskedText) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [text, maskedText, trackRun]);
+	}, [text, maskedText, trackRunDebounced]);
 
 	const toggleTarget = (id: MaskTarget) => {
 		setTargets((prev) => {

--- a/src/components/tools/QrGenerator.tsx
+++ b/src/components/tools/QrGenerator.tsx
@@ -52,7 +52,7 @@ function getContrastRatio(hex1: string, hex2: string) {
 }
 
 export default function QrGenerator() {
-	const { trackRun } = useToolAnalytics('qr-generator');
+	const { trackRunDebounced } = useToolAnalytics('qr-generator');
 	const [text, setText] = useState('');
 	const [options, setOptions] = useState<QROptions>(defaultOptions);
 	const [qrDataUrl, setQrDataUrl] = useState('');
@@ -80,14 +80,14 @@ export default function QrGenerator() {
 				]);
 				setQrDataUrl(dataUrl);
 				setQrSvg(svg);
-				trackRun();
+				trackRunDebounced();
 			} catch {
 				// ignore
 			}
 		}, 150);
 
 		return () => clearTimeout(timer);
-	}, [text, options, trackRun]);
+	}, [text, options, trackRunDebounced]);
 
 	const handleDownloadPng = useCallback(() => {
 		if (qrDataUrl) downloadDataUrl(qrDataUrl, 'qrcode.png');

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -28,7 +28,8 @@ import type { RegexResult } from '@/lib/tools/regex-tester';
 import { COMMON_PATTERNS, testRegex } from '@/lib/tools/regex-tester';
 
 export default function RegexTester() {
-	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('regex-tester');
+	const { trackRunDebounced, trackSharedUrlOpen } =
+		useToolAnalytics('regex-tester');
 
 	const [settings, updateSettings, generateShareUrl] = useToolSettings(
 		'regex-tester',
@@ -71,14 +72,14 @@ export default function RegexTester() {
 				if (!cancelled) {
 					setResult(r);
 					// テスト実行の分析計測
-					trackRun();
+					trackRunDebounced();
 				}
 			},
 		);
 		return () => {
 			cancelled = true;
 		};
-	}, [pattern, flags, text, showReplace, replacement, trackRun]);
+	}, [pattern, flags, text, showReplace, replacement, trackRunDebounced]);
 
 	// Handle synchronized scrolling for highlight overlay
 	const handleScroll = (e: UIEvent<HTMLTextAreaElement>) => {

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -79,7 +79,8 @@ const SQL_KEYWORDS = [
 ];
 
 export default function SqlFormatter() {
-	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('sql-formatter');
+	const { trackRun, trackRunDebounced, trackSharedUrlOpen } =
+		useToolAnalytics('sql-formatter');
 	const [input, setInput] = useState('');
 	const [settings, updateSettings, generateShareUrl] = useToolSettings(
 		'sql-formatter',
@@ -148,9 +149,9 @@ export default function SqlFormatter() {
 	// 手動ボタンとは別にこちらでも成功時の実行を計測する
 	useEffect(() => {
 		if (autoFormat && output && !error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [autoFormat, output, error, trackRun]);
+	}, [autoFormat, output, error, trackRunDebounced]);
 
 	useEffect(() => {
 		if (autoFormat) {

--- a/src/components/tools/TextDiff.tsx
+++ b/src/components/tools/TextDiff.tsx
@@ -20,7 +20,7 @@ import {
 } from '@/lib/tools/text-diff';
 
 export default function TextDiff() {
-	const { trackRun } = useToolAnalytics('text-diff');
+	const { trackRunDebounced } = useToolAnalytics('text-diff');
 	const [textA, setTextA] = useState('');
 	const [textB, setTextB] = useState('');
 	const [mode, setMode] = useState<DiffMode>('lines');
@@ -35,9 +35,9 @@ export default function TextDiff() {
 
 	useEffect(() => {
 		if (result) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [result, trackRun]);
+	}, [result, trackRunDebounced]);
 
 	const handleDrop = useCallback(
 		async (e: DragEvent<HTMLTextAreaElement>, target: 'A' | 'B') => {

--- a/src/components/tools/UnicodeConverter.tsx
+++ b/src/components/tools/UnicodeConverter.tsx
@@ -9,7 +9,7 @@ import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { textToUnicode, unicodeToText } from '@/lib/tools/unicode-converter';
 
 export default function UnicodeConverter() {
-	const { trackRun } = useToolAnalytics('unicode-converter');
+	const { trackRunDebounced } = useToolAnalytics('unicode-converter');
 	const [input, setInput] = useState('');
 	const [direction, setDirection] = useState<'encode' | 'decode'>('encode');
 
@@ -31,9 +31,9 @@ export default function UnicodeConverter() {
 
 	useEffect(() => {
 		if (input.trim() && result.output && !result.error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [input, result, trackRun]);
+	}, [input, result, trackRunDebounced]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/tools/UnixTime.tsx
+++ b/src/components/tools/UnixTime.tsx
@@ -71,7 +71,7 @@ function OutputRow({ label, value }: { label: string; value: string }) {
 }
 
 export default function UnixTime() {
-	const { trackRun } = useToolAnalytics('unix-time');
+	const { trackRunDebounced } = useToolAnalytics('unix-time');
 	const [settings, updateSettings] = useToolSettings<Settings>('unix-time', {
 		timeZone: 'Asia/Tokyo',
 	});
@@ -135,9 +135,9 @@ export default function UnixTime() {
 
 	useEffect(() => {
 		if (outputs || batchRows.length > 0) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [outputs, batchRows, trackRun]);
+	}, [outputs, batchRows, trackRunDebounced]);
 
 	const handleNowClick = () => {
 		const nanos = nowInstantNanos();

--- a/src/components/tools/UrlEncoder.tsx
+++ b/src/components/tools/UrlEncoder.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/lib/tools/url-encoder';
 
 export default function UrlEncoder() {
-	const { trackRun } = useToolAnalytics('url-encoder');
+	const { trackRunDebounced } = useToolAnalytics('url-encoder');
 	const [mode, setMode] = useState<UrlEncodeMode>('component');
 	const [direction, setDirection] = useState<'encode' | 'decode'>('decode');
 	const [textInput, setTextInput] = useState('');
@@ -39,9 +39,9 @@ export default function UrlEncoder() {
 
 	useEffect(() => {
 		if (textInput.trim() && textResult.output && !textResult.error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [textInput, textResult, trackRun]);
+	}, [textInput, textResult, trackRunDebounced]);
 
 	// Swap input and output
 	const handleSwap = () => {

--- a/src/components/tools/WarekiConverter.tsx
+++ b/src/components/tools/WarekiConverter.tsx
@@ -98,7 +98,7 @@ function MonthDaySelects({
 }
 
 export default function WarekiConverter() {
-	const { trackRun } = useToolAnalytics('wareki-converter');
+	const { trackRunDebounced } = useToolAnalytics('wareki-converter');
 	const referenceDate = useMemo(() => new Date(), []);
 
 	const [direction, setDirection] = useState<Direction>('toWareki');
@@ -183,9 +183,9 @@ export default function WarekiConverter() {
 
 	useEffect(() => {
 		if (table && !error) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [table, error, trackRun]);
+	}, [table, error, trackRunDebounced]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/tools/YamlJsonToml.tsx
+++ b/src/components/tools/YamlJsonToml.tsx
@@ -100,7 +100,7 @@ function formatErrorLine(result: ConvertResult | null): string | null {
 }
 
 export default function YamlJsonToml() {
-	const { trackRun } = useToolAnalytics('yaml-json-toml');
+	const { trackRunDebounced } = useToolAnalytics('yaml-json-toml');
 	const [from, setFrom] = useState<Format>('yaml');
 	const [to, setTo] = useState<Format>('json');
 	const [input, setInput] = useState('');
@@ -116,8 +116,8 @@ export default function YamlJsonToml() {
 		}
 		const converted = convertFormats(from, to, input, { indent, sortKeys });
 		setResult(converted);
-		if (converted.ok) trackRun();
-	}, [input, from, to, indent, sortKeys, trackRun]);
+		if (converted.ok) trackRunDebounced();
+	}, [input, from, to, indent, sortKeys, trackRunDebounced]);
 
 	// 自動変換（250msデバウンス）
 	useEffect(() => {

--- a/src/components/tools/ZenkakuHankaku.tsx
+++ b/src/components/tools/ZenkakuHankaku.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/lib/tools/zenkaku-hankaku';
 
 export default function ZenkakuHankaku() {
-	const { trackRun } = useToolAnalytics('zenkaku-hankaku');
+	const { trackRunDebounced } = useToolAnalytics('zenkaku-hankaku');
 	const [input, setInput] = useState('');
 	const [direction, setDirection] = useState<Direction>('toHankaku');
 	const [options, setOptions] = useState<ConversionOptions>({
@@ -29,9 +29,9 @@ export default function ZenkakuHankaku() {
 	// 非空の入力から変換結果が生成された時点で実行を計測（空入力・マウント時は発火しない）
 	useEffect(() => {
 		if (input) {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [input, direction, options, trackRun]);
+	}, [input, direction, options, trackRunDebounced]);
 
 	const toggleOption = useCallback((key: keyof ConversionOptions) => {
 		setOptions((prev) => ({ ...prev, [key]: !prev[key] }));

--- a/src/components/tools/cipher/CipherPage.tsx
+++ b/src/components/tools/cipher/CipherPage.tsx
@@ -19,7 +19,7 @@ import { OutputPanel } from './OutputPanel';
 import { ShiftSlider } from './ShiftSlider';
 
 export function CipherPage() {
-	const { trackRun } = useToolAnalytics('cipher');
+	const { trackRunDebounced } = useToolAnalytics('cipher');
 	const [activeTab, setActiveTab] = useState<CipherAlgorithm>('caesar');
 	const [input, setInput] = useState('');
 
@@ -70,9 +70,9 @@ export function CipherPage() {
 
 	useEffect(() => {
 		if (input.trim() && output && output !== 'エラーが発生しました') {
-			trackRun();
+			trackRunDebounced();
 		}
-	}, [input, output, trackRun]);
+	}, [input, output, trackRunDebounced]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/tools/color/ColorConvertPage.tsx
+++ b/src/components/tools/color/ColorConvertPage.tsx
@@ -29,7 +29,7 @@ const checkerboardStyle: React.CSSProperties = {
 const DEFAULT_INPUT = '#1E90FF';
 
 export function ColorConvertPage() {
-	const { trackRun } = useToolAnalytics('color');
+	const { trackRunDebounced } = useToolAnalytics('color');
 	const [input, setInput] = useState(DEFAULT_INPUT);
 
 	const parsed = useMemo(() => parseColor(input), [input]);
@@ -37,8 +37,8 @@ export function ColorConvertPage() {
 	// 有効なカラーコードを認識できた（変換結果が出た）時のみ計測する
 	useEffect(() => {
 		if (!input.trim() || !parsed) return;
-		trackRun();
-	}, [input, parsed, trackRun]);
+		trackRunDebounced();
+	}, [input, parsed, trackRunDebounced]);
 
 	const results = useMemo(() => {
 		if (!parsed) return null;

--- a/src/components/tools/hash-generator/HashPage.tsx
+++ b/src/components/tools/hash-generator/HashPage.tsx
@@ -37,7 +37,7 @@ const MB = 1024 * 1024;
 const FILE_TOO_LARGE_MESSAGE = `ファイルサイズが上限（${MAX_FILE_SIZE / MB}MB）を超えています。`;
 
 export function HashPage() {
-	const { trackRun } = useToolAnalytics('hash');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('hash');
 	const [inputMode, setInputMode] = useState<InputMode>('text');
 	const [text, setText] = useState('');
 	const [file, setFile] = useState<File | null>(null);
@@ -75,7 +75,7 @@ export function HashPage() {
 				if (runIdRef.current === runId) {
 					setResults(computed);
 					setError(null);
-					trackRun();
+					trackRunDebounced();
 				}
 			} catch (err) {
 				if (runIdRef.current === runId) {
@@ -90,7 +90,7 @@ export function HashPage() {
 			}
 		}, 300);
 		return () => clearTimeout(timer);
-	}, [inputMode, text, algorithms, trackRun]);
+	}, [inputMode, text, algorithms, trackRunDebounced]);
 
 	// --- ファイル計算 ---
 	const runFileHash = useCallback(

--- a/src/components/tools/id-generator/IdGeneratorPage.tsx
+++ b/src/components/tools/id-generator/IdGeneratorPage.tsx
@@ -7,7 +7,7 @@ import { GeneratePanel } from './GeneratePanel';
 type Mode = 'generate' | 'analyze';
 
 export function IdGeneratorPage() {
-	const { trackRun } = useToolAnalytics('uuid');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('uuid');
 	const [mode, setMode] = useState<Mode>('generate');
 
 	return (
@@ -21,7 +21,7 @@ export function IdGeneratorPage() {
 					<GeneratePanel onGenerated={trackRun} />
 				</TabsContent>
 				<TabsContent value="analyze" className="mt-4">
-					<AnalyzePanel onAnalyzed={trackRun} />
+					<AnalyzePanel onAnalyzed={trackRunDebounced} />
 				</TabsContent>
 			</Tabs>
 		</div>

--- a/src/components/tools/json-csv/JsonCsvPage.tsx
+++ b/src/components/tools/json-csv/JsonCsvPage.tsx
@@ -49,7 +49,7 @@ const SAMPLE_CSV = [
 ].join('\r\n');
 
 export function JsonCsvPage() {
-	const { trackRun } = useToolAnalytics('json-csv');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('json-csv');
 	const [direction, setDirection] = useState<Direction>('json-to-csv');
 	const [input, setInput] = useState('');
 	const [result, setResult] = useState<ConvertResult | null>(null);
@@ -79,8 +79,8 @@ export function JsonCsvPage() {
 				? jsonToCsv(input, jsonOpts)
 				: csvToJson(input, csvOpts),
 		);
-		trackRun();
-	}, [input, direction, jsonOpts, csvOpts, trackRun]);
+		trackRunDebounced();
+	}, [input, direction, jsonOpts, csvOpts, trackRunDebounced]);
 
 	// 自動変換（300ms debounce）。1MB以上は手動実行に切り替え
 	useEffect(() => {

--- a/src/components/tools/markdown/MarkdownPreviewPage.tsx
+++ b/src/components/tools/markdown/MarkdownPreviewPage.tsx
@@ -54,7 +54,7 @@ function greet(name) {
 `;
 
 export function MarkdownPreviewPage() {
-	const { trackRun } = useToolAnalytics('markdown');
+	const { trackRunDebounced } = useToolAnalytics('markdown');
 	const [input, setInput] = useState('');
 	const [html, setHtml] = useState('');
 	const [error, setError] = useState<string | null>(null);
@@ -74,7 +74,7 @@ export function MarkdownPreviewPage() {
 					setHtml(result);
 					setError(null);
 					// 変換結果が出た時のみ計測する
-					if (result) trackRun();
+					if (result) trackRunDebounced();
 				})
 				.catch((err: unknown) => {
 					if (cancelled) return;
@@ -86,7 +86,7 @@ export function MarkdownPreviewPage() {
 			cancelled = true;
 			clearTimeout(timer);
 		};
-	}, [input, trackRun]);
+	}, [input, trackRunDebounced]);
 
 	const handleClear = useCallback(() => {
 		setInput('');

--- a/src/components/zipcode/ZipcodePage.tsx
+++ b/src/components/zipcode/ZipcodePage.tsx
@@ -150,7 +150,7 @@ function SingleSearch({ onRun }: { onRun: () => void }) {
 }
 
 export function ZipcodePage() {
-	const { trackRun } = useToolAnalytics('zipcode');
+	const { trackRun, trackRunDebounced } = useToolAnalytics('zipcode');
 	return (
 		<Tabs defaultValue="single" className="space-y-4">
 			<TabsList className="grid w-full grid-cols-2">
@@ -158,7 +158,7 @@ export function ZipcodePage() {
 				<TabsTrigger value="bulk">一括変換</TabsTrigger>
 			</TabsList>
 			<TabsContent value="single">
-				<SingleSearch onRun={trackRun} />
+				<SingleSearch onRun={trackRunDebounced} />
 			</TabsContent>
 			<TabsContent value="bulk">
 				<BulkConvertPanel onRun={trackRun} />

--- a/src/lib/hooks/useToolAnalytics.ts
+++ b/src/lib/hooks/useToolAnalytics.ts
@@ -1,9 +1,43 @@
 import { useCallback, useEffect, useRef } from 'react';
-import { track } from '../analytics';
+import { track } from '../analytics.ts';
 
 // 「初回操作」とみなすユーザー操作イベント。
 // マウント（＝擬似PV）ではなく、実際にツールへ触れた最初の操作で tool_engage を発火させる。
 const ENGAGE_EVENTS = ['pointerdown', 'keydown'] as const;
+
+// 入力依存の再計算（useEffect の deps に生の入力を含む場合）で trackRun を呼ぶツール向けの
+// デバウンス時間。「入力停止後1回だけ」発火させ、ツール間で tool_run を比較可能にする。
+export const DEBOUNCE_MS = 500;
+
+/** trackRunDebounced が使う保留中タイマーの保持先（React 非依存・単体テスト対象） */
+export type DebounceHandle = { current: ReturnType<typeof setTimeout> | null };
+
+/**
+ * handle に保留中のタイマーがあれば解除してから、delayMs 後に fn を1回だけ実行するよう
+ * 再スケジュールする（一般的なデバウンス実装）。React に依存しないため node:test の
+ * mock.timers で直接検証できる。
+ */
+export function scheduleDebounced(
+	handle: DebounceHandle,
+	fn: () => void,
+	delayMs: number,
+): void {
+	if (handle.current !== null) {
+		clearTimeout(handle.current);
+	}
+	handle.current = setTimeout(() => {
+		handle.current = null;
+		fn();
+	}, delayMs);
+}
+
+/** handle に保留中のタイマーがあれば解除する（アンマウント時のクリーンアップ用） */
+export function cancelDebounced(handle: DebounceHandle): void {
+	if (handle.current !== null) {
+		clearTimeout(handle.current);
+		handle.current = null;
+	}
+}
 
 export function useToolAnalytics(toolSlug: string) {
 	const hasEngagedRef = useRef(false);
@@ -43,6 +77,22 @@ export function useToolAnalytics(toolSlug: string) {
 		track('tool_run', { tool: toolSlug });
 	}, [toolSlug]);
 
+	// 入力依存の useEffect から呼ぶための trackRun。DEBOUNCE_MS 内の連続呼び出しは
+	// 最後の1回にまとめられる（＝「入力停止後に1回だけ」発火する）。
+	const debounceHandleRef = useRef<DebounceHandle>({ current: null });
+
+	const trackRunDebounced = useCallback(() => {
+		if (!toolSlug) return;
+		scheduleDebounced(debounceHandleRef.current, trackRun, DEBOUNCE_MS);
+	}, [toolSlug, trackRun]);
+
+	useEffect(() => {
+		const handle = debounceHandleRef.current;
+		return () => {
+			cancelDebounced(handle);
+		};
+	}, []);
+
 	const trackSharedUrlOpen = useCallback(() => {
 		if (!toolSlug) return;
 		track('shared_url_open', { tool: toolSlug });
@@ -58,6 +108,7 @@ export function useToolAnalytics(toolSlug: string) {
 
 	return {
 		trackRun,
+		trackRunDebounced,
 		trackSharedUrlOpen,
 		trackSettingsRestore,
 	};

--- a/tests/unit/use-tool-analytics.test.ts
+++ b/tests/unit/use-tool-analytics.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	cancelDebounced,
+	DEBOUNCE_MS,
+	type DebounceHandle,
+	scheduleDebounced,
+} from '../../src/lib/hooks/useToolAnalytics.ts';
+
+test('scheduleDebounced: 500ms以内の連続呼び出しは実行を1回にまとめる', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: DebounceHandle = { current: null };
+	let calls = 0;
+
+	for (let i = 0; i < 10; i++) {
+		scheduleDebounced(
+			handle,
+			() => {
+				calls++;
+			},
+			DEBOUNCE_MS,
+		);
+		t.mock.timers.tick(100);
+	}
+	assert.strictEqual(calls, 0);
+
+	t.mock.timers.tick(DEBOUNCE_MS);
+	assert.strictEqual(calls, 1);
+});
+
+test('scheduleDebounced: 待機を挟めば複数回実行される', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: DebounceHandle = { current: null };
+	let calls = 0;
+
+	scheduleDebounced(handle, () => calls++, DEBOUNCE_MS);
+	t.mock.timers.tick(DEBOUNCE_MS);
+	assert.strictEqual(calls, 1);
+
+	scheduleDebounced(handle, () => calls++, DEBOUNCE_MS);
+	t.mock.timers.tick(DEBOUNCE_MS);
+	assert.strictEqual(calls, 2);
+});
+
+test('cancelDebounced: キャンセルすると保留中の実行が起きない（アンマウント相当）', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: DebounceHandle = { current: null };
+	let calls = 0;
+
+	scheduleDebounced(handle, () => calls++, DEBOUNCE_MS);
+	cancelDebounced(handle);
+	t.mock.timers.tick(DEBOUNCE_MS * 2);
+
+	assert.strictEqual(calls, 0);
+});
+
+test('cancelDebounced: 保留タイマーが無い状態で呼んでもエラーにならない', () => {
+	const handle: DebounceHandle = { current: null };
+	assert.doesNotThrow(() => cancelDebounced(handle));
+});
+
+test('scheduleDebounced: 独立したハンドル同士は互いに影響しない（別ツールslug相当）', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handleA: DebounceHandle = { current: null };
+	const handleB: DebounceHandle = { current: null };
+	let callsA = 0;
+	let callsB = 0;
+
+	scheduleDebounced(handleA, () => callsA++, DEBOUNCE_MS);
+	t.mock.timers.tick(200);
+	scheduleDebounced(handleB, () => callsB++, DEBOUNCE_MS);
+	t.mock.timers.tick(DEBOUNCE_MS - 200);
+
+	// handleA は最初の呼び出しから DEBOUNCE_MS 経過済みなので発火、handleB はまだ
+	assert.strictEqual(callsA, 1);
+	assert.strictEqual(callsB, 0);
+
+	t.mock.timers.tick(200);
+	assert.strictEqual(callsB, 1);
+});


### PR DESCRIPTION
## Summary

`tool_run` was firing once per keystroke on any tool whose tracking call lived inside a `useEffect` keyed on live input, making the metric useless for cross-tool comparison (e.g. cipher's runs/engages ratio was ~40). This PR:

- Adds `trackRunDebounced()` to `useToolAnalytics` (500ms debounce, built on a small React-independent `scheduleDebounced`/`cancelDebounced` core so it's unit-testable without a renderer).
- Migrates all 25 input-dependent `trackRun()` call sites (including `cipher`, plus several tools that already had ad-hoc per-component `setTimeout` debounces — `CronChecker`, `image-base64`, `DummyDataGenerator`, `QrGenerator`, `HashPage`, `JsonCsvPage`, `YamlJsonToml`, `MarkdownPreviewPage`) to the centralized debounce instead of scattering timers per component. Explicit-action call sites (buttons, file drops, `onRunComplete` callbacks) are untouched and still fire immediately.
- Instruments `image-merge`, the one catalog tool with no analytics wired up (its sibling image tools all have it). `transcribe` is intentionally left uninstrumented — it has a documented zero-network-send invariant.
- Syncs `docs/analytics.md`: adds the missing `settings_restore` row (it was already firing via `useToolSettings.ts`, just undocumented) and documents the two `tool_run` firing modes.

### Step 0 finding worth flagging

Before implementing, I audited all 46 components using `useToolAnalytics` and cross-checked the originating ticket's claims against the current code. Two of the ticket's "unwired" items were already fully implemented on `main` (merged 2026-07-04, before the ticket was written):
- `search_empty` — already wired in `SearchModal.tsx` with a 500ms debounce.
- `related_click` — already wired in `RelatedTools.astro` via the exact `data-*` + delegated-listener pattern the ticket recommended.
- `shared_url_open` — already wired in 7 tools; the ticket's "0 occurrences in 7 days" was a data observation, not a missing implementation.

No changes were made to these three; this PR only touches what was actually missing (`tool_run` debounce, `image-merge` instrumentation, docs sync).

## Test plan

- [x] `npm run test:unit` — 880/880 pass, including new `tests/unit/use-tool-analytics.test.ts` (debounce coalescing, unmount cleanup, independent handles).
- [x] `npm run check` (Astro + Biome) — 0 errors.
- [x] `npm run build` — succeeds, all 101 pages built including `/image-merge`.
- [x] Manual dev-server check (Playwright) on `/unicode-converter` and `/cipher`: typing an 11/17-char string fires exactly one `tool_run` in the dev console log, not one per keystroke.
- [x] Acceptance criteria self-verified: debounced firing, `catalog.ts` slug coverage (only `transcribe`, intentionally, is uninstrumented), `docs/analytics.md` now matches `AnalyticsEvents` (6/6 events).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016jDDJAv3ioN5LCFpsXcrXo

---
_Generated by [Claude Code](https://claude.ai/code/session_016jDDJAv3ioN5LCFpsXcrXo)_