### PR TITLE
fix(clipboard): 共有URLコピー失敗時に成功トーストを表示しない（8箇所）

### DIFF
--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,6 +1,7 @@
-import { Check, Copy } from 'lucide-react';
+import { Check, Copy, X } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { copyText } from '@/lib/clipboard';
 
 interface CopyButtonProps {
 	text: string;
@@ -20,24 +21,18 @@ export default function CopyButton({
 	disabled = false,
 }: CopyButtonProps) {
 	const [copied, setCopied] = useState(false);
+	const [failed, setFailed] = useState(false);
 
 	const handleCopy = useCallback(async () => {
-		try {
-			await navigator.clipboard.writeText(text);
+		const ok = await copyText(text);
+		if (ok) {
+			setFailed(false);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
-		} catch {
-			// Fallback for older browsers
-			const textarea = document.createElement('textarea');
-			textarea.value = text;
-			textarea.style.position = 'fixed';
-			textarea.style.opacity = '0';
-			document.body.appendChild(textarea);
-			textarea.select();
-			document.execCommand('copy');
-			document.body.removeChild(textarea);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
+		} else {
+			setCopied(false);
+			setFailed(true);
+			setTimeout(() => setFailed(false), 2000);
 		}
 	}, [text]);
 
@@ -47,10 +42,17 @@ export default function CopyButton({
 			size={size}
 			onClick={handleCopy}
 			disabled={disabled}
-			className={`transition-all ${copied ? 'copy-flash text-safety border-safety/50' : ''} ${className}`}
-			aria-label={copied ? 'コピーしました' : label}
+			className={`transition-all ${copied ? 'copy-flash text-safety border-safety/50' : ''} ${failed ? 'text-destructive border-destructive/50' : ''} ${className}`}
+			aria-label={
+				failed ? 'コピーに失敗しました' : copied ? 'コピーしました' : label
+			}
 		>
-			{copied ? (
+			{failed ? (
+				<>
+					<X className="h-4 w-4" />
+					<span className="ml-1">コピー失敗</span>
+				</>
+			) : copied ? (
 				<>
 					<Check className="h-4 w-4" />
 					<span className="ml-1">コピー済み</span>

--- a/src/components/image-compress/ImageCompressPage.tsx
+++ b/src/components/image-compress/ImageCompressPage.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { copyText } from '@/lib/clipboard';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
@@ -65,6 +66,7 @@ export function ImageCompressPage() {
 		DEFAULT_UI_OPTIONS,
 	);
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 
 	const {
 		items,
@@ -111,11 +113,18 @@ export function ImageCompressPage() {
 		[options],
 	);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	const handleFilesSelect = useCallback(
@@ -235,10 +244,17 @@ export function ImageCompressPage() {
 							variant="outline"
 							onClick={handleShare}
 							disabled={processing}
+							className={
+								shareCopyFailed ? 'text-destructive border-destructive/50' : ''
+							}
 						>
 							<Share2 className="h-4 w-4" />
 							<span className="ml-1">
-								{shareCopied ? 'コピー完了！' : '設定を共有'}
+								{shareCopyFailed
+									? 'コピーに失敗しました'
+									: shareCopied
+										? 'コピー完了！'
+										: '設定を共有'}
 							</span>
 						</Button>
 						{doneCount >= 2 && (

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
+import { copyText } from '@/lib/clipboard';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
@@ -42,6 +43,7 @@ export function ImageConvertPage() {
 		DEFAULT_UI_OPTIONS,
 	);
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 	const [processedTarget, setProcessedTarget] = useState<TargetFormat>(
 		DEFAULT_UI_OPTIONS.target,
 	);
@@ -135,11 +137,18 @@ export function ImageConvertPage() {
 		[updateOptions, clearCompletion],
 	);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	const handleReconvert = useCallback(() => {
@@ -235,10 +244,17 @@ export function ImageConvertPage() {
 							variant="outline"
 							onClick={handleShare}
 							disabled={processing}
+							className={
+								shareCopyFailed ? 'text-destructive border-destructive/50' : ''
+							}
 						>
 							<Share2 className="h-4 w-4" />
 							<span className="ml-1">
-								{shareCopied ? 'コピー完了！' : '設定を共有'}
+								{shareCopyFailed
+									? 'コピーに失敗しました'
+									: shareCopied
+										? 'コピー完了！'
+										: '設定を共有'}
 							</span>
 						</Button>
 						{doneCount >= 2 && (

--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { copyText } from '@/lib/clipboard';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -68,6 +69,8 @@ export default function CsvEditor() {
 	const [activeTab, setActiveTab] = useState('input');
 	const [inputText, setInputText] = useState('');
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const [copyFailed, setCopyFailed] = useState(false);
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -164,11 +167,18 @@ export default function CsvEditor() {
 		setSortKeys([]);
 	}, []);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	// Parse CSV text input
@@ -330,11 +340,15 @@ export default function CsvEditor() {
 		URL.revokeObjectURL(url);
 	};
 
-	const handleCopy = () => {
+	const handleCopy = useCallback(async () => {
 		if (!csvData) return;
 		const result = exportCsv(csvData, delimiter);
-		navigator.clipboard.writeText(result);
-	};
+		const ok = await copyText(result);
+		setCopyFailed(!ok);
+		if (!ok) {
+			setTimeout(() => setCopyFailed(false), 2000);
+		}
+	}, [csvData, delimiter]);
 
 	// Editor Cell / Row Mutations
 	const updateCell = (
@@ -495,10 +509,16 @@ export default function CsvEditor() {
 							variant="outline"
 							size="sm"
 							onClick={handleShare}
-							className="h-8 flex items-center gap-1.5"
+							className={`h-8 flex items-center gap-1.5 ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 						>
 							<Share2 className="h-4 w-4" />
-							<span>{shareCopied ? 'コピー完了！' : '設定を共有'}</span>
+							<span>
+								{shareCopyFailed
+									? 'コピーに失敗しました'
+									: shareCopied
+										? 'コピー完了！'
+										: '設定を共有'}
+							</span>
 						</Button>
 					</div>
 				</div>
@@ -521,10 +541,12 @@ export default function CsvEditor() {
 								variant="outline"
 								size="sm"
 								onClick={handleCopy}
-								className="h-8 flex-1 sm:flex-none"
+								className={`h-8 flex-1 sm:flex-none ${copyFailed ? 'text-destructive border-destructive/50' : ''}`}
 							>
 								<Copy className="h-4 w-4 sm:mr-2" />
-								<span className="hidden sm:inline">コピー</span>
+								<span className="hidden sm:inline">
+									{copyFailed ? 'コピー失敗' : 'コピー'}
+								</span>
 							</Button>
 							<Button
 								variant="outline"

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -19,6 +19,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { copyText } from '@/lib/clipboard';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -70,6 +71,7 @@ export default function JsonFormatter() {
 	const [error, setError] = useState<string | null>(null);
 	const [errorPosition, setErrorPosition] = useState<number | null>(null);
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -175,11 +177,18 @@ export default function JsonFormatter() {
 		[indent],
 	);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	return (
@@ -233,10 +242,16 @@ export default function JsonFormatter() {
 					onClick={handleShare}
 					variant="outline"
 					size="sm"
-					className="ml-auto flex items-center gap-1.5"
+					className={`ml-auto flex items-center gap-1.5 ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 				>
 					<Share2 className="h-4 w-4" />
-					<span>{shareCopied ? 'コピー完了！' : '設定を共有'}</span>
+					<span>
+						{shareCopyFailed
+							? 'コピーに失敗しました'
+							: shareCopied
+								? 'コピー完了！'
+								: '設定を共有'}
+					</span>
 				</Button>
 			</div>
 

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -22,6 +22,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { copyText } from '@/lib/clipboard';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import type { RegexResult } from '@/lib/tools/regex-tester';
@@ -44,6 +45,7 @@ export default function RegexTester() {
 	const { pattern, flags, showReplace, replacement } = settings;
 	const [text, setText] = useState('郵便番号: 100-0001 と 530-0001');
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -130,11 +132,18 @@ export default function RegexTester() {
 		return nodes;
 	}, [text, result.matches, result.error, pattern]);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	return (
@@ -150,10 +159,16 @@ export default function RegexTester() {
 									onClick={handleShare}
 									variant="outline"
 									size="sm"
-									className="h-8 text-xs rounded-xl flex items-center gap-1.5"
+									className={`h-8 text-xs rounded-xl flex items-center gap-1.5 ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 								>
 									<Share2 className="h-3 w-3" />
-									<span>{shareCopied ? 'コピー完了！' : '設定を共有'}</span>
+									<span>
+										{shareCopyFailed
+											? 'コピーに失敗しました'
+											: shareCopied
+												? 'コピー完了！'
+												: '設定を共有'}
+									</span>
 								</Button>
 								<Select
 									onValueChange={(val) => {

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -24,6 +24,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { copyText } from '@/lib/clipboard';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -108,6 +109,7 @@ export default function SqlFormatter() {
 		[updateSettings],
 	);
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 
 	const [manualOutput, setManualOutput] = useState('');
 	const [manualError, setManualError] = useState<string | null>(null);
@@ -160,11 +162,18 @@ export default function SqlFormatter() {
 		}
 	}, [autoFormat]);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	const applyLayoutWidth = useCallback((expanded: boolean) => {
@@ -402,10 +411,14 @@ export default function SqlFormatter() {
 						variant="outline"
 						size="sm"
 						onClick={handleShare}
-						className="hidden sm:flex"
+						className={`hidden sm:flex ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 					>
 						<Share2 className="h-4 w-4 mr-2" />
-						{shareCopied ? 'コピー完了！' : '設定を共有'}
+						{shareCopyFailed
+							? 'コピーに失敗しました'
+							: shareCopied
+								? 'コピー完了！'
+								: '設定を共有'}
 					</Button>
 
 					<Button
@@ -431,10 +444,14 @@ export default function SqlFormatter() {
 					variant="outline"
 					size="sm"
 					onClick={handleShare}
-					className="w-full"
+					className={`w-full ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 				>
 					<Share2 className="h-4 w-4 mr-2" />
-					{shareCopied ? 'コピー完了！' : '設定を共有'}
+					{shareCopyFailed
+						? 'コピーに失敗しました'
+						: shareCopied
+							? 'コピー完了！'
+							: '設定を共有'}
 				</Button>
 			</div>
 

--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -27,6 +27,7 @@ import {
 	TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { copyText } from '@/lib/clipboard';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -107,6 +108,7 @@ export function TaxCalcPage() {
 		createInvoiceLine(2),
 	]);
 	const [shareCopied, setShareCopied] = useState(false);
+	const [shareCopyFailed, setShareCopyFailed] = useState(false);
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -116,11 +118,18 @@ export function TaxCalcPage() {
 		}
 	}, [trackSharedUrlOpen]);
 
-	const handleShare = useCallback(() => {
+	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		navigator.clipboard.writeText(shareUrl);
-		setShareCopied(true);
-		setTimeout(() => setShareCopied(false), 2000);
+		const ok = await copyText(shareUrl);
+		if (ok) {
+			setShareCopyFailed(false);
+			setShareCopied(true);
+			setTimeout(() => setShareCopied(false), 2000);
+		} else {
+			setShareCopied(false);
+			setShareCopyFailed(true);
+			setTimeout(() => setShareCopyFailed(false), 2000);
+		}
 	}, [generateShareUrl]);
 
 	// --- WebMCP Tool Registration ---
@@ -248,10 +257,16 @@ export function TaxCalcPage() {
 					onClick={handleShare}
 					variant="outline"
 					size="sm"
-					className="h-9 flex items-center gap-1.5 shrink-0"
+					className={`h-9 flex items-center gap-1.5 shrink-0 ${shareCopyFailed ? 'text-destructive border-destructive/50' : ''}`}
 				>
 					<Share2 className="h-4 w-4" />
-					<span>{shareCopied ? 'コピー完了！' : '設定を共有'}</span>
+					<span>
+						{shareCopyFailed
+							? 'コピーに失敗しました'
+							: shareCopied
+								? 'コピー完了！'
+								: '設定を共有'}
+					</span>
 				</Button>
 			</div>
 

--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -1,0 +1,40 @@
+/**
+ * クリップボードへのコピーを試み、成否を返す。
+ * Clipboard API が使えない場合（非セキュアコンテキストなど）や書き込みに失敗した場合は
+ * `document.execCommand('copy')` にフォールバックし、その戻り値をそのまま返す。
+ */
+export async function copyText(text: string): Promise<boolean> {
+	const clipboard =
+		typeof navigator !== 'undefined' ? navigator.clipboard : undefined;
+
+	if (clipboard?.writeText) {
+		try {
+			await clipboard.writeText(text);
+			return true;
+		} catch {
+			// フォールバックへ
+		}
+	}
+
+	return copyTextViaExecCommand(text);
+}
+
+function copyTextViaExecCommand(text: string): boolean {
+	if (typeof document === 'undefined') return false;
+
+	const textarea = document.createElement('textarea');
+	textarea.value = text;
+	textarea.style.position = 'fixed';
+	textarea.style.opacity = '0';
+	document.body.appendChild(textarea);
+	textarea.select();
+
+	let succeeded = false;
+	try {
+		succeeded = document.execCommand('copy');
+	} catch {
+		succeeded = false;
+	}
+	document.body.removeChild(textarea);
+	return succeeded;
+}

--- a/tests/unit/clipboard.test.ts
+++ b/tests/unit/clipboard.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+import { copyText } from '../../src/lib/clipboard.ts';
+
+function stubNavigator(clipboard: unknown) {
+	Object.defineProperty(globalThis, 'navigator', {
+		value: clipboard === undefined ? {} : { clipboard },
+		configurable: true,
+	});
+}
+
+function stubDocument(execCommandResult: boolean | 'throw') {
+	const style: Record<string, string> = {};
+	const textarea = {
+		value: '',
+		style,
+		select: () => {},
+	};
+	const body = {
+		appendChild: () => {},
+		removeChild: () => {},
+	};
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			createElement: () => textarea,
+			body,
+			execCommand: () => {
+				if (execCommandResult === 'throw') {
+					throw new Error('execCommand not supported');
+				}
+				return execCommandResult;
+			},
+		},
+		configurable: true,
+	});
+}
+
+function clearDocument() {
+	Object.defineProperty(globalThis, 'document', {
+		value: undefined,
+		configurable: true,
+	});
+}
+
+afterEach(() => {
+	stubNavigator(undefined);
+	clearDocument();
+});
+
+test('Clipboard API が成功すれば true を返す', async () => {
+	stubNavigator({ writeText: async () => {} });
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+});
+
+test('Clipboard API が拒否されたら execCommand フォールバックの結果を返す（成功）', async () => {
+	stubNavigator({
+		writeText: async () => {
+			throw new Error('permission denied');
+		},
+	});
+	stubDocument(true);
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+});
+
+test('Clipboard API が拒否されたら execCommand フォールバックの結果を返す（失敗）', async () => {
+	stubNavigator({
+		writeText: async () => {
+			throw new Error('permission denied');
+		},
+	});
+	stubDocument(false);
+	const ok = await copyText('hello');
+	assert.equal(ok, false);
+});
+
+test('非セキュアコンテキストなど navigator.clipboard が存在しない場合は例外を投げず execCommand にフォールバックする', async () => {
+	stubNavigator(undefined);
+	stubDocument(true);
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+});
+
+test('execCommand が例外を投げても false を返し呼び出し元に伝播しない', async () => {
+	stubNavigator(undefined);
+	stubDocument('throw');
+	const ok = await copyText('hello');
+	assert.equal(ok, false);
+});
+
+test('document が存在しない環境では false を返す', async () => {
+	stubNavigator(undefined);
+	clearDocument();
+	const ok = await copyText('hello');
+	assert.equal(ok, false);
+});


### PR DESCRIPTION
taskId: `3acdfd3603368182bb29fd35325e5fea`
実行ID: `triage-impl-20260731-0818`

## Summary
- `navigator.clipboard.writeText()` を await/catch なしで呼んでいた8箇所で、書き込みに失敗しても常に成功トーストが表示されていた不具合を修正
- 共通ヘルパー `src/lib/clipboard.ts` の `copyText(text): Promise<boolean>` を新設。Clipboard API を試行し、非セキュアコンテキスト（`navigator.clipboard` が `undefined`）や書き込み失敗時は `document.execCommand('copy')` にフォールバックし、実際の成否を返す
- 対象8箇所（`JsonFormatter` / `SqlFormatter` / `RegexTester` / `CsvEditor` ×2 / `TaxCalcPage` / `ImageCompressPage` / `ImageConvertPage`）を `await copyText()` 経由に統一し、失敗時は「コピーに失敗しました」等の失敗フィードバックを表示するよう変更
- `CopyButton`（正実装として参照されていたコンポーネント）も `copyText` を使うよう統一し、`execCommand('copy')` の戻り値を検査せず成功扱いしていた点を修正

## 受け入れ基準への対応状況
1. ✅ クリップボード書き込み失敗時に成功トーストが表示されず、失敗を示すフィードバックが出る（各箇所で「コピーに失敗しました」/「コピー失敗」表示に変更）
2. ✅ 該当8箇所すべてが共通のコピー処理（`copyText`）経由に統一されている
3. ✅ 成功時・失敗時の双方を検証する単体テストを追加（`tests/unit/clipboard.test.ts`、Clipboard API 成功・拒否時のフォールバック成功/失敗・非セキュアコンテキスト・`execCommand` 例外・`document` 不在の各ケース）
4. ✅ lint / test / build が成功する

## 検証
- `npm run test:unit` — 917 pass / 0 fail
- `npm run check`（astro check + biome）— 0 errors（既存の警告のみ、本PRの変更由来ではない）
- `npm run build` — 成功

## スコープ外
- `CronChecker.tsx` の共有URLコピーは受け入れ基準の対象8箇所に含まれないため変更していません（try/catchのみで元々フォールバックなしの3実装の1つとして本タスクの本文に言及されていますが、修正対象表には含まれていません）


---
_Generated by [Claude Code](https://claude.ai/code/session_01DFFhpnmiCQU4GWR3PMjoQw)_