### PR TITLE
chore: .npmrc から非標準の min-release-age 設定を削除

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-min-release-age=3


### PR DESCRIPTION
## 概要
- `.npmrc` の `min-release-age=3` は npm では非標準設定で、`npm install` のたびに `npm warn Unknown project config` が表示されていた（npm 10+ で廃止予定）
- 該当設定行を削除（機能低下なし、代替手段の導入・検討は本PRのスコープ外）

## 変更内容
- `.npmrc`: `min-release-age=3` の行のみ削除（他の設定行は元々存在せず、他ファイルへの変更なし）

## 検証結果
- [x] `.npmrc` から `min-release-age` 関連設定が削除されている（`git diff` で1行削除のみを確認）
- [x] `npm install` 成功（`Unknown project config` 警告が出ないことを確認、609 packages installed, 0 vulnerabilities）
- [x] `npm run lint` 成功（exit 0, 既存の14件の警告のみで本変更と無関係）
- [x] `npm run test:unit` 成功（917/917 tests pass）
- [x] `npm run build` 成功（101 pages built, sw.js / OG画像生成含め正常完了）
- [x] `.npmrc` の他設定行に差分なし（ファイルはこの1行のみで構成されていたため削除後は空ファイル）

補足: タスクの受け入れ基準では `pnpm install` と記載されていましたが、本リポジトリは `package-lock.json` を用いた npm ベースの構成（`packageManager` フィールドなし、CLAUDE.mdのコマンドもすべて npm）のため、`npm install` で検証しました。

---

Notion タスク: https://app.notion.com/p/391dfd36033681898df0ee1c35514db9

🤖 Generated with [Claude Code](https://claude.ai/code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LZ6xMCN4SuBksTNCxAyacL)_