### PR TITLE
fix(clipboard): iOS Safari 向け execCommand フォールバックとフォーカス復元

### DIFF
--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -22,12 +22,19 @@ export async function copyText(text: string): Promise<boolean> {
 function copyTextViaExecCommand(text: string): boolean {
 	if (typeof document === 'undefined') return false;
 
+	const activeElement = document.activeElement as HTMLElement | null;
+
 	const textarea = document.createElement('textarea');
 	textarea.value = text;
+	textarea.setAttribute('readonly', '');
 	textarea.style.position = 'fixed';
+	textarea.style.top = '0';
+	textarea.style.left = '0';
 	textarea.style.opacity = '0';
 	document.body.appendChild(textarea);
 	textarea.select();
+	// iOS Safari では select() のみだと選択範囲が確定せず execCommand('copy') が失敗するため明示的に設定する
+	textarea.setSelectionRange(0, text.length);
 
 	let succeeded = false;
 	try {
@@ -36,5 +43,6 @@ function copyTextViaExecCommand(text: string): boolean {
 		succeeded = false;
 	}
 	document.body.removeChild(textarea);
+	activeElement?.focus?.();
 	return succeeded;
 }

--- a/tests/unit/clipboard.test.ts
+++ b/tests/unit/clipboard.test.ts
@@ -9,12 +9,24 @@ function stubNavigator(clipboard: unknown) {
 	});
 }
 
-function stubDocument(execCommandResult: boolean | 'throw') {
+function stubDocument(
+	execCommandResult: boolean | 'throw',
+	options: { activeElement?: { focus: () => void } } = {},
+) {
 	const style: Record<string, string> = {};
+	const attributes: Record<string, string> = {};
+	const selectionRangeCalls: Array<[number, number]> = [];
 	const textarea = {
 		value: '',
 		style,
 		select: () => {},
+		setAttribute: (name: string, value: string) => {
+			attributes[name] = value;
+		},
+		setSelectionRange: (start: number, end: number) => {
+			selectionRangeCalls.push([start, end]);
+		},
+		getAttribute: (name: string) => attributes[name],
 	};
 	const body = {
 		appendChild: () => {},
@@ -24,6 +36,7 @@ function stubDocument(execCommandResult: boolean | 'throw') {
 		value: {
 			createElement: () => textarea,
 			body,
+			activeElement: options.activeElement ?? null,
 			execCommand: () => {
 				if (execCommandResult === 'throw') {
 					throw new Error('execCommand not supported');
@@ -33,6 +46,7 @@ function stubDocument(execCommandResult: boolean | 'throw') {
 		},
 		configurable: true,
 	});
+	return { textarea, attributes, selectionRangeCalls };
 }
 
 function clearDocument() {
@@ -94,4 +108,44 @@ test('document が存在しない環境では false を返す', async () => {
 	clearDocument();
 	const ok = await copyText('hello');
 	assert.equal(ok, false);
+});
+
+test('iOS Safari 対策として readonly 属性と setSelectionRange による選択範囲確定を行う', async () => {
+	stubNavigator(undefined);
+	const { textarea, attributes, selectionRangeCalls } = stubDocument(true);
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+	assert.equal(attributes.readonly, '');
+	assert.deepEqual(selectionRangeCalls, [[0, 'hello'.length]]);
+	assert.equal(textarea.style.top, '0');
+	assert.equal(textarea.style.left, '0');
+	assert.equal(textarea.style.position, 'fixed');
+});
+
+test('コピー後に元の activeElement へフォーカスを復元する', async () => {
+	stubNavigator(undefined);
+	let focusCalled = false;
+	const activeElement = {
+		focus: () => {
+			focusCalled = true;
+		},
+	};
+	stubDocument(true, { activeElement });
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+	assert.equal(focusCalled, true);
+});
+
+test('execCommand が失敗してもフォーカス復元は行われる', async () => {
+	stubNavigator(undefined);
+	let focusCalled = false;
+	const activeElement = {
+		focus: () => {
+			focusCalled = true;
+		},
+	};
+	stubDocument(false, { activeElement });
+	const ok = await copyText('hello');
+	assert.equal(ok, false);
+	assert.equal(focusCalled, true);
 });


### PR DESCRIPTION
## 概要

PR #272 のレビュー指摘（🟡 Warning 3）への追従タスク。
`src/lib/clipboard.ts` の `copyTextViaExecCommand` は `textarea.select()` のみで選択範囲を作っており、iOS Safari では選択範囲が確定せず `document.execCommand('copy')` が失敗していた。あわせて `select()` によるフォーカス奪取後、`removeChild` 後に元の要素へフォーカスを戻していなかった。

## 変更内容

- `readonly` 属性の付与と `setSelectionRange(0, text.length)` による選択範囲の明示的な確定（iOS Safari 対策）
- `textarea` を `position: fixed` / `top: 0` / `left: 0` に配置し、スクロール位置が飛ばないようにする
- コピー処理後、元の `document.activeElement` へフォーカスを復元する
- `tests/unit/clipboard.test.ts` に上記を検証する単体テストを追加（`stubDocument` のテキストエリアスタブを `setAttribute` / `setSelectionRange` / `activeElement` 対応に拡張）

## 受け入れ基準チェック

- [x] `copyTextViaExecCommand` で readonly 属性付与・`setSelectionRange` による選択範囲確定
- [x] `textarea` を `position:fixed` / `top:0` / `left:0` に配置
- [x] コピー後に元の `activeElement` へフォーカスを復元
- [x] 検証用の単体テストを `tests/unit/clipboard.test.ts` に追加
- [x] 既存6ケースを含む `clipboard.test.ts` は全9件パス。`npm run lint` / `npm run check` / `npm run build` は成功（`npm run test:unit` は本変更と無関係な26件の既存失敗が残るが、変更前後で失敗件数は同一であることを確認済み）

## 参考

- タスク: https://app.notion.com/p/138726f862d44cbfa6c011b9ba9b90bd
- 元PR: #272

---
_Generated by [Claude Code](https://claude.ai/code/session_011vUkTJNjaqjunZf9hPF9G2)_