### PR TITLE
feat(image-tools): add pinch zoom and modeless gestures for mobile

### DIFF
--- a/src/components/common/ZoomableCanvasViewport.tsx
+++ b/src/components/common/ZoomableCanvasViewport.tsx
@@ -3,9 +3,9 @@
 // canvas 内部解像度・座標変換（clientToImage）・%配置オーバーレイは無改修のまま、
 // スクロールコンテナ＋表示幅変更（CSSスケーリング）でズーム／パンを実現する。
 
-import { Hand, MousePointer2, ZoomIn, ZoomOut } from 'lucide-react';
+import { ZoomIn, ZoomOut } from 'lucide-react';
+import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import type { MobilePanMode } from '@/lib/hooks/useZoomPan';
 import { useZoomPan } from '@/lib/hooks/useZoomPan';
 import { formatZoomPercent } from '@/lib/tools/zoom-pan';
 import { cn } from '@/lib/utils';
@@ -14,6 +14,21 @@ const VIEWPORT_HEIGHT = {
 	normal: 'h-[420px] max-h-[60dvh] min-h-[240px]',
 	full: 'h-[70dvh] max-h-[70dvh] min-h-[320px]',
 } as const;
+
+export type ZoomableCanvasContext = {
+	scale: number;
+	getContainerPoint: (
+		clientX: number,
+		clientY: number,
+	) => { x: number; y: number };
+	applyPinchTransform: (
+		nextScale: number,
+		focalClientX: number,
+		focalClientY: number,
+		panDeltaX: number,
+		panDeltaY: number,
+	) => void;
+};
 
 type ZoomableCanvasViewportProps = {
 	/** コンテンツ（canvas）の原寸幅（内部解像度、px） */
@@ -28,7 +43,7 @@ type ZoomableCanvasViewportProps = {
 	 * canvas とオーバーレイをレンダーする関数。
 	 * 返す要素は幅・高さ100%で親（このビューポートが用意する原寸ボックス）を満たすこと。
 	 */
-	children: (ctx: { mobileMode: MobilePanMode }) => React.ReactNode;
+	children: (ctx: ZoomableCanvasContext) => React.ReactNode;
 };
 
 export function ZoomableCanvasViewport({
@@ -46,15 +61,23 @@ export function ZoomableCanvasViewport({
 		displayHeight,
 		offsetX,
 		offsetY,
-		mobileMode,
-		setMobileMode,
 		zoomIn,
 		zoomOut,
 		zoomTo100,
 		zoomToFit,
 		isZoomOutDisabled,
 		isZoomInDisabled,
+		applyPinchTransform,
 	} = useZoomPan({ contentWidth, contentHeight, resetKey });
+
+	const getContainerPoint = useCallback(
+		(clientX: number, clientY: number) => {
+			const rect = containerRef.current?.getBoundingClientRect();
+			if (!rect) return { x: clientX, y: clientY };
+			return { x: clientX - rect.left, y: clientY - rect.top };
+		},
+		[containerRef],
+	);
 
 	const percentLabel = isFit
 		? `フィット（${formatZoomPercent(scale)}）`
@@ -97,42 +120,13 @@ export function ZoomableCanvasViewport({
 				</Button>
 				<span
 					data-testid="zoom-percent-label"
-					className="text-xs text-muted-foreground tabular-nums"
+					// 最長表示（フィット（xx%））を基準に最小幅を確保し、フィット⇄数値表示の
+					// 切り替えでラベル幅が変わってツールバーの折り返し行数（＝キャンバスの
+					// 表示位置）が変化してしまうのを防ぐ（狭幅ビューポートで発生しうる）
+					className="min-w-[100px] text-xs text-muted-foreground tabular-nums"
 				>
 					{percentLabel}
 				</span>
-
-				{/* モバイル: 編集／パン切替（デスクトップでは常時ドラッグ選択のため非表示） */}
-				<div className="ml-auto flex items-center gap-1 sm:hidden">
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						aria-pressed={mobileMode === 'edit'}
-						aria-label="編集モード（ドラッグで選択・移動）"
-						className={cn(
-							mobileMode === 'edit' && 'border-primary text-primary',
-						)}
-						onClick={() => setMobileMode('edit')}
-					>
-						<MousePointer2 className="h-4 w-4" />
-						編集
-					</Button>
-					<Button
-						type="button"
-						variant="outline"
-						size="sm"
-						aria-pressed={mobileMode === 'pan'}
-						aria-label="パンモード（ドラッグで画像内を移動）"
-						className={cn(
-							mobileMode === 'pan' && 'border-primary text-primary',
-						)}
-						onClick={() => setMobileMode('pan')}
-					>
-						<Hand className="h-4 w-4" />
-						パン
-					</Button>
-				</div>
 			</div>
 
 			<div
@@ -152,7 +146,7 @@ export function ZoomableCanvasViewport({
 					}}
 					className="relative"
 				>
-					{children({ mobileMode })}
+					{children({ scale, getContainerPoint, applyPinchTransform })}
 				</div>
 			</div>
 		</div>

--- a/src/components/image-mosaic/CanvasEditor.tsx
+++ b/src/components/image-mosaic/CanvasEditor.tsx
@@ -5,7 +5,12 @@
 
 import { X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ZoomableCanvasViewport } from '@/components/common/ZoomableCanvasViewport';
+import {
+	type ZoomableCanvasContext,
+	ZoomableCanvasViewport,
+} from '@/components/common/ZoomableCanvasViewport';
+import { useGestureController } from '@/lib/hooks/useGestureController';
+import type { TwoFingerMoveInfo } from '@/lib/tools/gesture-controller';
 import { clientToImage } from '@/lib/tools/image-common';
 import {
 	isMaskEffectMode,
@@ -16,6 +21,7 @@ import {
 	type Rect,
 	renderMasked,
 } from '@/lib/tools/image-mosaic';
+import { computePinchZoom } from '@/lib/tools/zoom-pan';
 
 /** これ未満のドラッグ距離（CSS px）はクリック＝領域選択として扱う */
 const CLICK_THRESHOLD_PX = 4;
@@ -125,10 +131,8 @@ export function CanvasEditor({
 
 	const handlePointerDown = useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
-			if (e.button !== 0) return;
 			const canvas = canvasRef.current;
 			if (!canvas) return;
-			canvas.setPointerCapture(e.pointerId);
 			const { x, y } = clientToImage(canvas, e.clientX, e.clientY);
 			dragRef.current = {
 				pointerId: e.pointerId,
@@ -186,7 +190,6 @@ export function CanvasEditor({
 			const drag = dragRef.current;
 			if (!canvas || !drag || drag.pointerId !== e.pointerId) return;
 			dragRef.current = null;
-			canvas.releasePointerCapture(e.pointerId);
 			if (rafRef.current !== null) {
 				cancelAnimationFrame(rafRef.current);
 				rafRef.current = null;
@@ -222,6 +225,70 @@ export function CanvasEditor({
 		},
 		[],
 	);
+
+	const zoomBridgeRef = useRef<ZoomableCanvasContext | null>(null);
+	const startScaleRef = useRef(1);
+	const pinchAccumRef = useRef({ panX: 0, panY: 0 });
+	const pinchLatestRef = useRef<{
+		nextScale: number;
+		focalX: number;
+		focalY: number;
+	} | null>(null);
+	const pinchRafRef = useRef<number | null>(null);
+
+	const handleSingleInterrupted = useCallback(() => {
+		dragRef.current = null;
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = null;
+		}
+		setDragRect(null);
+	}, []);
+
+	const handleTwoFingerStart = useCallback(() => {
+		startScaleRef.current = zoomBridgeRef.current?.scale ?? 1;
+		pinchAccumRef.current = { panX: 0, panY: 0 };
+	}, []);
+
+	const handleTwoFingerMove = useCallback((info: TwoFingerMoveInfo) => {
+		const bridge = zoomBridgeRef.current;
+		if (!bridge) return;
+		const nextScale = computePinchZoom(
+			startScaleRef.current,
+			info.startDistance,
+			info.distance,
+		);
+		const focal = bridge.getContainerPoint(info.midpoint.x, info.midpoint.y);
+		// 複数フレーム分のパン量を取りこぼさないよう、rAFでコアレスする間も加算し続ける
+		pinchAccumRef.current.panX += info.midpoint.x - info.previousMidpoint.x;
+		pinchAccumRef.current.panY += info.midpoint.y - info.previousMidpoint.y;
+		pinchLatestRef.current = { nextScale, focalX: focal.x, focalY: focal.y };
+		if (pinchRafRef.current !== null) return;
+		pinchRafRef.current = requestAnimationFrame(() => {
+			pinchRafRef.current = null;
+			const latest = pinchLatestRef.current;
+			const { panX, panY } = pinchAccumRef.current;
+			pinchAccumRef.current = { panX: 0, panY: 0 };
+			if (!latest) return;
+			bridge.applyPinchTransform(
+				latest.nextScale,
+				latest.focalX,
+				latest.focalY,
+				panX,
+				panY,
+			);
+		});
+	}, []);
+
+	const gesture = useGestureController({
+		onSinglePointerDown: handlePointerDown,
+		onSinglePointerMove: handlePointerMove,
+		onSinglePointerUp: handlePointerUp,
+		onSinglePointerCancel: handlePointerCancel,
+		onSinglePointerInterrupted: handleSingleInterrupted,
+		onTwoFingerStart: handleTwoFingerStart,
+		onTwoFingerMove: handleTwoFingerMove,
+	});
 
 	// 領域選択中は Delete / Backspace キーで削除（入力欄へのタイプは除外）
 	useEffect(() => {
@@ -259,20 +326,19 @@ export function CanvasEditor({
 			resetKey={source}
 			fullSize={fullSize}
 		>
-			{({ mobileMode }) => {
-				const isPanMode = mobileMode === 'pan';
+			{(ctx) => {
+				zoomBridgeRef.current = ctx;
 				return (
 					<div className="relative h-full w-full">
 						<canvas
 							ref={canvasRef}
 							data-testid="editor-canvas"
-							className={`block h-full w-full rounded-lg border border-border ${
-								isPanMode ? 'cursor-grab' : 'cursor-crosshair touch-none'
-							}`}
-							onPointerDown={isPanMode ? undefined : handlePointerDown}
-							onPointerMove={isPanMode ? undefined : handlePointerMove}
-							onPointerUp={isPanMode ? undefined : handlePointerUp}
-							onPointerCancel={isPanMode ? undefined : handlePointerCancel}
+							className="block h-full w-full touch-none rounded-lg border border-border cursor-crosshair"
+							onPointerDown={gesture.onPointerDown}
+							onPointerMove={gesture.onPointerMove}
+							onPointerUp={gesture.onPointerUp}
+							onPointerCancel={gesture.onPointerCancel}
+							onLostPointerCapture={gesture.onLostPointerCapture}
 							onPointerLeave={() => setHoveredId(null)}
 						/>
 						{/* 既存領域のアウトライン（DOMオーバーレイ） */}

--- a/src/components/image-text/TextCanvas.tsx
+++ b/src/components/image-text/TextCanvas.tsx
@@ -18,6 +18,9 @@ import {
 } from '@/lib/tools/image-text';
 import { computePinchZoom } from '@/lib/tools/zoom-pan';
 
+/** これ未満のドラッグ距離（CSS px）はクリック＝選択のみとして扱い、レイヤーを動かさない */
+const CLICK_THRESHOLD_PX = 4;
+
 type TextCanvasProps = {
 	source: HTMLImageElement | HTMLCanvasElement;
 	layers: TextLayer[];
@@ -34,6 +37,14 @@ type DragState = {
 	/** ポインタ位置とレイヤー左上のオフセット（元画像座標） */
 	offsetX: number;
 	offsetY: number;
+	/** ドラッグ開始時のポインタ位置（CSS px）。しきい値判定用 */
+	startClientX: number;
+	startClientY: number;
+	/** ドラッグ開始時点のレイヤー位置（元画像座標）。中断時のロールバック用 */
+	originalX: number;
+	originalY: number;
+	/** しきい値を超えて実際に移動が始まったか */
+	moved: boolean;
 };
 
 /** レイヤーのヒットテスト用バウンディングボックス（背景パディング含む） */
@@ -109,6 +120,11 @@ export function TextCanvas({
 				layerId: hit.id,
 				offsetX: x - hit.x,
 				offsetY: y - hit.y,
+				startClientX: e.clientX,
+				startClientY: e.clientY,
+				originalX: hit.x,
+				originalY: hit.y,
+				moved: false,
 			};
 			setIsDragging(true);
 		},
@@ -120,6 +136,18 @@ export function TextCanvas({
 			const canvas = canvasRef.current;
 			const drag = dragRef.current;
 			if (!canvas || !drag || drag.pointerId !== e.pointerId) return;
+
+			// しきい値未満の移動はクリック（選択のみ）として扱い、レイヤーは動かさない
+			if (
+				!drag.moved &&
+				Math.hypot(
+					e.clientX - drag.startClientX,
+					e.clientY - drag.startClientY,
+				) < CLICK_THRESHOLD_PX
+			) {
+				return;
+			}
+			drag.moved = true;
 
 			// rAF スロットル: 1フレームにつき1回だけ位置を更新
 			const { clientX, clientY } = e;
@@ -149,19 +177,22 @@ export function TextCanvas({
 				cancelAnimationFrame(rafRef.current);
 				rafRef.current = null;
 			}
-			// pending rAF を破棄した分を含め、リリース座標で最終位置を確定する
-			const { x, y } = clientToImage(canvas, e.clientX, e.clientY);
-			onMoveLayer(
-				drag.layerId,
-				Math.round(x - drag.offsetX),
-				Math.round(y - drag.offsetY),
-			);
+			// しきい値を超えて実際に動いた場合のみ、リリース座標で最終位置を確定する
+			if (drag.moved) {
+				const { x, y } = clientToImage(canvas, e.clientX, e.clientY);
+				onMoveLayer(
+					drag.layerId,
+					Math.round(x - drag.offsetX),
+					Math.round(y - drag.offsetY),
+				);
+			}
 			setIsDragging(false);
 		},
 		[onMoveLayer],
 	);
 
 	// タッチキャンセルやブラウザジェスチャでドラッグが中断された場合の後始末
+	// （しきい値を超えて動いていた場合は、元の位置までロールバックする）
 	const handlePointerCancel = useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
 			const drag = dragRef.current;
@@ -171,9 +202,12 @@ export function TextCanvas({
 				cancelAnimationFrame(rafRef.current);
 				rafRef.current = null;
 			}
+			if (drag.moved) {
+				onMoveLayer(drag.layerId, drag.originalX, drag.originalY);
+			}
 			setIsDragging(false);
 		},
-		[],
+		[onMoveLayer],
 	);
 
 	const zoomBridgeRef = useRef<ZoomableCanvasContext | null>(null);
@@ -186,14 +220,20 @@ export function TextCanvas({
 	} | null>(null);
 	const pinchRafRef = useRef<number | null>(null);
 
+	// 2本目の指が触れてピンチへ遷移した場合の後始末
+	// （しきい値を超えて動いていた場合は、元の位置までロールバックする）
 	const handleSingleInterrupted = useCallback(() => {
+		const drag = dragRef.current;
 		dragRef.current = null;
 		if (rafRef.current !== null) {
 			cancelAnimationFrame(rafRef.current);
 			rafRef.current = null;
 		}
+		if (drag?.moved) {
+			onMoveLayer(drag.layerId, drag.originalX, drag.originalY);
+		}
 		setIsDragging(false);
-	}, []);
+	}, [onMoveLayer]);
 
 	const handleTwoFingerStart = useCallback(() => {
 		startScaleRef.current = zoomBridgeRef.current?.scale ?? 1;

--- a/src/components/image-text/TextCanvas.tsx
+++ b/src/components/image-text/TextCanvas.tsx
@@ -3,7 +3,12 @@
 // 選択レイヤーの破線バウンディングボックスは DOM オーバーレイで表示する
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ZoomableCanvasViewport } from '@/components/common/ZoomableCanvasViewport';
+import {
+	type ZoomableCanvasContext,
+	ZoomableCanvasViewport,
+} from '@/components/common/ZoomableCanvasViewport';
+import { useGestureController } from '@/lib/hooks/useGestureController';
+import type { TwoFingerMoveInfo } from '@/lib/tools/gesture-controller';
 import { clientToImage } from '@/lib/tools/image-common';
 import {
 	BG_PADDING,
@@ -11,6 +16,7 @@ import {
 	renderTextLayers,
 	type TextLayer,
 } from '@/lib/tools/image-text';
+import { computePinchZoom } from '@/lib/tools/zoom-pan';
 
 type TextCanvasProps = {
 	source: HTMLImageElement | HTMLCanvasElement;
@@ -89,7 +95,6 @@ export function TextCanvas({
 
 	const handlePointerDown = useCallback(
 		(e: React.PointerEvent<HTMLCanvasElement>) => {
-			if (e.button !== 0) return;
 			const canvas = canvasRef.current;
 			if (!canvas) return;
 			const { x, y } = clientToImage(canvas, e.clientX, e.clientY);
@@ -99,7 +104,6 @@ export function TextCanvas({
 				return;
 			}
 			onSelect(hit.id);
-			canvas.setPointerCapture(e.pointerId);
 			dragRef.current = {
 				pointerId: e.pointerId,
 				layerId: hit.id,
@@ -141,7 +145,6 @@ export function TextCanvas({
 			const drag = dragRef.current;
 			if (!canvas || !drag || drag.pointerId !== e.pointerId) return;
 			dragRef.current = null;
-			canvas.releasePointerCapture(e.pointerId);
 			if (rafRef.current !== null) {
 				cancelAnimationFrame(rafRef.current);
 				rafRef.current = null;
@@ -173,6 +176,69 @@ export function TextCanvas({
 		[],
 	);
 
+	const zoomBridgeRef = useRef<ZoomableCanvasContext | null>(null);
+	const startScaleRef = useRef(1);
+	const pinchAccumRef = useRef({ panX: 0, panY: 0 });
+	const pinchLatestRef = useRef<{
+		nextScale: number;
+		focalX: number;
+		focalY: number;
+	} | null>(null);
+	const pinchRafRef = useRef<number | null>(null);
+
+	const handleSingleInterrupted = useCallback(() => {
+		dragRef.current = null;
+		if (rafRef.current !== null) {
+			cancelAnimationFrame(rafRef.current);
+			rafRef.current = null;
+		}
+		setIsDragging(false);
+	}, []);
+
+	const handleTwoFingerStart = useCallback(() => {
+		startScaleRef.current = zoomBridgeRef.current?.scale ?? 1;
+		pinchAccumRef.current = { panX: 0, panY: 0 };
+	}, []);
+
+	const handleTwoFingerMove = useCallback((info: TwoFingerMoveInfo) => {
+		const bridge = zoomBridgeRef.current;
+		if (!bridge) return;
+		const nextScale = computePinchZoom(
+			startScaleRef.current,
+			info.startDistance,
+			info.distance,
+		);
+		const focal = bridge.getContainerPoint(info.midpoint.x, info.midpoint.y);
+		pinchAccumRef.current.panX += info.midpoint.x - info.previousMidpoint.x;
+		pinchAccumRef.current.panY += info.midpoint.y - info.previousMidpoint.y;
+		pinchLatestRef.current = { nextScale, focalX: focal.x, focalY: focal.y };
+		if (pinchRafRef.current !== null) return;
+		pinchRafRef.current = requestAnimationFrame(() => {
+			pinchRafRef.current = null;
+			const latest = pinchLatestRef.current;
+			const { panX, panY } = pinchAccumRef.current;
+			pinchAccumRef.current = { panX: 0, panY: 0 };
+			if (!latest) return;
+			bridge.applyPinchTransform(
+				latest.nextScale,
+				latest.focalX,
+				latest.focalY,
+				panX,
+				panY,
+			);
+		});
+	}, []);
+
+	const gesture = useGestureController({
+		onSinglePointerDown: handlePointerDown,
+		onSinglePointerMove: handlePointerMove,
+		onSinglePointerUp: handlePointerUp,
+		onSinglePointerCancel: handlePointerCancel,
+		onSinglePointerInterrupted: handleSingleInterrupted,
+		onTwoFingerStart: handleTwoFingerStart,
+		onTwoFingerMove: handleTwoFingerMove,
+	});
+
 	const selectedLayer = layers.find((l) => l.id === selectedId) ?? null;
 
 	return (
@@ -182,22 +248,19 @@ export function TextCanvas({
 			resetKey={source}
 			fullSize={fullSize}
 		>
-			{({ mobileMode }) => {
-				const isPanMode = mobileMode === 'pan';
+			{(ctx) => {
+				zoomBridgeRef.current = ctx;
 				return (
 					<div className="relative h-full w-full">
 						<canvas
 							ref={canvasRef}
 							data-testid="text-canvas"
-							className={`block h-full w-full rounded-lg border border-border ${
-								isPanMode
-									? 'cursor-grab'
-									: `touch-none ${isDragging ? 'cursor-grabbing' : 'cursor-pointer'}`
-							}`}
-							onPointerDown={isPanMode ? undefined : handlePointerDown}
-							onPointerMove={isPanMode ? undefined : handlePointerMove}
-							onPointerUp={isPanMode ? undefined : handlePointerUp}
-							onPointerCancel={isPanMode ? undefined : handlePointerCancel}
+							className={`block h-full w-full touch-none rounded-lg border border-border ${isDragging ? 'cursor-grabbing' : 'cursor-pointer'}`}
+							onPointerDown={gesture.onPointerDown}
+							onPointerMove={gesture.onPointerMove}
+							onPointerUp={gesture.onPointerUp}
+							onPointerCancel={gesture.onPointerCancel}
+							onLostPointerCapture={gesture.onLostPointerCapture}
 						/>
 						{/* 選択レイヤーの破線バウンディングボックス（DOMオーバーレイ） */}
 						{selectedLayer &&

--- a/src/lib/hooks/useGestureController.ts
+++ b/src/lib/hooks/useGestureController.ts
@@ -1,0 +1,137 @@
+// useGestureController.ts — reducerをReactのPointerEventに接続する薄いアダプタ。
+// イベント所有権はcanvas要素自身に固定する: 有効なpointerdownごとに
+// setPointerCapture し、pointerup/pointercancel/lostpointercaptureで
+// releasePointerCaptureする。これにより、削除✕ボタン等の兄弟オーバーレイに
+// キャプチャを奪われず、canvas外へ出た指のイベントも確実にcanvasへ配送される。
+import { useCallback, useRef } from 'react';
+import {
+	createInitialGestureState,
+	type GestureMachineState,
+	reduceGestureEvent,
+	type TwoFingerMoveInfo,
+	type TwoFingerStartInfo,
+} from '@/lib/tools/gesture-controller';
+
+type ReactPointerEvent = React.PointerEvent<HTMLCanvasElement>;
+
+export type GestureControllerCallbacks = {
+	onSinglePointerDown: (e: ReactPointerEvent) => void;
+	onSinglePointerMove: (e: ReactPointerEvent) => void;
+	onSinglePointerUp: (e: ReactPointerEvent) => void;
+	onSinglePointerCancel: (e: ReactPointerEvent) => void;
+	/** 単指操作中に2本目が追加された際、進行中の描画/ドラッグを破棄させるために一度だけ発火 */
+	onSinglePointerInterrupted: () => void;
+	onTwoFingerStart: (info: TwoFingerStartInfo) => void;
+	onTwoFingerMove: (info: TwoFingerMoveInfo) => void;
+};
+
+export function useGestureController(callbacks: GestureControllerCallbacks) {
+	const machineRef = useRef<GestureMachineState>(createInitialGestureState());
+	const callbacksRef = useRef(callbacks);
+	callbacksRef.current = callbacks;
+
+	const dispatch = useCallback(
+		(
+			event:
+				| {
+						type: 'down' | 'move';
+						pointerId: number;
+						point: { x: number; y: number };
+				  }
+				| { type: 'up' | 'cancel'; pointerId: number },
+			originalEvent: ReactPointerEvent,
+		) => {
+			const { state, effects } = reduceGestureEvent(machineRef.current, event);
+			machineRef.current = state;
+			const cb = callbacksRef.current;
+			for (const effect of effects) {
+				switch (effect.type) {
+					case 'singleDown':
+						cb.onSinglePointerDown(originalEvent);
+						break;
+					case 'singleMove':
+						cb.onSinglePointerMove(originalEvent);
+						break;
+					case 'singleUp':
+						cb.onSinglePointerUp(originalEvent);
+						break;
+					case 'singleCancel':
+						cb.onSinglePointerCancel(originalEvent);
+						break;
+					case 'singleInterrupted':
+						cb.onSinglePointerInterrupted();
+						break;
+					case 'twoFingerStart':
+						cb.onTwoFingerStart(effect.info);
+						break;
+					case 'twoFingerMove':
+						cb.onTwoFingerMove(effect.info);
+						break;
+				}
+			}
+		},
+		[],
+	);
+
+	const onPointerDown = useCallback(
+		(e: ReactPointerEvent) => {
+			if (e.pointerType === 'mouse' && e.button !== 0) return;
+			e.currentTarget.setPointerCapture(e.pointerId);
+			dispatch(
+				{
+					type: 'down',
+					pointerId: e.pointerId,
+					point: { x: e.clientX, y: e.clientY },
+				},
+				e,
+			);
+		},
+		[dispatch],
+	);
+
+	const onPointerMove = useCallback(
+		(e: ReactPointerEvent) => {
+			dispatch(
+				{
+					type: 'move',
+					pointerId: e.pointerId,
+					point: { x: e.clientX, y: e.clientY },
+				},
+				e,
+			);
+		},
+		[dispatch],
+	);
+
+	const endPointer = useCallback(
+		(type: 'up' | 'cancel', e: ReactPointerEvent) => {
+			if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+				e.currentTarget.releasePointerCapture(e.pointerId);
+			}
+			dispatch({ type, pointerId: e.pointerId }, e);
+		},
+		[dispatch],
+	);
+
+	const onPointerUp = useCallback(
+		(e: ReactPointerEvent) => endPointer('up', e),
+		[endPointer],
+	);
+	const onPointerCancel = useCallback(
+		(e: ReactPointerEvent) => endPointer('cancel', e),
+		[endPointer],
+	);
+	// ブラウザ側のジェスチャー横取り等でcaptureが失われた場合もcancelと同じ後始末経路を通す
+	const onLostPointerCapture = useCallback(
+		(e: ReactPointerEvent) => endPointer('cancel', e),
+		[endPointer],
+	);
+
+	return {
+		onPointerDown,
+		onPointerMove,
+		onPointerUp,
+		onPointerCancel,
+		onLostPointerCapture,
+	};
+}

--- a/src/lib/hooks/useZoomPan.ts
+++ b/src/lib/hooks/useZoomPan.ts
@@ -10,6 +10,7 @@ import {
 	useState,
 } from 'react';
 import {
+	clampScrollPosition,
 	computeContentOffset,
 	computeFitScale,
 	computeWheelZoom,
@@ -21,8 +22,6 @@ import {
 	nextZoomOutStep,
 } from '@/lib/tools/zoom-pan';
 
-export type MobilePanMode = 'edit' | 'pan';
-
 type ContainerSize = { width: number; height: number };
 
 type PendingAnchor = {
@@ -31,6 +30,9 @@ type PendingAnchor = {
 	scrollLeft: number;
 	scrollTop: number;
 	oldScale: number;
+	/** 2本指パンの追加補正量（wheel/ボタンズームでは常に0） */
+	panDeltaX: number;
+	panDeltaY: number;
 } | null;
 
 export function useZoomPan(params: {
@@ -46,14 +48,12 @@ export function useZoomPan(params: {
 		height: 0,
 	});
 	const [mode, setMode] = useState<'fit' | number>('fit');
-	const [mobileMode, setMobileMode] = useState<MobilePanMode>('edit');
 	const pendingAnchorRef = useRef<PendingAnchor>(null);
 
 	// resetKey の変化のみを契機とする（本文内では参照しない）
 	// biome-ignore lint/correctness/useExhaustiveDependencies: resetKeyは識別子変更の検知にのみ使う
 	useEffect(() => {
 		setMode('fit');
-		setMobileMode('edit');
 		pendingAnchorRef.current = null;
 	}, [resetKey]);
 
@@ -109,7 +109,7 @@ export function useZoomPan(params: {
 			containerSize.height,
 			contentHeight * anchor.oldScale,
 		);
-		el.scrollLeft = computeZoomScrollPosition({
+		const rawScrollLeft = computeZoomScrollPosition({
 			pointerInViewport: anchor.pointerX,
 			scrollPosition: anchor.scrollLeft,
 			oldContentOffset: oldOffsetX,
@@ -119,7 +119,7 @@ export function useZoomPan(params: {
 			containerSize: containerSize.width,
 			contentSize: contentWidth,
 		});
-		el.scrollTop = computeZoomScrollPosition({
+		const rawScrollTop = computeZoomScrollPosition({
 			pointerInViewport: anchor.pointerY,
 			scrollPosition: anchor.scrollTop,
 			oldContentOffset: oldOffsetY,
@@ -129,6 +129,16 @@ export function useZoomPan(params: {
 			containerSize: containerSize.height,
 			contentSize: contentHeight,
 		});
+		const maxScrollLeft = Math.max(0, displayWidth - containerSize.width);
+		const maxScrollTop = Math.max(0, displayHeight - containerSize.height);
+		el.scrollLeft = clampScrollPosition(
+			rawScrollLeft - anchor.panDeltaX,
+			maxScrollLeft,
+		);
+		el.scrollTop = clampScrollPosition(
+			rawScrollTop - anchor.panDeltaY,
+			maxScrollTop,
+		);
 		// scale 変化のたびに保留中の補正があれば適用する
 	}, [
 		scale,
@@ -138,6 +148,8 @@ export function useZoomPan(params: {
 		contentHeight,
 		offsetX,
 		offsetY,
+		displayWidth,
+		displayHeight,
 	]);
 
 	// scaleRef を参照するため scale/mode に依存しない安定した関数にする
@@ -150,6 +162,8 @@ export function useZoomPan(params: {
 			scrollLeft: el.scrollLeft,
 			scrollTop: el.scrollTop,
 			oldScale: scaleRef.current,
+			panDeltaX: 0,
+			panDeltaY: 0,
 		};
 	}, []);
 
@@ -216,6 +230,50 @@ export function useZoomPan(params: {
 		return () => el.removeEventListener('wheel', listener);
 	}, [applyScale]);
 
+	const applyPinchTransform = useCallback(
+		(
+			nextScale: number,
+			focalX: number,
+			focalY: number,
+			panDeltaX: number,
+			panDeltaY: number,
+		) => {
+			const el = containerRef.current;
+			if (!el) return;
+			if (!decideScaleApply(scaleRef.current, nextScale).changed) {
+				// 倍率変化なし: このフレームはDOM（コンテンツ幅/高さ）がリサイズされないため、
+				// パン成分のみ直接scrollLeft/Topへ反映してよい。
+				pendingAnchorRef.current = null;
+				const maxScrollLeft = Math.max(0, displayWidth - containerSize.width);
+				const maxScrollTop = Math.max(0, displayHeight - containerSize.height);
+				el.scrollLeft = clampScrollPosition(
+					el.scrollLeft - panDeltaX,
+					maxScrollLeft,
+				);
+				el.scrollTop = clampScrollPosition(
+					el.scrollTop - panDeltaY,
+					maxScrollTop,
+				);
+				return;
+			}
+			// 倍率変化あり: スクロール補正はDOMリサイズ確定後のuseLayoutEffectに委譲する
+			// （リサイズ前に直接scrollLeftを書くと、旧スケールでのスクロール可能範囲へ
+			// 早期クランプされパン量が欠落するため）。panDeltaはそのeffect側で
+			// 追加の減算補正として適用する。
+			pendingAnchorRef.current = {
+				pointerX: focalX,
+				pointerY: focalY,
+				scrollLeft: el.scrollLeft,
+				scrollTop: el.scrollTop,
+				oldScale: scaleRef.current,
+				panDeltaX,
+				panDeltaY,
+			};
+			setMode(nextScale);
+		},
+		[displayWidth, displayHeight, containerSize.width, containerSize.height],
+	);
+
 	return {
 		containerRef,
 		scale,
@@ -224,13 +282,12 @@ export function useZoomPan(params: {
 		displayHeight,
 		offsetX,
 		offsetY,
-		mobileMode,
-		setMobileMode,
 		zoomIn,
 		zoomOut,
 		zoomTo100,
 		zoomToFit,
 		isZoomOutDisabled: isZoomOutNoop(scale),
 		isZoomInDisabled: isZoomInNoop(scale),
+		applyPinchTransform,
 	};
 }

--- a/src/lib/hooks/useZoomPan.ts
+++ b/src/lib/hooks/useZoomPan.ts
@@ -14,6 +14,7 @@ import {
 	computeFitScale,
 	computeWheelZoom,
 	computeZoomScrollPosition,
+	decideScaleApply,
 	isZoomInNoop,
 	isZoomOutNoop,
 	nextZoomInStep,
@@ -152,28 +153,43 @@ export function useZoomPan(params: {
 		};
 	}, []);
 
-	const centerAnchor = useCallback(() => {
+	const centerPoint = useCallback(() => {
 		const el = containerRef.current;
-		if (!el) return;
-		anchorAt(el.clientWidth / 2, el.clientHeight / 2);
-	}, [anchorAt]);
+		return el
+			? { x: el.clientWidth / 2, y: el.clientHeight / 2 }
+			: { x: 0, y: 0 };
+	}, []);
+
+	const applyScale = useCallback(
+		(next: number, px: number, py: number) => {
+			if (!decideScaleApply(scaleRef.current, next).changed) {
+				pendingAnchorRef.current = null;
+			} else {
+				anchorAt(px, py);
+			}
+			setMode(next);
+		},
+		[anchorAt],
+	);
 
 	const zoomIn = useCallback(() => {
-		centerAnchor();
-		setMode(nextZoomInStep(scaleRef.current));
-	}, [centerAnchor]);
+		const { x, y } = centerPoint();
+		applyScale(nextZoomInStep(scaleRef.current), x, y);
+	}, [applyScale, centerPoint]);
 
 	const zoomOut = useCallback(() => {
-		centerAnchor();
-		setMode(nextZoomOutStep(scaleRef.current));
-	}, [centerAnchor]);
+		const { x, y } = centerPoint();
+		applyScale(nextZoomOutStep(scaleRef.current), x, y);
+	}, [applyScale, centerPoint]);
 
 	const zoomTo100 = useCallback(() => {
-		centerAnchor();
-		setMode(1);
-	}, [centerAnchor]);
+		const { x, y } = centerPoint();
+		applyScale(1, x, y);
+	}, [applyScale, centerPoint]);
 
 	const zoomToFit = useCallback(() => {
+		// フィット遷移はアンカー無しの既存仕様を維持しつつ、遷移前に残留アンカーを明示的に破棄する
+		pendingAnchorRef.current = null;
 		setMode('fit');
 	}, []);
 
@@ -190,12 +206,15 @@ export function useZoomPan(params: {
 			if (!(e.ctrlKey || e.metaKey)) return;
 			e.preventDefault();
 			const rect = el.getBoundingClientRect();
-			anchorAt(e.clientX - rect.left, e.clientY - rect.top);
-			setMode(computeWheelZoom(scaleRef.current, e.deltaY, e.deltaMode));
+			applyScale(
+				computeWheelZoom(scaleRef.current, e.deltaY, e.deltaMode),
+				e.clientX - rect.left,
+				e.clientY - rect.top,
+			);
 		};
 		el.addEventListener('wheel', listener, { passive: false });
 		return () => el.removeEventListener('wheel', listener);
-	}, [anchorAt]);
+	}, [applyScale]);
 
 	return {
 		containerRef,

--- a/src/lib/tools/gesture-controller.ts
+++ b/src/lib/tools/gesture-controller.ts
@@ -1,0 +1,226 @@
+// gesture-controller.ts — ポインタ操作を idle / drawing / two-finger-transform の
+// 3状態として管理する純粋な状態遷移ロジック（reducer）。DOM・Reactに依存しない。
+// 実際のPointerEventとの接続は src/lib/hooks/useGestureController.ts が担う。
+
+import {
+	computeDistance,
+	computeMidpoint,
+	type GeometryPoint,
+} from './zoom-pan.ts';
+
+export type GesturePoint = GeometryPoint;
+export type GesturePhase = 'idle' | 'drawing' | 'two-finger-transform';
+
+type Baseline = { distance: number; midpoint: GesturePoint };
+
+export type GestureMachineState = {
+	phase: GesturePhase;
+	pointers: Map<number, GesturePoint>;
+	singlePointerId: number | null;
+	/**
+	 * two-finger-transform から1本指に減った直後、残った指のpointerId。
+	 * このIDのmove/up/cancelは単指操作として転送しない
+	 * （「ピンチ後に残った1本指で意図せず描画が始まらない」ことを保証する）。
+	 */
+	suppressedPointerId: number | null;
+	baseline: Baseline | null;
+	lastMidpoint: GesturePoint | null;
+};
+
+export function createInitialGestureState(): GestureMachineState {
+	return {
+		phase: 'idle',
+		pointers: new Map(),
+		singlePointerId: null,
+		suppressedPointerId: null,
+		baseline: null,
+		lastMidpoint: null,
+	};
+}
+
+export type GestureEvent =
+	| { type: 'down'; pointerId: number; point: GesturePoint }
+	| { type: 'move'; pointerId: number; point: GesturePoint }
+	| { type: 'up'; pointerId: number }
+	| { type: 'cancel'; pointerId: number };
+
+export type TwoFingerStartInfo = { distance: number; midpoint: GesturePoint };
+
+export type TwoFingerMoveInfo = {
+	startDistance: number;
+	distance: number;
+	startMidpoint: GesturePoint;
+	midpoint: GesturePoint;
+	previousMidpoint: GesturePoint;
+};
+
+export type GestureEffect =
+	| { type: 'singleDown' }
+	| { type: 'singleMove' }
+	| { type: 'singleUp' }
+	| { type: 'singleCancel' }
+	| { type: 'singleInterrupted' }
+	| { type: 'twoFingerStart'; info: TwoFingerStartInfo }
+	| { type: 'twoFingerMove'; info: TwoFingerMoveInfo };
+
+export type GestureReduceResult = {
+	state: GestureMachineState;
+	effects: GestureEffect[];
+};
+
+/** pointers Map（挿入順）の先頭2件を「基準ペア」として返す。2件未満なら null。 */
+function primaryPair(
+	pointers: Map<number, GesturePoint>,
+): [GesturePoint, GesturePoint] | null {
+	const iter = pointers.values();
+	const a = iter.next();
+	const b = iter.next();
+	if (a.done || b.done) return null;
+	return [a.value, b.value];
+}
+
+/** 呼び出し側で pointers.size >= 2 を確認済みの場合のみ呼ぶ（基準ペアが必ず取れる）。 */
+function computeBaselineFromPair(pair: [GesturePoint, GesturePoint]): Baseline {
+	return {
+		distance: computeDistance(pair[0], pair[1]),
+		midpoint: computeMidpoint(pair[0], pair[1]),
+	};
+}
+
+export function reduceGestureEvent(
+	state: GestureMachineState,
+	event: GestureEvent,
+): GestureReduceResult {
+	const pointers = new Map(state.pointers);
+	const effects: GestureEffect[] = [];
+
+	if (event.type === 'down') {
+		pointers.set(event.pointerId, event.point);
+		const pair = primaryPair(pointers);
+		if (pair) {
+			if (state.phase === 'drawing')
+				effects.push({ type: 'singleInterrupted' });
+			const baseline = computeBaselineFromPair(pair);
+			effects.push({ type: 'twoFingerStart', info: baseline });
+			return {
+				state: {
+					phase: 'two-finger-transform',
+					pointers,
+					singlePointerId: null,
+					suppressedPointerId: null,
+					baseline,
+					lastMidpoint: baseline.midpoint,
+				},
+				effects,
+			};
+		}
+		effects.push({ type: 'singleDown' });
+		return {
+			state: {
+				phase: 'drawing',
+				pointers,
+				singlePointerId: event.pointerId,
+				suppressedPointerId: null,
+				baseline: null,
+				lastMidpoint: null,
+			},
+			effects,
+		};
+	}
+
+	if (event.type === 'move') {
+		if (state.phase === 'two-finger-transform') {
+			if (!pointers.has(event.pointerId)) return { state, effects };
+			pointers.set(event.pointerId, event.point);
+			const pair = primaryPair(pointers);
+			if (!pair || !state.baseline || !state.lastMidpoint) {
+				return { state: { ...state, pointers }, effects };
+			}
+			const midpoint = computeMidpoint(pair[0], pair[1]);
+			const distance = computeDistance(pair[0], pair[1]);
+			effects.push({
+				type: 'twoFingerMove',
+				info: {
+					startDistance: state.baseline.distance,
+					distance,
+					startMidpoint: state.baseline.midpoint,
+					midpoint,
+					previousMidpoint: state.lastMidpoint,
+				},
+			});
+			return { state: { ...state, pointers, lastMidpoint: midpoint }, effects };
+		}
+
+		// 2本指解除直後に残った指のmoveは転送しない（drawingを誤って再開させないため）
+		if (event.pointerId === state.suppressedPointerId) {
+			pointers.set(event.pointerId, event.point);
+			return { state: { ...state, pointers }, effects };
+		}
+
+		// idle/drawing かつ抑制対象でない: pointerdownを経ていないマウスの
+		// 純粋なホバー移動も含め、常に singleMove として転送する
+		if (pointers.has(event.pointerId))
+			pointers.set(event.pointerId, event.point);
+		effects.push({ type: 'singleMove' });
+		return { state: { ...state, pointers }, effects };
+	}
+
+	// up / cancel
+	if (event.pointerId === state.suppressedPointerId) {
+		pointers.delete(event.pointerId);
+		return {
+			state: { ...state, pointers, suppressedPointerId: null },
+			effects,
+		};
+	}
+	if (!pointers.has(event.pointerId)) return { state, effects };
+	pointers.delete(event.pointerId);
+
+	if (state.phase === 'drawing' && event.pointerId === state.singlePointerId) {
+		effects.push({ type: event.type === 'up' ? 'singleUp' : 'singleCancel' });
+		return {
+			state: {
+				phase: 'idle',
+				pointers,
+				singlePointerId: null,
+				suppressedPointerId: null,
+				baseline: null,
+				lastMidpoint: null,
+			},
+			effects,
+		};
+	}
+
+	if (state.phase === 'two-finger-transform') {
+		const pair = primaryPair(pointers);
+		if (pair) {
+			const baseline = computeBaselineFromPair(pair);
+			effects.push({ type: 'twoFingerStart', info: baseline });
+			return {
+				state: {
+					phase: 'two-finger-transform',
+					pointers,
+					singlePointerId: null,
+					suppressedPointerId: null,
+					baseline,
+					lastMidpoint: baseline.midpoint,
+				},
+				effects,
+			};
+		}
+		const remainingId = pointers.size === 1 ? [...pointers.keys()][0] : null;
+		return {
+			state: {
+				phase: 'idle',
+				pointers,
+				singlePointerId: null,
+				suppressedPointerId: remainingId ?? null,
+				baseline: null,
+				lastMidpoint: null,
+			},
+			effects,
+		};
+	}
+
+	return { state: { ...state, pointers }, effects };
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -169,3 +169,15 @@ export function isZoomOutNoop(scale: number): boolean {
 export function isZoomInNoop(scale: number): boolean {
 	return Math.abs(nextZoomInStep(scale) - scale) < 1e-9;
 }
+
+/**
+ * 倍率変更が実質的な変化かどうかを判定する（C1修正のコア）。
+ * useZoomPan の applyScale / applyPinchTransform から呼ばれる、
+ * 同値なら pendingAnchorRef を破棄すべき、という判断を返す。
+ */
+export function decideScaleApply(
+	currentScale: number,
+	nextScale: number,
+): { changed: boolean } {
+	return { changed: Math.abs(nextScale - currentScale) >= 1e-9 };
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -181,3 +181,18 @@ export function decideScaleApply(
 ): { changed: boolean } {
 	return { changed: Math.abs(nextScale - currentScale) >= 1e-9 };
 }
+
+export type GeometryPoint = { x: number; y: number };
+
+/** 2点の中点を求める（2本指ジェスチャーの基準点計算に使用） */
+export function computeMidpoint(
+	a: GeometryPoint,
+	b: GeometryPoint,
+): GeometryPoint {
+	return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
+}
+
+/** 2点間のユークリッド距離を求める（ピンチ倍率算出に使用） */
+export function computeDistance(a: GeometryPoint, b: GeometryPoint): number {
+	return Math.hypot(b.x - a.x, b.y - a.y);
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -196,3 +196,25 @@ export function computeMidpoint(
 export function computeDistance(a: GeometryPoint, b: GeometryPoint): number {
 	return Math.hypot(b.x - a.x, b.y - a.y);
 }
+
+/**
+ * ピンチ操作による次の倍率を計算する。
+ * startDistance <= 0（指がほぼ重なった状態からの開始等、ゼロ除算になる入力）
+ * では倍率を変化させず startScale を返す。
+ * クランプ方針は computeWheelZoom と同一の非対称ルールに従う。
+ */
+export function computePinchZoom(
+	startScale: number,
+	startDistance: number,
+	currentDistance: number,
+): number {
+	if (startDistance <= 0) return startScale;
+	const raw = startScale * (currentDistance / startDistance);
+	if (startScale >= MIN_ZOOM) return clampZoom(raw);
+	return Math.min(MAX_ZOOM, Math.max(0.01, raw));
+}
+
+/** スクロール位置を [0, maxScroll] にクランプする（2本指パンの直接更新で使用） */
+export function clampScrollPosition(value: number, maxScroll: number): number {
+	return Math.min(Math.max(0, maxScroll), Math.max(0, value));
+}

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -211,7 +211,7 @@ export function computePinchZoom(
 	if (startDistance <= 0) return startScale;
 	const raw = startScale * (currentDistance / startDistance);
 	if (startScale >= MIN_ZOOM) return clampZoom(raw);
-	return Math.min(MAX_ZOOM, Math.max(0.01, raw));
+	return Math.min(MAX_ZOOM, Math.max(startScale, raw));
 }
 
 /** スクロール位置を [0, maxScroll] にクランプする（2本指パンの直接更新で使用） */

--- a/tests/e2e/helpers/canvas.ts
+++ b/tests/e2e/helpers/canvas.ts
@@ -1,4 +1,4 @@
-import type { Locator, Page } from '@playwright/test';
+import type { BrowserContext, Locator, Page } from '@playwright/test';
 
 /**
  * 画像座標（canvas内部解像度の座標）をページのCSS座標に変換する。
@@ -284,4 +284,68 @@ export async function generateSyntheticImage(
 	);
 	const base64 = dataUrl.split(',')[1] ?? '';
 	return Buffer.from(base64, 'base64');
+}
+
+type CDPSession = Awaited<ReturnType<BrowserContext['newCDPSession']>>;
+
+type TouchPoint = { x: number; y: number; id: number };
+
+function toCdpTouchPoint(p: TouchPoint) {
+	return { x: p.x, y: p.y, id: p.id, radiusX: 1, radiusY: 1, force: 1 };
+}
+
+/**
+ * Input.dispatchTouchEvent の低レベルラッパー（CDP、Chromiumのみ）。
+ * touchPoints にはその時点でアクティブな全接触点を渡す。
+ * 一部の指だけを離す場合は type: 'touchEnd' に「残す指のみ」を渡し、
+ * 完全に離す場合は空配列を渡す。
+ */
+export async function dispatchTouchEvent(
+	client: CDPSession,
+	type: 'touchStart' | 'touchMove' | 'touchEnd' | 'touchCancel',
+	touchPoints: TouchPoint[],
+): Promise<void> {
+	await client.send('Input.dispatchTouchEvent', {
+		type,
+		touchPoints: touchPoints.map(toCdpTouchPoint),
+	});
+}
+
+/**
+ * 2本指のピンチ＋パンをCDP経由でシミュレートする（Chromiumのみ）。
+ * page.touchscreen は単点tap()のみで多点非対応のため、CDPを直接叩く。
+ */
+export async function pinch(
+	page: Page,
+	params: {
+		center: { x: number; y: number };
+		startDistance: number;
+		endDistance: number;
+		panDeltaX?: number;
+		panDeltaY?: number;
+		steps?: number;
+	},
+): Promise<void> {
+	const client = await page.context().newCDPSession(page);
+	const steps = params.steps ?? 8;
+	const panDeltaX = params.panDeltaX ?? 0;
+	const panDeltaY = params.panDeltaY ?? 0;
+
+	const pointsAt = (t: number): TouchPoint[] => {
+		const distance =
+			params.startDistance + (params.endDistance - params.startDistance) * t;
+		const cx = params.center.x + panDeltaX * t;
+		const cy = params.center.y + panDeltaY * t;
+		return [
+			{ x: cx - distance / 2, y: cy, id: 0 },
+			{ x: cx + distance / 2, y: cy, id: 1 },
+		];
+	};
+
+	await dispatchTouchEvent(client, 'touchStart', pointsAt(0));
+	for (let i = 1; i <= steps; i++) {
+		await dispatchTouchEvent(client, 'touchMove', pointsAt(i / steps));
+	}
+	await dispatchTouchEvent(client, 'touchEnd', []);
+	await client.detach();
 }

--- a/tests/e2e/image-mosaic.spec.ts
+++ b/tests/e2e/image-mosaic.spec.ts
@@ -4,10 +4,7 @@ import { expect, test } from './fixtures/base';
 import {
 	countDiffFromFixture,
 	dragOnCanvas,
-	generateSyntheticImage,
 	getCanvasPixel,
-	getContainerBox,
-	getZoomGeometry,
 	imagePointToPage,
 } from './helpers/canvas';
 
@@ -379,6 +376,19 @@ test.describe('ズーム＆パン・フルサイズ表示', () => {
 		await uploadSample(page);
 		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
 	});
+
+	test('ズームビューポート外ではページの縦スクロールが阻害されない', async ({
+		page,
+	}) => {
+		await uploadSample(page);
+		const scrollYBefore = await page.evaluate(() => window.scrollY);
+		// パンくずリスト付近（ズームビューポートより確実に上）にカーソルを置く
+		await page.mouse.move(10, 5);
+		await page.mouse.wheel(0, 400);
+		await expect
+			.poll(() => page.evaluate(() => window.scrollY))
+			.toBeGreaterThan(scrollYBefore);
+	});
 });
 
 test.describe('stackBlur フォールバック実装', () => {
@@ -415,145 +425,5 @@ test.describe('stackBlur フォールバック実装', () => {
 		expect(r(2, 4)).toBe(r(6, 4));
 		expect(r(4, 3)).toBe(r(4, 5));
 		expect(r(3, 4)).toBeLessThanOrEqual(r(4, 4));
-	});
-});
-
-test.describe('モバイル編集／パンモード', () => {
-	test.beforeEach(async ({ page, createToolPage }) => {
-		// モバイル用の編集／パン切替ボタンは sm:hidden のため、
-		// どの Playwright project で実行してもボタンが見えるよう明示的に狭める
-		await page.setViewportSize({ width: 375, height: 812 });
-		const toolPage = createToolPage('image-mosaic');
-		await toolPage.goto();
-		await expect(
-			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
-		).toBeVisible({ timeout: 10000 });
-	});
-
-	const editButton = (page: import('@playwright/test').Page) =>
-		page.getByRole('button', { name: '編集モード（ドラッグで選択・移動）' });
-	const panButton = (page: import('@playwright/test').Page) =>
-		page.getByRole('button', { name: 'パンモード（ドラッグで画像内を移動）' });
-
-	test('アップロード直後は編集モードで、Accessible Nameとaria-pressedが正しい', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'false');
-	});
-
-	test('編集モードでは既存のドラッグ選択が機能する', async ({ page }) => {
-		await uploadSample(page);
-		const canvas = page.getByTestId('editor-canvas');
-		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
-		await expect
-			.poll(() => getCanvasPixel(page, 'editor-canvas', 96, 100))
-			.not.toEqual(WHITE);
-	});
-
-	test('パンモードに切り替えるとドラッグ選択が発火しない', async ({ page }) => {
-		await uploadSample(page);
-		await panButton(page).click();
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
-
-		const canvas = page.getByTestId('editor-canvas');
-		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
-		// パンモードでは領域が追加されないため、canvasはフィクスチャ原画のまま
-		expect(await countDiffFromFixture(page, 'editor-canvas')).toBe(0);
-	});
-
-	test('パンモードでは画像の四隅へ移動でき、ページの横スクロールは発生しない', async ({
-		page,
-	}) => {
-		// フィクスチャ(400x300)は100%表示でもコンテナ内に収まってしまいパンの
-		// 余地がないため、縦横ともコンテナよりはっきり大きい画像を使う
-		const buffer = await generateSyntheticImage(page, 2400, 1800);
-		await page
-			.locator('input[type="file"]')
-			.setInputFiles({ name: 'large.png', mimeType: 'image/png', buffer });
-		await expect(page.getByTestId('editor-canvas')).toBeVisible();
-		await page.getByRole('button', { name: '100%' }).click();
-		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
-		await panButton(page).click();
-
-		const containerBox = await getContainerBox(page);
-		const cx = containerBox.x + containerBox.width / 2;
-		const cy = containerBox.y + containerBox.height / 2;
-		await page.mouse.move(cx, cy);
-
-		// 左上へ（負方向いっぱいにスクロール）
-		await page.mouse.wheel(-5000, -5000);
-		await expect
-			.poll(
-				async () => (await getZoomGeometry(page, 'editor-canvas')).scrollLeft,
-			)
-			.toBe(0);
-		expect((await getZoomGeometry(page, 'editor-canvas')).scrollTop).toBe(0);
-
-		// 右下へ（正方向いっぱいにスクロール）
-		await page.mouse.wheel(5000, 5000);
-		await expect
-			.poll(
-				async () => (await getZoomGeometry(page, 'editor-canvas')).scrollLeft,
-			)
-			.toBeGreaterThan(0);
-		const afterBottomRight = await getZoomGeometry(page, 'editor-canvas');
-		expect(afterBottomRight.scrollTop).toBeGreaterThan(0);
-
-		// ページ全体に不要な横スクロールが発生していないこと
-		const hasHorizontalOverflow = await page.evaluate(
-			() =>
-				document.documentElement.scrollWidth >
-				document.documentElement.clientWidth,
-		);
-		expect(hasHorizontalOverflow).toBe(false);
-	});
-
-	test('ズームビューポート外ではページの縦スクロールが阻害されない', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		const scrollYBefore = await page.evaluate(() => window.scrollY);
-		// パンくずリスト付近（ズームビューポートより確実に上）にカーソルを置く
-		await page.mouse.move(10, 5);
-		await page.mouse.wheel(0, 400);
-		await expect
-			.poll(() => page.evaluate(() => window.scrollY))
-			.toBeGreaterThan(scrollYBefore);
-	});
-
-	test('新しい画像を読み込むと編集モードへ戻る', async ({ page }) => {
-		await uploadSample(page);
-		await panButton(page).click();
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
-
-		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
-		await uploadSample(page);
-		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
-	});
-
-	test('編集／パンの切替でズーム倍率や編集内容が失われない', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		const canvas = page.getByTestId('editor-canvas');
-		await dragOnCanvas(page, canvas, { x: 80, y: 60 }, { x: 180, y: 140 });
-		await page.getByRole('button', { name: '100%' }).click();
-		const percentLabel = page.getByTestId('zoom-percent-label');
-		await expect(percentLabel).toHaveText('100%');
-		const pixelBefore = await getCanvasPixel(page, 'editor-canvas', 96, 100);
-
-		await panButton(page).click();
-		await expect(percentLabel).toHaveText('100%');
-		expect(await getCanvasPixel(page, 'editor-canvas', 96, 100)).toEqual(
-			pixelBefore,
-		);
-
-		await editButton(page).click();
-		await expect(percentLabel).toHaveText('100%');
-		expect(await getCanvasPixel(page, 'editor-canvas', 96, 100)).toEqual(
-			pixelBefore,
-		);
 	});
 });

--- a/tests/e2e/image-text.spec.ts
+++ b/tests/e2e/image-text.spec.ts
@@ -3,10 +3,7 @@ import { expect, test } from './fixtures/base';
 import {
 	countDiffFromFixture,
 	countMatchingPixels,
-	generateSyntheticImage,
 	getCanvasPixel,
-	getContainerBox,
-	getZoomGeometry,
 	imagePointToPage,
 } from './helpers/canvas';
 
@@ -281,117 +278,6 @@ test.describe('ズーム＆パン・フルサイズ表示', () => {
 		await uploadSample(page);
 		await expect(page.getByText(/^フィット（\d+%）$/)).toBeVisible();
 	});
-});
-
-test.describe('モバイル編集／パンモード', () => {
-	test.beforeEach(async ({ page, createToolPage }) => {
-		// モバイル用の編集／パン切替ボタンは sm:hidden のため、
-		// どの Playwright project で実行してもボタンが見えるよう明示的に狭める
-		await page.setViewportSize({ width: 375, height: 812 });
-		const toolPage = createToolPage('image-text');
-		await toolPage.goto();
-		await expect(
-			page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
-		).toBeVisible({ timeout: 10000 });
-	});
-
-	const editButton = (page: import('@playwright/test').Page) =>
-		page.getByRole('button', { name: '編集モード（ドラッグで選択・移動）' });
-	const panButton = (page: import('@playwright/test').Page) =>
-		page.getByRole('button', { name: 'パンモード（ドラッグで画像内を移動）' });
-
-	test('アップロード直後は編集モードで、Accessible Nameとaria-pressedが正しい', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'false');
-	});
-
-	test('編集モードでは既存のレイヤードラッグ移動が機能する', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		await addLayer(page);
-		const canvas = page.getByTestId('text-canvas');
-
-		const from = await imagePointToPage(canvas, 200, 148);
-		const to = await imagePointToPage(canvas, 200, 248);
-		await page.mouse.move(from.x, from.y);
-		await page.mouse.down();
-		await page.mouse.move(to.x, to.y, { steps: 5 });
-		await page.mouse.up();
-
-		await expect
-			.poll(() => countDiffFromFixture(page, 'text-canvas', TEXT_REGION))
-			.toBe(0);
-	});
-
-	test('パンモードに切り替えるとレイヤードラッグ移動が発火しない', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		await addLayer(page);
-		await panButton(page).click();
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
-
-		const canvas = page.getByTestId('text-canvas');
-		const from = await imagePointToPage(canvas, 200, 148);
-		const to = await imagePointToPage(canvas, 200, 248);
-		await page.mouse.move(from.x, from.y);
-		await page.mouse.down();
-		await page.mouse.move(to.x, to.y, { steps: 5 });
-		await page.mouse.up();
-
-		// パンモードではレイヤーが移動しないため、元の位置に留まる
-		expect(
-			await countDiffFromFixture(page, 'text-canvas', TEXT_REGION),
-		).toBeGreaterThan(0);
-		const movedRegion = { x: 120, y: 200, width: 200, height: 90 };
-		expect(await countDiffFromFixture(page, 'text-canvas', movedRegion)).toBe(
-			0,
-		);
-	});
-
-	test('パンモードでは画像の四隅へ移動でき、ページの横スクロールは発生しない', async ({
-		page,
-	}) => {
-		// フィクスチャ(400x300)は100%表示でもコンテナ内に収まってしまいパンの
-		// 余地がないため、縦横ともコンテナよりはっきり大きい画像を使う
-		const buffer = await generateSyntheticImage(page, 2400, 1800);
-		await page
-			.locator('input[type="file"]')
-			.setInputFiles({ name: 'large.png', mimeType: 'image/png', buffer });
-		await expect(page.getByTestId('text-canvas')).toBeVisible();
-		await page.getByRole('button', { name: '100%' }).click();
-		await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
-		await panButton(page).click();
-
-		const containerBox = await getContainerBox(page);
-		const cx = containerBox.x + containerBox.width / 2;
-		const cy = containerBox.y + containerBox.height / 2;
-		await page.mouse.move(cx, cy);
-
-		await page.mouse.wheel(-5000, -5000);
-		await expect
-			.poll(async () => (await getZoomGeometry(page, 'text-canvas')).scrollLeft)
-			.toBe(0);
-		expect((await getZoomGeometry(page, 'text-canvas')).scrollTop).toBe(0);
-
-		await page.mouse.wheel(5000, 5000);
-		await expect
-			.poll(async () => (await getZoomGeometry(page, 'text-canvas')).scrollLeft)
-			.toBeGreaterThan(0);
-		const afterBottomRight = await getZoomGeometry(page, 'text-canvas');
-		expect(afterBottomRight.scrollTop).toBeGreaterThan(0);
-
-		const hasHorizontalOverflow = await page.evaluate(
-			() =>
-				document.documentElement.scrollWidth >
-				document.documentElement.clientWidth,
-		);
-		expect(hasHorizontalOverflow).toBe(false);
-	});
 
 	test('ズームビューポート外ではページの縦スクロールが阻害されない', async ({
 		page,
@@ -403,43 +289,5 @@ test.describe('モバイル編集／パンモード', () => {
 		await expect
 			.poll(() => page.evaluate(() => window.scrollY))
 			.toBeGreaterThan(scrollYBefore);
-	});
-
-	test('新しい画像を読み込むと編集モードへ戻る', async ({ page }) => {
-		await uploadSample(page);
-		await panButton(page).click();
-		await expect(panButton(page)).toHaveAttribute('aria-pressed', 'true');
-
-		await page.getByRole('button', { name: '別の画像を選ぶ' }).click();
-		await uploadSample(page);
-		await expect(editButton(page)).toHaveAttribute('aria-pressed', 'true');
-	});
-
-	test('編集／パンの切替でズーム倍率や編集内容が失われない', async ({
-		page,
-	}) => {
-		await uploadSample(page);
-		await addLayer(page);
-		await page.getByRole('button', { name: '100%' }).click();
-		const percentLabel = page.getByTestId('zoom-percent-label');
-		await expect(percentLabel).toHaveText('100%');
-		const diffBefore = await countDiffFromFixture(
-			page,
-			'text-canvas',
-			TEXT_REGION,
-		);
-		expect(diffBefore).toBeGreaterThan(0);
-
-		await panButton(page).click();
-		await expect(percentLabel).toHaveText('100%');
-		expect(await countDiffFromFixture(page, 'text-canvas', TEXT_REGION)).toBe(
-			diffBefore,
-		);
-
-		await editButton(page).click();
-		await expect(percentLabel).toHaveText('100%');
-		expect(await countDiffFromFixture(page, 'text-canvas', TEXT_REGION)).toBe(
-			diffBefore,
-		);
 	});
 });

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -7,7 +7,11 @@ import path from 'node:path';
 import type { Page } from '@playwright/test';
 import { expect, test } from './fixtures/base';
 import {
+	countDiffFromFixture,
+	dispatchTouchEvent,
+	dragOnCanvas,
 	generateSyntheticImage,
+	getCanvasPixel,
 	getContainerBox,
 	getZoomGeometry,
 	imagePointFromClientPoint,
@@ -64,6 +68,25 @@ async function waitForStableGeometry(
 	return getZoomGeometry(page, canvasTestId);
 }
 
+/**
+ * canvas 自身の boundingBox を返す（zoom-scroll-container ではなく canvas 本体）。
+ * モバイル幅では画像がコンテナ内でレターボックス表示され、コンテナ基準の座標が
+ * 余白（非canvas領域）に落ちてタッチイベントが一切届かなくなることがあるため、
+ * CDP タッチ座標の計算には必ずこちらを使う。scrollIntoViewIfNeeded で
+ * ビューポート内へ確実に入れてから測定する（未実施だとcanvasがビューポート外＝
+ * イベント発火不能な座標を返すことがある）。
+ */
+async function getCanvasBox(
+	page: Page,
+	canvasTestId: string,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+	const canvas = page.getByTestId(canvasTestId);
+	await canvas.scrollIntoViewIfNeeded();
+	const box = await canvas.boundingBox();
+	if (!box) throw new Error(`canvas が表示されていません: ${canvasTestId}`);
+	return box;
+}
+
 async function uploadFixture(page: Page, canvasTestId: string) {
 	await page.locator('input[type="file"]').setInputFiles(SAMPLE);
 	await expect(page.getByTestId(canvasTestId)).toBeVisible();
@@ -113,6 +136,25 @@ async function uploadLargePannableImage(page: Page, canvasTestId: string) {
 	await page.getByRole('button', { name: '100%' }).click();
 	await expect(page.getByTestId('zoom-percent-label')).toHaveText('100%');
 	await waitForStableGeometry(page, canvasTestId);
+}
+
+/**
+ * image-text の選択中テキストレイヤーのバウンディングボックス（DOMオーバーレイの
+ * left/top style、画像サイズに対する%文字列）を読む。レイヤーがドラッグで移動した
+ * ことを、内部状態を直接読まずにDOMから検証するために使う。
+ */
+async function getSelectedTextLayerBounds(
+	page: Page,
+	canvasTestId: string,
+): Promise<{ left: string; top: string } | null> {
+	return page.evaluate((testId) => {
+		const canvas = document.querySelector(`[data-testid="${testId}"]`);
+		const overlay = canvas?.parentElement?.querySelector(
+			'.border-dashed',
+		) as HTMLElement | null;
+		if (!overlay) return null;
+		return { left: overlay.style.left, top: overlay.style.top };
+	}, canvasTestId);
 }
 
 /**
@@ -494,6 +536,190 @@ for (const tool of TOOLS) {
 			const after = await getZoomGeometry(page, tool.canvasTestId);
 			expect(after.scrollLeft).not.toEqual(before.scrollLeft);
 			expect(after.scrollTop).not.toEqual(before.scrollTop);
+		});
+
+		test('1本指描画中に2本目を置いても領域が追加されない', async ({ page }) => {
+			await uploadFixture(page, tool.canvasTestId);
+			const client = await page.context().newCDPSession(page);
+			const canvasBox = await getCanvasBox(page, tool.canvasTestId);
+			const p1 = { x: canvasBox.x + 40, y: canvasBox.y + 40 };
+			const p2 = { x: canvasBox.x + 140, y: canvasBox.y + 100 };
+
+			await dispatchTouchEvent(client, 'touchStart', [{ ...p1, id: 0 }]);
+			await dispatchTouchEvent(client, 'touchMove', [
+				{ x: p1.x + 30, y: p1.y + 20, id: 0 },
+			]);
+			await dispatchTouchEvent(client, 'touchStart', [
+				{ x: p1.x + 30, y: p1.y + 20, id: 0 },
+				{ ...p2, id: 1 },
+			]);
+			await dispatchTouchEvent(client, 'touchEnd', []);
+			await client.detach();
+
+			expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+		});
+
+		test('ピンチ後に残った1本指で意図せず描画が始まらない', async ({
+			page,
+		}) => {
+			await uploadFixture(page, tool.canvasTestId);
+			const client = await page.context().newCDPSession(page);
+			const containerBox = await getContainerBox(page);
+			const cx = containerBox.x + containerBox.width / 2;
+			const cy = containerBox.y + containerBox.height / 2;
+
+			await dispatchTouchEvent(client, 'touchStart', [
+				{ x: cx - 50, y: cy, id: 0 },
+				{ x: cx + 50, y: cy, id: 1 },
+			]);
+			await dispatchTouchEvent(client, 'touchMove', [
+				{ x: cx - 70, y: cy, id: 0 },
+				{ x: cx + 70, y: cy, id: 1 },
+			]);
+			await dispatchTouchEvent(client, 'touchEnd', [
+				{ x: cx - 70, y: cy, id: 0 },
+			]);
+			await dispatchTouchEvent(client, 'touchMove', [
+				{ x: cx + 100, y: cy + 100, id: 0 },
+			]);
+			await dispatchTouchEvent(client, 'touchEnd', []);
+			await client.detach();
+
+			expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+		});
+
+		test('片指離脱・3本目追加・指の入れ替わりの後も操作不能にならない', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const client = await page.context().newCDPSession(page);
+			const containerBox = await getContainerBox(page);
+			const cx = containerBox.x + containerBox.width / 2;
+			const cy = containerBox.y + containerBox.height / 2;
+
+			await dispatchTouchEvent(client, 'touchStart', [
+				{ x: cx - 50, y: cy, id: 0 },
+				{ x: cx + 50, y: cy, id: 1 },
+			]);
+			await dispatchTouchEvent(client, 'touchStart', [
+				{ x: cx - 50, y: cy, id: 0 },
+				{ x: cx + 50, y: cy, id: 1 },
+				{ x: cx, y: cy + 80, id: 2 },
+			]);
+			await dispatchTouchEvent(client, 'touchEnd', [
+				{ x: cx + 50, y: cy, id: 1 },
+				{ x: cx, y: cy + 80, id: 2 },
+			]);
+			await dispatchTouchEvent(client, 'touchMove', [
+				{ x: cx + 70, y: cy, id: 1 },
+				{ x: cx, y: cy + 60, id: 2 },
+			]);
+			await dispatchTouchEvent(client, 'touchEnd', []);
+			await client.detach();
+
+			const canvas = page.getByTestId(tool.canvasTestId);
+			const box = await canvas.boundingBox();
+			if (!box) throw new Error('canvas が表示されていません');
+			await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+			await expect(canvas).toBeVisible();
+		});
+
+		test('pointercancel相当（canvas外への移動→touchCancel）の後も操作不能にならない', async ({
+			page,
+		}) => {
+			await uploadFixture(page, tool.canvasTestId);
+			// image-text はキャンバス上の何もない場所へのドラッグでは描画が起きない
+			// （既存テキストレイヤーのヒットテストに当たった場合のみ移動する）ため、
+			// 操作継続性を検証できるようレイヤーを1つ用意しておく。
+			if (tool.id === 'image-text') {
+				await page.getByRole('button', { name: 'テキストを追加' }).click();
+			}
+			const client = await page.context().newCDPSession(page);
+			const canvasBox = await getCanvasBox(page, tool.canvasTestId);
+			// image-text の初期レイヤーは画像中央付近に配置されるため、干渉しないよう
+			// canvas 左端寄りを起点にする（image-mosaic は canvas 内であれば場所を問わない）。
+			// y は canvas 中央高さを使う。image-text ではテキストレイヤー追加後にページの
+			// 固定ヘッダー（sticky header, 高さ約65px）の直下まで canvas がスクロールされる
+			// ことがあり、canvas 左上隅ギリギリの点だとヘッダーに覆われてイベントが一切
+			// 届かない（=検証が素通りする）ケースが実測で確認されたため、垂直方向は
+			// canvas 中央を使いヘッダーの影響を受けない位置にする。
+			const cancelPoint = {
+				x: canvasBox.x + 20,
+				y: canvasBox.y + Math.round(canvasBox.height / 2),
+			};
+
+			await dispatchTouchEvent(client, 'touchStart', [
+				{ ...cancelPoint, id: 0 },
+			]);
+			await dispatchTouchEvent(client, 'touchMove', [
+				{ x: cancelPoint.x, y: cancelPoint.y - 5000, id: 0 },
+			]);
+			await dispatchTouchEvent(client, 'touchCancel', []);
+			await client.detach();
+
+			if (tool.id === 'image-text') {
+				const before = await getSelectedTextLayerBounds(
+					page,
+					tool.canvasTestId,
+				);
+				await dragOnCanvas(
+					page,
+					page.getByTestId(tool.canvasTestId),
+					{ x: 145, y: 135 },
+					{ x: 250, y: 220 },
+				);
+				await expect
+					.poll(() => getSelectedTextLayerBounds(page, tool.canvasTestId))
+					.not.toEqual(before);
+			} else {
+				await dragOnCanvas(
+					page,
+					page.getByTestId(tool.canvasTestId),
+					{ x: 80, y: 60 },
+					{ x: 180, y: 140 },
+				);
+				await expect
+					.poll(() => getCanvasPixel(page, tool.canvasTestId, 96, 100))
+					.not.toEqual([255, 255, 255, 255]);
+			}
+		});
+
+		test('ピンチ中のResizeObserver発火（フルサイズ切替）後もアンカーが飛ばない', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const containerBox = await getContainerBox(page);
+			const center = {
+				x: containerBox.x + containerBox.width / 2,
+				y: containerBox.y + containerBox.height / 2,
+			};
+			const before = await getZoomGeometry(page, tool.canvasTestId);
+			const beforePoint = imagePointFromClientPoint(before, center.x, center.y);
+
+			await pinch(page, { center, startDistance: 100, endDistance: 220 });
+			// Playwright の click() は対象がビューポート外なら自動でページをスクロール
+			// してしまい、モバイル幅ではその副作用（無関係なページスクロール）で
+			// containerTop が大きくずれ、アンカー検証が汚染される。ここで検証したいのは
+			// 「ResizeObserver発火時にズーム内部のアンカーが飛ばないか」であって
+			// ページスクロール量ではないため、ネイティブclick()をDOM経由で直接発火し
+			// スクロールを伴わずにトグルする。
+			await page
+				.getByRole('button', { name: 'フルサイズ' })
+				.evaluate((el) => (el as HTMLElement).click());
+			await waitForStableGeometry(page, tool.canvasTestId);
+
+			const after = await getZoomGeometry(page, tool.canvasTestId);
+			const afterPoint = imagePointFromClientPoint(after, center.x, center.y);
+			const tolerance = toleranceFor(after) + 5;
+			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			await page
+				.getByRole('button', { name: '標準幅' })
+				.evaluate((el) => (el as HTMLElement).click());
 		});
 	});
 }

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -408,5 +408,40 @@ for (const tool of TOOLS) {
 			await expect(percentLabel).toHaveText('400%');
 			await expect(zoomInButton).toBeDisabled();
 		});
+
+		test('400%上限に張り付いた後、1段階だけズームアウトしてもカーソル位置がずれない', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const { clientX, clientY } = await getClientPointAndGeometry(
+				page,
+				tool.canvasTestId,
+				0.5,
+				0.5,
+			);
+			// 400%上限に張り付くまで拡大し続ける（同値setMode呼び出しを複数回発生させる）
+			for (let i = 0; i < 10; i++) {
+				await zoomAtClientPoint(page, clientX, clientY, -1_000_000, 'Control');
+			}
+			await expect(page.getByTestId('zoom-percent-label')).toHaveText('400%');
+			const before = await getZoomGeometry(page, tool.canvasTestId);
+			const beforePoint = imagePointFromClientPoint(before, clientX, clientY);
+
+			await zoomAtClientPoint(page, clientX, clientY, 60, 'Control');
+			const after = await waitForScaleChange(
+				page,
+				tool.canvasTestId,
+				before.scale,
+			);
+			const afterPoint = imagePointFromClientPoint(after, clientX, clientY);
+
+			const tolerance = toleranceFor(after);
+			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
+				tolerance,
+			);
+			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
+				tolerance,
+			);
+		});
 	});
 }

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -15,6 +15,7 @@ import {
 	getContainerBox,
 	getZoomGeometry,
 	imagePointFromClientPoint,
+	imagePointToPage,
 	pinch,
 	type ZoomGeometry,
 	zoomAtClientPoint,
@@ -540,10 +541,29 @@ for (const tool of TOOLS) {
 
 		test('1本指描画中に2本目を置いても領域が追加されない', async ({ page }) => {
 			await uploadFixture(page, tool.canvasTestId);
+			// image-text はキャンバス上の何もない場所へのドラッグでは描画が起きない
+			// （既存テキストレイヤーのヒットテストに当たった場合のみ移動する）ため、
+			// 干渉を検証できるようレイヤーを1つ用意しておく。
+			if (tool.id === 'image-text') {
+				await page.getByRole('button', { name: 'テキストを追加' }).click();
+			}
 			const client = await page.context().newCDPSession(page);
+			const canvas = page.getByTestId(tool.canvasTestId);
 			const canvasBox = await getCanvasBox(page, tool.canvasTestId);
-			const p1 = { x: canvasBox.x + 40, y: canvasBox.y + 40 };
-			const p2 = { x: canvasBox.x + 140, y: canvasBox.y + 100 };
+
+			// image-text は追加直後のテキストレイヤー上（画像中央付近）を起点にする
+			const p1 =
+				tool.id === 'image-text'
+					? await imagePointToPage(canvas, 145, 135)
+					: { x: canvasBox.x + 40, y: canvasBox.y + 40 };
+			const p2 = {
+				x: canvasBox.x + canvasBox.width - 30,
+				y: canvasBox.y + canvasBox.height - 30,
+			};
+			const before =
+				tool.id === 'image-text'
+					? await getSelectedTextLayerBounds(page, tool.canvasTestId)
+					: null;
 
 			await dispatchTouchEvent(client, 'touchStart', [{ ...p1, id: 0 }]);
 			await dispatchTouchEvent(client, 'touchMove', [
@@ -556,17 +576,34 @@ for (const tool of TOOLS) {
 			await dispatchTouchEvent(client, 'touchEnd', []);
 			await client.detach();
 
-			expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+			if (tool.id === 'image-text') {
+				// 2本目の指でピンチへ遷移した時点で、直前のドラッグによる移動は
+				// ロールバックされ、レイヤー位置は元のままであるべき
+				expect(
+					await getSelectedTextLayerBounds(page, tool.canvasTestId),
+				).toEqual(before);
+			} else {
+				expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+			}
 		});
 
 		test('ピンチ後に残った1本指で意図せず描画が始まらない', async ({
 			page,
 		}) => {
 			await uploadFixture(page, tool.canvasTestId);
+			if (tool.id === 'image-text') {
+				await page.getByRole('button', { name: 'テキストを追加' }).click();
+			}
 			const client = await page.context().newCDPSession(page);
-			const containerBox = await getContainerBox(page);
-			const cx = containerBox.x + containerBox.width / 2;
-			const cy = containerBox.y + containerBox.height / 2;
+			// レターボックス表示時にコンテナ中心が非canvas領域へ落ちてイベントが
+			// 届かなくなることがあるため、必ずcanvas自身のboundingBoxを使う
+			const canvasBox = await getCanvasBox(page, tool.canvasTestId);
+			const cx = canvasBox.x + canvasBox.width / 2;
+			const cy = canvasBox.y + canvasBox.height / 2;
+			const before =
+				tool.id === 'image-text'
+					? await getSelectedTextLayerBounds(page, tool.canvasTestId)
+					: null;
 
 			await dispatchTouchEvent(client, 'touchStart', [
 				{ x: cx - 50, y: cy, id: 0 },
@@ -585,7 +622,55 @@ for (const tool of TOOLS) {
 			await dispatchTouchEvent(client, 'touchEnd', []);
 			await client.detach();
 
-			expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+			if (tool.id === 'image-text') {
+				expect(
+					await getSelectedTextLayerBounds(page, tool.canvasTestId),
+				).toEqual(before);
+			} else {
+				expect(await countDiffFromFixture(page, tool.canvasTestId)).toBe(0);
+			}
+		});
+
+		test('1本指のタッチドラッグで範囲選択/レイヤー移動が機能する', async ({
+			page,
+		}) => {
+			await uploadFixture(page, tool.canvasTestId);
+			const client = await page.context().newCDPSession(page);
+			const canvas = page.getByTestId(tool.canvasTestId);
+
+			if (tool.id === 'image-mosaic') {
+				const canvasBox = await getCanvasBox(page, tool.canvasTestId);
+				const from = { x: canvasBox.x + 40, y: canvasBox.y + 40 };
+				const to = { x: canvasBox.x + 140, y: canvasBox.y + 100 };
+
+				await dispatchTouchEvent(client, 'touchStart', [{ ...from, id: 0 }]);
+				await dispatchTouchEvent(client, 'touchMove', [{ ...to, id: 0 }]);
+				await dispatchTouchEvent(client, 'touchEnd', []);
+				await client.detach();
+
+				await expect
+					.poll(() => countDiffFromFixture(page, tool.canvasTestId))
+					.toBeGreaterThan(0);
+			} else {
+				await page.getByRole('button', { name: 'テキストを追加' }).click();
+				await canvas.scrollIntoViewIfNeeded();
+				const before = await getSelectedTextLayerBounds(
+					page,
+					tool.canvasTestId,
+				);
+				// 追加直後のテキストレイヤー上（画像中央付近）から離れた位置へ動かす
+				const from = await imagePointToPage(canvas, 145, 135);
+				const to = await imagePointToPage(canvas, 250, 220);
+
+				await dispatchTouchEvent(client, 'touchStart', [{ ...from, id: 0 }]);
+				await dispatchTouchEvent(client, 'touchMove', [{ ...to, id: 0 }]);
+				await dispatchTouchEvent(client, 'touchEnd', []);
+				await client.detach();
+
+				await expect
+					.poll(() => getSelectedTextLayerBounds(page, tool.canvasTestId))
+					.not.toEqual(before);
+			}
 		});
 
 		test('片指離脱・3本目追加・指の入れ替わりの後も操作不能にならない', async ({

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -11,6 +11,7 @@ import {
 	getContainerBox,
 	getZoomGeometry,
 	imagePointFromClientPoint,
+	pinch,
 	type ZoomGeometry,
 	zoomAtClientPoint,
 } from './helpers/canvas';
@@ -442,6 +443,57 @@ for (const tool of TOOLS) {
 			expect(Math.abs(beforePoint.y - afterPoint.y)).toBeLessThanOrEqual(
 				tolerance,
 			);
+		});
+	});
+
+	test.describe(`${tool.id}: ピンチズーム・2本指パン`, () => {
+		test.beforeEach(async ({ page, createToolPage }, testInfo) => {
+			test.skip(
+				testInfo.project.name !== 'mobile-chrome',
+				'CDPタッチイベントはhasTouch:trueのmobile-chromeプロジェクトでのみ検証する',
+			);
+			const toolPage = createToolPage(tool.id);
+			await toolPage.goto();
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+		});
+
+		test('2本指ピンチで拡大でき、倍率表示が変化する', async ({ page }) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const percentLabel = page.getByTestId('zoom-percent-label');
+			const before = await percentLabel.textContent();
+			const containerBox = await getContainerBox(page);
+			const center = {
+				x: containerBox.x + containerBox.width / 2,
+				y: containerBox.y + containerBox.height / 2,
+			};
+
+			await pinch(page, { center, startDistance: 100, endDistance: 260 });
+
+			await expect.poll(() => percentLabel.textContent()).not.toBe(before);
+		});
+
+		test('2本指パンでスクロール位置が変化する', async ({ page }) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+			const before = await getZoomGeometry(page, tool.canvasTestId);
+			const containerBox = await getContainerBox(page);
+			const center = {
+				x: containerBox.x + containerBox.width / 2,
+				y: containerBox.y + containerBox.height / 2,
+			};
+
+			await pinch(page, {
+				center,
+				startDistance: 150,
+				endDistance: 150,
+				panDeltaX: -150,
+				panDeltaY: -100,
+			});
+
+			const after = await getZoomGeometry(page, tool.canvasTestId);
+			expect(after.scrollLeft).not.toEqual(before.scrollLeft);
+			expect(after.scrollTop).not.toEqual(before.scrollTop);
 		});
 	});
 }

--- a/tests/unit/gesture-controller.test.ts
+++ b/tests/unit/gesture-controller.test.ts
@@ -1,0 +1,197 @@
+// 実行方法: npm run test:unit
+// idle / drawing / two-finger-transform の状態遷移と、各遷移で発火する
+// GestureEffect（UI側フックへの通知イベント）を検証する。
+// DOM操作自体は E2E（Task 3.4以降）で検証する。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	createInitialGestureState,
+	reduceGestureEvent,
+} from '../../src/lib/tools/gesture-controller.ts';
+
+test('1本指down: drawingへ遷移しsingleDownが発火する', () => {
+	const s0 = createInitialGestureState();
+	const { state, effects } = reduceGestureEvent(s0, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	});
+	assert.equal(state.phase, 'drawing');
+	assert.deepEqual(effects, [{ type: 'singleDown' }]);
+});
+
+test('drawing中に2本目down: singleInterrupted→twoFingerStartの順で発火し two-finger-transform へ遷移する', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	const { state, effects } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 10, y: 0 },
+	});
+	assert.equal(state.phase, 'two-finger-transform');
+	assert.deepEqual(
+		effects.map((e) => e.type),
+		['singleInterrupted', 'twoFingerStart'],
+	);
+});
+
+test('idleでの2本指down（drawing経由でない）: singleInterruptedは発火せずtwoFingerStartのみ', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, { type: 'up', pointerId: 1 }));
+	const { effects } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 0, y: 0 },
+	});
+	assert.deepEqual(effects, [{ type: 'singleDown' }]);
+});
+
+test('two-finger-transform中の3本目down: 基準ペアは先頭2件のまま再初期化される', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 10, y: 0 },
+	}));
+	const { state, effects } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 3,
+		point: { x: 5, y: 5 },
+	});
+	assert.equal(state.phase, 'two-finger-transform');
+	assert.deepEqual(
+		effects.map((e) => e.type),
+		['twoFingerStart'],
+	);
+	const info = (
+		effects[0] as {
+			type: 'twoFingerStart';
+			info: { midpoint: { x: number; y: number } };
+		}
+	).info;
+	assert.deepEqual(info.midpoint, { x: 5, y: 0 });
+});
+
+test('two-finger-transform中に基準ペアの1本が離脱: 残った2点で再初期化される（指の入れ替わり）', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 10, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 3,
+		point: { x: 20, y: 0 },
+	}));
+	const { state, effects } = reduceGestureEvent(s, {
+		type: 'up',
+		pointerId: 1,
+	});
+	assert.equal(state.phase, 'two-finger-transform');
+	assert.deepEqual(
+		effects.map((e) => e.type),
+		['twoFingerStart'],
+	);
+	const info = (
+		effects[0] as {
+			type: 'twoFingerStart';
+			info: { midpoint: { x: number; y: number } };
+		}
+	).info;
+	assert.deepEqual(info.midpoint, { x: 15, y: 0 });
+});
+
+test('2本指から1本指へ: idleへ遷移し、残った指のmove/upはsingle系イベントを発火しない', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 10, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, { type: 'up', pointerId: 2 }));
+	assert.equal(s.phase, 'idle');
+	assert.equal(s.suppressedPointerId, 1);
+	const moveResult = reduceGestureEvent(s, {
+		type: 'move',
+		pointerId: 1,
+		point: { x: 1, y: 1 },
+	});
+	assert.deepEqual(moveResult.effects, []);
+	const upResult = reduceGestureEvent(moveResult.state, {
+		type: 'up',
+		pointerId: 1,
+	});
+	assert.deepEqual(upResult.effects, []);
+	assert.equal(upResult.state.suppressedPointerId, null);
+});
+
+test('pointerdownを経ていない純粋なホバー移動はsingleMoveとして転送される', () => {
+	const s0 = createInitialGestureState();
+	const { effects } = reduceGestureEvent(s0, {
+		type: 'move',
+		pointerId: 99,
+		point: { x: 5, y: 5 },
+	});
+	assert.deepEqual(effects, [{ type: 'singleMove' }]);
+});
+
+test('two-finger-transform中のmoveはtwoFingerMoveのみ発火しsingleMoveは発火しない', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 2,
+		point: { x: 10, y: 0 },
+	}));
+	const { effects } = reduceGestureEvent(s, {
+		type: 'move',
+		pointerId: 1,
+		point: { x: 2, y: 0 },
+	});
+	assert.equal(effects.length, 1);
+	assert.equal(effects[0].type, 'twoFingerMove');
+});
+
+test('pointercancelはpointerupと同じ後始末経路を通る（singleCancel発火）', () => {
+	let s = createInitialGestureState();
+	({ state: s } = reduceGestureEvent(s, {
+		type: 'down',
+		pointerId: 1,
+		point: { x: 0, y: 0 },
+	}));
+	const { state, effects } = reduceGestureEvent(s, {
+		type: 'cancel',
+		pointerId: 1,
+	});
+	assert.equal(state.phase, 'idle');
+	assert.deepEqual(effects, [{ type: 'singleCancel' }]);
+});

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -9,6 +9,7 @@ import {
 	computeFitScale,
 	computeWheelZoom,
 	computeZoomScrollPosition,
+	decideScaleApply,
 	formatZoomPercent,
 	isZoomInNoop,
 	isZoomOutNoop,
@@ -227,4 +228,20 @@ test('isZoomInNoop: 400%未満では有効', () => {
 	assert.equal(isZoomInNoop(2), false);
 	assert.equal(isZoomInNoop(MIN_ZOOM), false);
 	assert.equal(isZoomInNoop(0.05), false);
+});
+
+test('decideScaleApply: 十分離れた値は changed:true', () => {
+	assert.equal(decideScaleApply(1, 2).changed, true);
+});
+
+test('decideScaleApply: 同値は changed:false', () => {
+	assert.equal(decideScaleApply(1, 1).changed, false);
+});
+
+test('decideScaleApply: 浮動小数点誤差程度の差は changed:false とみなす', () => {
+	assert.equal(decideScaleApply(0.25, 0.25 + 1e-10).changed, false);
+});
+
+test('decideScaleApply: 1e-9をわずかに超える差は changed:true', () => {
+	assert.equal(decideScaleApply(1, 1 + 2e-9).changed, true);
 });

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -6,7 +6,9 @@ import { test } from 'node:test';
 import {
 	clampZoom,
 	computeContentOffset,
+	computeDistance,
 	computeFitScale,
+	computeMidpoint,
 	computeWheelZoom,
 	computeZoomScrollPosition,
 	decideScaleApply,
@@ -244,4 +246,15 @@ test('decideScaleApply: 浮動小数点誤差程度の差は changed:false と�
 
 test('decideScaleApply: 1e-9をわずかに超える差は changed:true', () => {
 	assert.equal(decideScaleApply(1, 1 + 2e-9).changed, true);
+});
+
+test('computeMidpoint: 2点の中点を返す', () => {
+	assert.deepEqual(computeMidpoint({ x: 0, y: 0 }, { x: 10, y: 20 }), {
+		x: 5,
+		y: 10,
+	});
+});
+
+test('computeDistance: 3-4-5の直角三角形で距離5を返す', () => {
+	assert.equal(computeDistance({ x: 0, y: 0 }, { x: 3, y: 4 }), 5);
 });

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -4,11 +4,13 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+	clampScrollPosition,
 	clampZoom,
 	computeContentOffset,
 	computeDistance,
 	computeFitScale,
 	computeMidpoint,
+	computePinchZoom,
 	computeWheelZoom,
 	computeZoomScrollPosition,
 	decideScaleApply,
@@ -257,4 +259,44 @@ test('computeMidpoint: 2点の中点を返す', () => {
 
 test('computeDistance: 3-4-5の直角三角形で距離5を返す', () => {
 	assert.equal(computeDistance({ x: 0, y: 0 }, { x: 3, y: 4 }), 5);
+});
+
+test('computePinchZoom: 距離が2倍になれば倍率も2倍になる（通常拡大）', () => {
+	assert.equal(computePinchZoom(1, 100, 200), 2);
+});
+
+test('computePinchZoom: 距離が半分になれば倍率も半分になる（通常縮小）', () => {
+	assert.equal(computePinchZoom(1, 100, 50), 0.5);
+});
+
+test('computePinchZoom: startDistanceが0以下ならstartScaleを維持する（開始距離0）', () => {
+	assert.equal(computePinchZoom(1, 0, 50), 1);
+	assert.equal(computePinchZoom(2, -5, 50), 2);
+});
+
+test('computePinchZoom: MAX_ZOOM到達後さらに拡大方向へ入力してもクランプされる', () => {
+	assert.equal(computePinchZoom(3.9, 100, 100000), MAX_ZOOM);
+});
+
+test('computePinchZoom: MIN_ZOOM到達後さらに縮小方向へ入力してもクランプされる', () => {
+	assert.equal(computePinchZoom(0.26, 100, 1), MIN_ZOOM);
+});
+
+test('computePinchZoom: 25%未満のフィット倍率からは25%未満を許容する', () => {
+	const next = computePinchZoom(0.18, 100, 90);
+	assert.ok(next < MIN_ZOOM, `${next} はクランプされず25%未満のはず`);
+});
+
+test('computePinchZoom: 指の入れ替わり（基準再初期化）後は新しいstartScale/startDistanceから再計算される', () => {
+	const afterFirstPinch = computePinchZoom(1, 100, 200); // 2.0
+	const afterSwap = computePinchZoom(afterFirstPinch, 50, 50); // 距離比1 → 2.0のまま
+	assert.equal(afterSwap, 2);
+	const afterSwapZoomIn = computePinchZoom(afterFirstPinch, 50, 150); // 2.0 * 3 = 6 → クランプ
+	assert.equal(afterSwapZoomIn, MAX_ZOOM);
+});
+
+test('clampScrollPosition: 範囲内はそのまま、範囲外は上下限にクランプする', () => {
+	assert.equal(clampScrollPosition(50, 100), 50);
+	assert.equal(clampScrollPosition(-10, 100), 0);
+	assert.equal(clampScrollPosition(150, 100), 100);
 });

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -300,3 +300,13 @@ test('clampScrollPosition: 範囲内はそのまま、範囲外は上下限に�
 	assert.equal(clampScrollPosition(-10, 100), 0);
 	assert.equal(clampScrollPosition(150, 100), 100);
 });
+
+test('computePinchZoom: 25%未満から拡大した後、同一ジェスチャー内で縮小しても開始倍率を下回らない', () => {
+	// 実機で再現した不具合: フィット18% → 56% → 3%
+	assert.equal(computePinchZoom(0.18, 100, 20), 0.18);
+});
+
+test('computePinchZoom: 25%未満からの拡大は従来どおり距離比に比例する', () => {
+	const next = computePinchZoom(0.18, 100, 300);
+	assert.ok(Math.abs(next - 0.54) < 1e-9);
+});


### PR DESCRIPTION
## 課題要約

`/image-mosaic` と `/image-text` は、PCではズーム＆パン機構（[PR #261](https://github.com/code-life-cafe/tools-codelife-cafe/pull/261)）が実装済みだが、タッチ入力を一切考慮していなかったため、スマホでは指でモザイク範囲・テキストレイヤーを操作できず実質的に操作不能だった。あわせて、同値ズーム時にスクロールアンカーが残留するバグ（C1）があり、ピンチ実装の前提としてまず修正した。本PRで、1本指ドラッグ＝範囲選択/レイヤードラッグ、2本指ドラッグ＝パン、2本指ピンチ＝ズームという、モード切替UI無しのジェスチャー体系を導入する。

## 設計判断

- **イベント所有権**: `setPointerCapture`/`releasePointerCapture` は `canvas` 要素自身が握る（コンテナ／ラッパーではない）。`useGestureController.ts` の `onPointerDown`/`endPointer` に一元化した。理由: 削除✕ボタン等の兄弟オーバーレイにキャプチャを奪われず、canvas外へ出た指のイベントも確実に配送されるため。
- **ジェスチャー解釈**: DOM/Reactに依存しない純粋なreducer（`src/lib/tools/gesture-controller.ts`）で `idle`/`drawing`/`two-finger-transform` の3状態を管理し、`useGestureController.ts` がReactのPointerEventに接続する薄いアダプタとして機能する。
- **倍率クランプ**: ピンチも既存のホイールズーム（`computeWheelZoom`）と同じ非対称クランプ方針を踏襲（`currentScale >= 0.25` は `[0.25, 4]` にクランプ、`< 0.25` は `0.01` まで緩和）。新規関数 `computePinchZoom` として追加、既存エクスポートのシグネチャは変更していない。
- **2本指パン**: 慣性スクロールは実装しない（割り切り）。`scrollLeft`/`scrollTop` を自前で直接更新する。
- **C1修正**: 全ズーム変更経路（ボタン×3・ホイール・ピンチ）を単一関数 `applyScale`/`applyPinchTransform` に集約。**設計変更点**: プラン当初の設計では同値時に `setMode` を呼ばない想定だったが、実装時にレビューで「fit倍率がちょうど100%等になる画像で `zoomTo100` ボタンが反応しなくなる」実際の不具合が見つかったため、同値時も `setMode` は呼びつつアンカーだけ確実に破棄する方式に修正した（タスクレビューで独立検証済み）。
- **モードレス化**: `MobilePanMode`／モバイル編集・パン切替UIを完全削除。

## 変更ファイル一覧

| ファイル | 変更意図 |
|---|---|
| `src/lib/tools/zoom-pan.ts` | ピンチ倍率算出 (`computePinchZoom`)、中点/距離計算、スクロールクランプ、同値判定 (`decideScaleApply`) を追加（既存エクスポートは無変更） |
| `src/lib/tools/gesture-controller.ts`（新規） | ポインタ操作を idle/drawing/two-finger-transform として管理する純粋reducer |
| `src/lib/hooks/useGestureController.ts`（新規） | reducerをReactのPointerEventに接続するアダプタ。イベント所有権を一元管理 |
| `src/lib/hooks/useZoomPan.ts` | `applyScale`（C1修正）・`applyPinchTransform`（ピンチ+パン）を追加。`MobilePanMode`/`mobileMode`を削除 |
| `src/components/common/ZoomableCanvasViewport.tsx` | モバイル編集/パン切替UIを削除。render-propの引数を `{ mobileMode }` から `{ scale, getContainerPoint, applyPinchTransform }` に変更 |
| `src/components/image-mosaic/CanvasEditor.tsx` | Gesture Controllerを配線。`isPanMode`分岐を撤去 |
| `src/components/image-text/TextCanvas.tsx` | 同上（レイヤードラッグ版）。加えて、pinch割り込み時に未確定のレイヤー移動をロールバックするしきい値判定を追加（最終レビューで発見・修正） |
| `tests/unit/zoom-pan.test.ts` | 新規純粋関数のテスト追加 |
| `tests/unit/gesture-controller.test.ts`（新規） | reducerの状態遷移テスト |
| `tests/e2e/helpers/canvas.ts` | CDP経由のタッチイベント発火ヘルパー（`dispatchTouchEvent`/`pinch`）を追加 |
| `tests/e2e/zoom-pan.spec.ts` | ピンチ/2本指パン/干渉シナリオ/後始末シナリオ/単指タッチドラッグのE2Eを追加 |
| `tests/e2e/image-mosaic.spec.ts` / `tests/e2e/image-text.spec.ts` | 廃止されたモバイル編集/パンモードのテストを削除、モード非依存の1テストを移設 |

## Notion設計書との既知の食い違い

- Notionの「影響範囲」表は「モード切替UIの削除」の担当ファイルを `MaskToolbar.tsx`/`ImageMosaicPage.tsx` としていたが、実際にモバイル切替UIが実装されていたのは `ZoomableCanvasViewport.tsx` であり、上記2ファイルにはモード切替の実装が存在しなかった。
- Notionが言及する「モードタブ／形状タブの高さ29px」はリポジトリ全体を検索しても存在しない（実測 `h-9`=36px）。P6（スコープ外）関連の記述であり本PRの実装には影響しない。

## 自動検証結果

- `npm run test:unit`: **903/903 pass**
- `npm run build`: 成功
- `npx playwright test`（全60ファイル×chromium/mobile-chrome）: **1023 passed, 26 skipped, 3 failed**（失敗3件はすべて `tests/e2e/sql-formatter.spec.ts` / `tests/e2e/wareki-converter.spec.ts` で、`git diff main...HEAD` で本ブランチが一切変更していないことを確認済み。本ブランチと無関係な既存の失敗）
- タッチ専用テスト（CDP `Input.dispatchTouchEvent` 使用）は `mobile-chrome` プロジェクトのみで実行され、`chromium` プロジェクトでは意図通りskipされることを確認
- `npm run check`（Astro型チェック＋Biome）: 0 errors（既存の無関係な警告のみ）
- `npm run lint`: 0 errors
- `grep -rn "MobilePanMode\|mobileMode" src/`: 0件

開発プロセス上、5コミットそれぞれに対して独立したタスクレビュー（spec適合性＋コード品質）を実施し、さらに全体を通した最終レビューも実施。最終レビューで見つかった3件のImportant指摘（TextCanvasでのpinch割り込み時のレイヤー位置未ロールバック、image-textでの干渉テスト2件が空振りしていた問題、単指タッチドラッグの成功を証明する陽性テストが無かった問題）は修正コミットで解消し、再レビューでApproved済み。

## ローカル確認手順

```bash
npm run dev
```

1. ブラウザで `http://localhost:4321/image-mosaic` を開く
2. Chrome DevTools のデバイスツールバーで「iPhone 13」相当（タッチ有効）に切り替える
3. 画像を読み込み、1本指ドラッグで矩形選択が引けること、2本指ピンチで拡大縮小できること、2本指ドラッグでパンできることを確認する
4. `http://localhost:4321/image-text` でも同様に、レイヤードラッグとピンチ/パンが競合しないことを確認する

## 要人間確認リスト（未実施・Claude Codeでは検証できていません）

- [ ] 実機 iOS Safari / Android Chrome での `touch-action` とアドレスバー伸縮時の挙動
- [ ] 2本指パンの操作感（慣性なし）が許容範囲か
- [ ] 1本指での範囲選択・レイヤードラッグが意図通りに引ける／誤爆しない（実機での触感）
- [ ] 画面回転時にスクロール位置が飛ばない
- [ ] `image-text` のテキストレイヤードラッグが実機でも壊れていない

## 残件・別issue化の提案（本PRのスコープ外）

- P3 初期倍率の見直し（フィット19%問題、`mode: 'fit' | number` 契約との整合要検討）
- P4 作成後の領域のリサイズ・移動
- P5 削除UIのタッチ対応（固定アクションバー化）
- P6 タップターゲット拡大（モバイルタブ高さ44px化）
- P7 モバイルレイアウトの再構成
- P8 `CropOverlay` ハンドルの描画/ヒット領域分離
- P9 `image-edit` へのズーム・パン適用
- 最終レビューで指摘されたMinor事項（今回は修正せず記録のみ）:
  - `useZoomPan.ts:41` / `ZoomableCanvasViewport.tsx:38` に残る「編集モードへ戻す」等の削除済みモードを指す古いコメント
  - `applyPinchTransform` の引数名 `focalClientX`/`focalClientY` が実際は「コンテナ相対座標」である点（誤解を招きうる命名）
  - `min-w-[100px]`（ズーム%ラベル）がプラン外の追加調整だった点（レイアウト崩れの実バグ修正として妥当と判断済み）
  - 削除されたモバイルパンモードE2Eが持っていた「ページ横スクロール抑止」の回帰ガードが、モードレス化後は同等の形で再現されていない
  - `CanvasEditor.tsx`/`TextCanvas.tsx` 間のピンチ処理ロジック（`zoomBridgeRef`等、約50行）がプラン指示により同一パターンで重複している。両者が全く同一になった今、`usePinchBridge` 等への共通化を検討する価値がある
