### PR TITLE
refactor(clipboard): unify copy feedback into useCopyFeedback hook

### DIFF
--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,7 +1,7 @@
 import { Check, Copy, X } from 'lucide-react';
-import { useCallback, useState } from 'react';
+import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 
 interface CopyButtonProps {
 	text: string;
@@ -20,21 +20,13 @@ export default function CopyButton({
 	className = '',
 	disabled = false,
 }: CopyButtonProps) {
-	const [copied, setCopied] = useState(false);
-	const [failed, setFailed] = useState(false);
+	const { state, copy } = useCopyFeedback();
+	const copied = state === 'copied';
+	const failed = state === 'failed';
 
-	const handleCopy = useCallback(async () => {
-		const ok = await copyText(text);
-		if (ok) {
-			setFailed(false);
-			setCopied(true);
-			setTimeout(() => setCopied(false), 2000);
-		} else {
-			setCopied(false);
-			setFailed(true);
-			setTimeout(() => setFailed(false), 2000);
-		}
-	}, [text]);
+	const handleCopy = useCallback(() => {
+		void copy(text);
+	}, [copy, text]);
 
 	return (
 		<Button

--- a/src/components/common/CopyButton.tsx
+++ b/src/components/common/CopyButton.tsx
@@ -1,7 +1,7 @@
 import { Check, Copy, X } from 'lucide-react';
 import { useCallback } from 'react';
 import { Button } from '@/components/ui/button';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
 interface CopyButtonProps {
 	text: string;

--- a/src/components/image-compress/ImageCompressPage.tsx
+++ b/src/components/image-compress/ImageCompressPage.tsx
@@ -10,7 +10,6 @@ import { useCallback, useEffect } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -24,6 +23,7 @@ import {
 	validateImageFile,
 } from '@/lib/tools/image-compress';
 import { buildZip, dedupeZipNames } from '@/lib/tools/zip';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import {
 	CompressOptionsPanel,
 	type CompressUiOptions,

--- a/src/components/image-compress/ImageCompressPage.tsx
+++ b/src/components/image-compress/ImageCompressPage.tsx
@@ -6,11 +6,11 @@ import {
 	Share2,
 	Trash2,
 } from 'lucide-react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
-import { copyText } from '@/lib/clipboard';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -65,8 +65,9 @@ export function ImageCompressPage() {
 		'image-compress',
 		DEFAULT_UI_OPTIONS,
 	);
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 
 	const {
 		items,
@@ -115,17 +116,8 @@ export function ImageCompressPage() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	const handleFilesSelect = useCallback(
 		(files: File[]) => {

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -12,8 +12,8 @@ import {
 import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
-import { copyText } from '@/lib/clipboard';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -42,8 +42,9 @@ export function ImageConvertPage() {
 		'image-convert',
 		DEFAULT_UI_OPTIONS,
 	);
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 	const [processedTarget, setProcessedTarget] = useState<TargetFormat>(
 		DEFAULT_UI_OPTIONS.target,
 	);
@@ -139,17 +140,8 @@ export function ImageConvertPage() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	const handleReconvert = useCallback(() => {
 		setProcessedTarget(options.target);

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -13,7 +13,6 @@ import { useCallback, useEffect, useState } from 'react';
 import { FileDropzone } from '@/components/common/FileDropzone';
 import { Button } from '@/components/ui/button';
 import { useBatchProcessing } from '@/lib/hooks/useBatchProcessing';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
@@ -25,6 +24,7 @@ import {
 	validateImageFile,
 } from '@/lib/tools/image-convert';
 import { buildZip, dedupeZipNames } from '@/lib/tools/zip';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import {
 	ConvertOptionsPanel,
 	type ConvertUiOptions,

--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -68,9 +68,11 @@ export default function CsvEditor() {
 	const { delimiter, hasHeader } = settings;
 	const [activeTab, setActiveTab] = useState('input');
 	const [inputText, setInputText] = useState('');
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
-	const [copyFailed, setCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
+	const { state: resultCopyState, copy: copyResult } = useCopyFeedback();
+	const copyFailed = resultCopyState === 'failed';
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -169,17 +171,8 @@ export default function CsvEditor() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	// Parse CSV text input
 	const handleParse = () => {
@@ -340,15 +333,15 @@ export default function CsvEditor() {
 		URL.revokeObjectURL(url);
 	};
 
+	const csvResultText = useMemo(
+		() => (csvData ? exportCsv(csvData, delimiter) : null),
+		[csvData, delimiter],
+	);
+
 	const handleCopy = useCallback(async () => {
-		if (!csvData) return;
-		const result = exportCsv(csvData, delimiter);
-		const ok = await copyText(result);
-		setCopyFailed(!ok);
-		if (!ok) {
-			setTimeout(() => setCopyFailed(false), 2000);
-		}
-	}, [csvData, delimiter]);
+		if (csvResultText === null) return;
+		await copyResult(csvResultText);
+	}, [csvResultText, copyResult]);
 
 	// Editor Cell / Row Mutations
 	const updateCell = (

--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -30,7 +30,6 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -51,6 +50,7 @@ import {
 	parseXlsx,
 	type SheetData,
 } from '@/lib/tools/xlsx-reader';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
 const ROWS_PER_PAGE = 50;
 

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -19,7 +19,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -70,8 +70,9 @@ export default function JsonFormatter() {
 	const [output, setOutput] = useState('');
 	const [error, setError] = useState<string | null>(null);
 	const [errorPosition, setErrorPosition] = useState<number | null>(null);
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -179,17 +180,8 @@ export default function JsonFormatter() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	return (
 		<div className="space-y-6">

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -19,7 +19,6 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -27,6 +26,7 @@ import {
 	type IndentType,
 	minifyJson,
 } from '@/lib/tools/json-formatter';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
 function highlightJson(json: string) {
 	if (!json) return '';

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -22,11 +22,11 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import type { RegexResult } from '@/lib/tools/regex-tester';
 import { COMMON_PATTERNS, testRegex } from '@/lib/tools/regex-tester';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
 export default function RegexTester() {
 	const { trackRunDebounced, trackSharedUrlOpen } =

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -22,7 +22,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import type { RegexResult } from '@/lib/tools/regex-tester';
@@ -44,8 +44,9 @@ export default function RegexTester() {
 
 	const { pattern, flags, showReplace, replacement } = settings;
 	const [text, setText] = useState('郵便番号: 100-0001 と 530-0001');
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -134,17 +135,8 @@ export default function RegexTester() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	return (
 		<div className="space-y-8">

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -24,7 +24,7 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -108,8 +108,9 @@ export default function SqlFormatter() {
 		},
 		[updateSettings],
 	);
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 
 	const [manualOutput, setManualOutput] = useState('');
 	const [manualError, setManualError] = useState<string | null>(null);
@@ -164,17 +165,8 @@ export default function SqlFormatter() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	const applyLayoutWidth = useCallback((expanded: boolean) => {
 		const container = document.getElementById('tool-layout-container');

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -24,7 +24,6 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -33,6 +32,7 @@ import {
 	type SqlDialect,
 	type SqlFormatOptions,
 } from '@/lib/tools/sql-formatter';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import { cn } from '@/lib/utils';
 
 const SQL_KEYWORDS = [

--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -27,7 +27,6 @@ import {
 	TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -40,6 +39,7 @@ import {
 	validateAmount,
 	validateQuantity,
 } from '@/lib/tools/tax';
+import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import { provideToolsFromFactory } from '@/lib/webmcp';
 import { taxTool } from '@/lib/webmcp/tools/tax.webmcp';
 

--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -27,7 +27,7 @@ import {
 	TableRow,
 } from '@/components/ui/table';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { copyText } from '@/lib/clipboard';
+import { useCopyFeedback } from '@/lib/hooks/useCopyFeedback';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -107,8 +107,9 @@ export function TaxCalcPage() {
 		createInvoiceLine(1),
 		createInvoiceLine(2),
 	]);
-	const [shareCopied, setShareCopied] = useState(false);
-	const [shareCopyFailed, setShareCopyFailed] = useState(false);
+	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
+	const shareCopied = shareState === 'copied';
+	const shareCopyFailed = shareState === 'failed';
 
 	// 共有URLからアクセスされた場合の計測
 	useEffect(() => {
@@ -120,17 +121,8 @@ export function TaxCalcPage() {
 
 	const handleShare = useCallback(async () => {
 		const shareUrl = generateShareUrl();
-		const ok = await copyText(shareUrl);
-		if (ok) {
-			setShareCopyFailed(false);
-			setShareCopied(true);
-			setTimeout(() => setShareCopied(false), 2000);
-		} else {
-			setShareCopied(false);
-			setShareCopyFailed(true);
-			setTimeout(() => setShareCopyFailed(false), 2000);
-		}
-	}, [generateShareUrl]);
+		await copyShareUrl(shareUrl);
+	}, [generateShareUrl, copyShareUrl]);
 
 	// --- WebMCP Tool Registration ---
 	useEffect(() => {

--- a/src/lib/hooks/useCopyFeedback.ts
+++ b/src/lib/hooks/useCopyFeedback.ts
@@ -1,0 +1,66 @@
+// useCopyFeedback — コピー成否フィードバック表示の共通フック
+// CopyButton や各ツールの「設定を共有」「結果コピー」ボタンで重複していた
+// copied/failed の2状態 + リセット用 setTimeout をここへ統合する。
+// タイマー管理（scheduleReset/cancelReset）は React に依存しない純粋関数として切り出しており、
+// useToolAnalytics の trackRunDebounced と同様に DOM無しで単体テストできる。
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { copyText } from '../clipboard.ts';
+
+export type CopyFeedbackState = 'idle' | 'copied' | 'failed';
+
+/** リセットタイマーの保持先（React非依存・単体テスト対象） */
+export type ResetHandle = { current: ReturnType<typeof setTimeout> | null };
+
+/**
+ * handle に保留中のタイマーがあれば解除してから、delayMs 後に fn を1回だけ実行するよう
+ * 再スケジュールする。連打時に古いタイマーが新しい表示を早期に消してしまわないよう、
+ * 呼び出しごとに必ず前回のタイマーを解除してから積み直す。
+ */
+export function scheduleReset(
+	handle: ResetHandle,
+	fn: () => void,
+	delayMs: number,
+): void {
+	if (handle.current !== null) {
+		clearTimeout(handle.current);
+	}
+	handle.current = setTimeout(() => {
+		handle.current = null;
+		fn();
+	}, delayMs);
+}
+
+/** handle に保留中のタイマーがあれば解除する（アンマウント時のクリーンアップ用） */
+export function cancelReset(handle: ResetHandle): void {
+	if (handle.current !== null) {
+		clearTimeout(handle.current);
+		handle.current = null;
+	}
+}
+
+/**
+ * copyText を呼び出し、成否を copied/failed として resetMs 後に idle へ戻る一時表示で保持する。
+ * アンマウント時にはリセットタイマーを解除する。
+ */
+export function useCopyFeedback(resetMs = 2000) {
+	const [state, setState] = useState<CopyFeedbackState>('idle');
+	const handleRef = useRef<ResetHandle>({ current: null });
+
+	useEffect(() => {
+		const handle = handleRef.current;
+		return () => cancelReset(handle);
+	}, []);
+
+	const copy = useCallback(
+		async (text: string) => {
+			const ok = await copyText(text);
+			setState(ok ? 'copied' : 'failed');
+			scheduleReset(handleRef.current, () => setState('idle'), resetMs);
+			return ok;
+		},
+		[resetMs],
+	);
+
+	return { state, copy } as const;
+}

--- a/src/lib/useCopyFeedback.ts
+++ b/src/lib/useCopyFeedback.ts
@@ -5,7 +5,7 @@
 // useToolAnalytics の trackRunDebounced と同様に DOM無しで単体テストできる。
 
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { copyText } from '../clipboard.ts';
+import { copyText } from './clipboard.ts';
 
 export type CopyFeedbackState = 'idle' | 'copied' | 'failed';
 

--- a/tests/unit/use-copy-feedback.test.ts
+++ b/tests/unit/use-copy-feedback.test.ts
@@ -4,7 +4,7 @@ import {
 	cancelReset,
 	type ResetHandle,
 	scheduleReset,
-} from '../../src/lib/hooks/useCopyFeedback.ts';
+} from '../../src/lib/useCopyFeedback.ts';
 
 test('scheduleReset: delayMs 経過後に fn が1回だけ実行される', (t) => {
 	t.mock.timers.enable({ apis: ['setTimeout'] });

--- a/tests/unit/use-copy-feedback.test.ts
+++ b/tests/unit/use-copy-feedback.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	cancelReset,
+	type ResetHandle,
+	scheduleReset,
+} from '../../src/lib/hooks/useCopyFeedback.ts';
+
+test('scheduleReset: delayMs 経過後に fn が1回だけ実行される', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: ResetHandle = { current: null };
+	let calls = 0;
+
+	scheduleReset(handle, () => calls++, 2000);
+	t.mock.timers.tick(1999);
+	assert.strictEqual(calls, 0);
+
+	t.mock.timers.tick(1);
+	assert.strictEqual(calls, 1);
+});
+
+test('scheduleReset: 連打（連続呼び出し）しても古いタイマーが新しい表示を早期に消さない', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: ResetHandle = { current: null };
+	const calls: number[] = [];
+
+	scheduleReset(handle, () => calls.push(1), 2000);
+	t.mock.timers.tick(1000);
+	// 1000ms経過時点で連打（表示をやり直す）。古いタイマーは解除され、新たに2000ms後まで延長される
+	scheduleReset(handle, () => calls.push(2), 2000);
+	t.mock.timers.tick(1000);
+	assert.deepEqual(calls, []);
+
+	t.mock.timers.tick(1000);
+	assert.deepEqual(calls, [2]);
+});
+
+test('cancelReset: 保留中のタイマーを解除すると fn は実行されない（アンマウント相当）', (t) => {
+	t.mock.timers.enable({ apis: ['setTimeout'] });
+	const handle: ResetHandle = { current: null };
+	let calls = 0;
+
+	scheduleReset(handle, () => calls++, 2000);
+	cancelReset(handle);
+	t.mock.timers.tick(4000);
+
+	assert.strictEqual(calls, 0);
+	assert.strictEqual(handle.current, null);
+});
+
+test('cancelReset: 保留タイマーが無い状態で呼んでもエラーにならない', () => {
+	const handle: ResetHandle = { current: null };
+	assert.doesNotThrow(() => cancelReset(handle));
+});


### PR DESCRIPTION
## Summary

PR #272 introduced `copyText()` but left the call sites unconsolidated: 8 places (`CopyButton` + `JsonFormatter` / `SqlFormatter` / `RegexTester` / `CsvEditor`×2 / `TaxCalcPage` / `ImageCompressPage` / `ImageConvertPage`) each duplicated the same `shareCopied`/`shareCopyFailed` `useState` pair and `setTimeout(..., 2000)` reset logic, and none of them cleared the timer on unmount.

- Adds `src/lib/hooks/useCopyFeedback.ts`: a `copied`/`failed`/`idle` state machine wrapping `copyText`, with a reset timer that's always cleared before rescheduling (so rapid re-clicks can't have a stale timer erase a newer result) and cleared on unmount.
- Timer scheduling is split into React-independent `scheduleReset`/`cancelReset` functions, mirroring the existing `scheduleDebounced`/`cancelDebounced` pattern in `useToolAnalytics.ts`, so it's unit-testable with `node:test` mock timers without a DOM.
- Migrates all 8 call sites + `CopyButton` to the shared hook, removing the duplicated state/timer code from each component. Display text and the 2-second reset behavior are unchanged.
- `CsvEditor.handleCopy`'s `useCallback` now depends on the memoized result text directly instead of the indirect `[csvData, delimiter]` pair (per the PR #272 review follow-up note).

## Test plan

- [x] `npm run lint` — 0 errors (pre-existing `noNonNullAssertion` warnings in `tests/e2e/webmcp.spec.ts` are unrelated to this change)
- [x] `npm run test:unit` — 925/925 passing, including new `tests/unit/use-copy-feedback.test.ts`
- [x] `npm run build` — succeeds
- [ ] `npm test` (Playwright E2E) — could not run in this sandbox: Playwright 1.61.1 expects Chromium build 1228 but the container only has build 1194 cached (`browserType.launch: Executable doesn't exist`). Confirmed this is a pre-existing environment limitation, not a regression — an untouched spec (`uuid.spec.ts`) fails identically. Will need to be verified by CI or a properly provisioned environment.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01V7BA7Su1FiwNHLFGFtXcxm


---
_Generated by [Claude Code](https://claude.ai/code/session_01V7BA7Su1FiwNHLFGFtXcxm)_