### PR TITLE
fix(clipboard): iOS Safari で execCommand フォールバックが機能しない不具合を修正

### DIFF
--- a/src/lib/clipboard.ts
+++ b/src/lib/clipboard.ts
@@ -22,12 +22,17 @@ export async function copyText(text: string): Promise<boolean> {
 function copyTextViaExecCommand(text: string): boolean {
 	if (typeof document === 'undefined') return false;
 
+	const activeElement = document.activeElement as HTMLElement | null;
 	const textarea = document.createElement('textarea');
 	textarea.value = text;
+	textarea.setAttribute('readonly', '');
 	textarea.style.position = 'fixed';
+	textarea.style.top = '0';
+	textarea.style.left = '0';
 	textarea.style.opacity = '0';
 	document.body.appendChild(textarea);
 	textarea.select();
+	textarea.setSelectionRange(0, text.length); // iOS Safari では select() のみだと選択範囲が確定しない
 
 	let succeeded = false;
 	try {
@@ -36,5 +41,6 @@ function copyTextViaExecCommand(text: string): boolean {
 		succeeded = false;
 	}
 	document.body.removeChild(textarea);
+	activeElement?.focus?.();
 	return succeeded;
 }

--- a/tests/unit/clipboard.test.ts
+++ b/tests/unit/clipboard.test.ts
@@ -9,12 +9,23 @@ function stubNavigator(clipboard: unknown) {
 	});
 }
 
-function stubDocument(execCommandResult: boolean | 'throw') {
+function stubDocument(
+	execCommandResult: boolean | 'throw',
+	options: { activeElement?: { focus: () => void } } = {},
+) {
 	const style: Record<string, string> = {};
+	const attributes: Record<string, string> = {};
+	const selectionRangeCalls: Array<[number, number]> = [];
 	const textarea = {
 		value: '',
 		style,
 		select: () => {},
+		setAttribute: (name: string, value: string) => {
+			attributes[name] = value;
+		},
+		setSelectionRange: (start: number, end: number) => {
+			selectionRangeCalls.push([start, end]);
+		},
 	};
 	const body = {
 		appendChild: () => {},
@@ -24,6 +35,7 @@ function stubDocument(execCommandResult: boolean | 'throw') {
 		value: {
 			createElement: () => textarea,
 			body,
+			activeElement: options.activeElement ?? null,
 			execCommand: () => {
 				if (execCommandResult === 'throw') {
 					throw new Error('execCommand not supported');
@@ -33,6 +45,7 @@ function stubDocument(execCommandResult: boolean | 'throw') {
 		},
 		configurable: true,
 	});
+	return { textarea, attributes, selectionRangeCalls };
 }
 
 function clearDocument() {
@@ -94,4 +107,50 @@ test('document が存在しない環境では false を返す', async () => {
 	clearDocument();
 	const ok = await copyText('hello');
 	assert.equal(ok, false);
+});
+
+test('execCommand フォールバックは readonly 属性と setSelectionRange で選択範囲を確定する（iOS Safari 対策）', async () => {
+	stubNavigator(undefined);
+	const { textarea, attributes, selectionRangeCalls } = stubDocument(true);
+	textarea.value = 'hello';
+	const ok = await copyText('hello');
+	assert.equal(ok, true);
+	assert.equal(attributes.readonly, '');
+	assert.deepEqual(selectionRangeCalls, [[0, 5]]);
+});
+
+test('execCommand フォールバックの textarea は position:fixed かつ top/left:0 に配置されスクロール位置が飛ばない', async () => {
+	stubNavigator(undefined);
+	const { textarea } = stubDocument(true);
+	await copyText('hello');
+	assert.equal(textarea.style.position, 'fixed');
+	assert.equal(textarea.style.top, '0');
+	assert.equal(textarea.style.left, '0');
+});
+
+test('execCommand フォールバック後、コピー前の activeElement へフォーカスを復元する', async () => {
+	stubNavigator(undefined);
+	let focusCalled = false;
+	const previouslyFocused = {
+		focus: () => {
+			focusCalled = true;
+		},
+	};
+	stubDocument(true, { activeElement: previouslyFocused });
+	await copyText('hello');
+	assert.equal(focusCalled, true);
+});
+
+test('execCommand フォールバック失敗時も元の activeElement へフォーカスを復元する', async () => {
+	stubNavigator(undefined);
+	let focusCalled = false;
+	const previouslyFocused = {
+		focus: () => {
+			focusCalled = true;
+		},
+	};
+	stubDocument(false, { activeElement: previouslyFocused });
+	const ok = await copyText('hello');
+	assert.equal(ok, false);
+	assert.equal(focusCalled, true);
 });


### PR DESCRIPTION
## 概要

PR #272 のレビュー指摘（🟡 Warning 3）の追従タスク。`src/lib/clipboard.ts` の `copyTextViaExecCommand` は `textarea.select()` のみで選択範囲を作っており、iOS Safari では選択範囲が確定せず `document.execCommand('copy')` が失敗していた（非セキュアコンテキストでのフォールバックが片肺）。加えて `select()` がフォーカスを奪ったまま元の要素に戻しておらず、`position: fixed` の座標指定もないためスクロール位置が飛び得る状態だった。

Notionタスク: https://app.notion.com/p/138726f862d44cbfa6c011b9ba9b90bd

## 変更内容

- `textarea` に `readonly` 属性を付与し、`select()` に加えて `setSelectionRange(0, text.length)` で選択範囲を確定（iOS Safari 対策）
- `textarea.style.top / left` を `'0'` に設定し、`position: fixed` と合わせてスクロール位置が飛ばないようにした
- コピー処理前の `document.activeElement` を保持し、`execCommand('copy')` の成否に関わらずコピー後に元の要素へフォーカスを復元
- `tests/unit/clipboard.test.ts` に readonly 属性・setSelectionRange・fixed 配置・フォーカス復元（成功時／失敗時）を検証する単体テストを追加。既存スタブ (`stubDocument`) に `setAttribute` / `setSelectionRange` / `activeElement` 差し替えを追加

## 受け入れ基準チェック

- [x] `copyTextViaExecCommand` で readonly 属性付与・`setSelectionRange` による選択範囲確定
- [x] textarea を `position:fixed` / `top:0` / `left:0` に配置
- [x] コピー後に元の `activeElement` へフォーカスを復元
- [x] 検証する単体テストを `tests/unit/clipboard.test.ts` に追加
- [x] 既存ケースを含む全単体テストがパス、lint / test:unit / build が成功

## テスト

- `npm run lint` — pass（既存の無関係な警告14件のみ、エラーなし）
- `node --test tests/unit/clipboard.test.ts` — 10/10 pass
- `npm run test:unit` — 921/921 pass
- `npm run build` — success

スコープ外の変更は行っていません。

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01X9cQv5aAB1yRNmGVY3jGYR)_