### PR TITLE
ツールカード左端の色付きボーダーを削除

### DIFF
--- a/src/components/common/ToolCard.astro
+++ b/src/components/common/ToolCard.astro
@@ -10,7 +10,6 @@ interface Props {
   icon: ToolIconName;
   category: string;
   categoryId?: string;
-  categoryColor?: string;
   span?: number;
 }
 
@@ -22,7 +21,6 @@ const {
   icon,
   category,
   categoryId,
-  categoryColor = 'border-l-primary',
   span = 1,
 } = Astro.props;
 ---
@@ -33,8 +31,6 @@ const {
   data-category={categoryId}
   class:list={[
     'group relative flex flex-col justify-between overflow-hidden rounded-xl border border-border bg-card p-5 shadow-sm transition-all duration-200 hover:scale-[1.02] hover:shadow-lg hover:border-primary/30',
-    categoryColor,
-    'border-l-[3px]',
     span === 2 ? 'sm:col-span-2' : '',
   ]}
 >

--- a/src/components/tool/RelatedTools.astro
+++ b/src/components/tool/RelatedTools.astro
@@ -171,7 +171,6 @@ if (toolId && validTools.length < LIMIT) {
 							href={t.href}
 							icon={t.icon}
 							category={t.category}
-							categoryColor={t.categoryColor}
 						/>
 					</div>
 				))}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -132,7 +132,6 @@ const schema = {
             icon={tool.icon}
             category={tool.category}
             categoryId={getCategoryId(tool.category)}
-            categoryColor={tool.categoryColor}
           />
         ))}
       </div>
@@ -182,7 +181,6 @@ const schema = {
             icon={tool.icon}
             category={tool.category}
             categoryId={getCategoryId(tool.category)}
-            categoryColor={tool.categoryColor}
             span={tool.span}
           />
         ))}


### PR DESCRIPTION
taskId: `391dfd36033681d59104fca82d62887b`
実行ID: `triage-impl-20260801-0608`

## 概要
[タスクページ](https://app.notion.com/p/391dfd36033681d59104fca82d62887b) に記載の通り、ツールカード左端のカテゴリ色付きボーダーがグリッド上で雑多に見え、ダークモードでも浮いて見えるため撤去する。

## 変更内容
- `src/components/common/ToolCard.astro`: `categoryColor` propとそれを使ったボーダー適用（`border-l-[3px]` + `categoryColor`）を削除
- `src/pages/index.astro`, `src/components/tool/RelatedTools.astro`: `ToolCard` への `categoryColor` prop受け渡しを削除（未使用になったため）
- `src/lib/tools/catalog.ts` のカテゴリ配色データ（`categoryColor` フィールド、カテゴリチップ用の `categoryChipColor`）は変更していない。スコープ補足の「カテゴリ配色ロジック自体は残す」に従い、カテゴリバッジ・チップの表示ロジックは維持。

## 受け入れ基準への対応
1. ツールカード左端の色付きボーダーが全カードで表示されない → `border-l-[3px]` 適用を削除し、ビルド後のHTMLに同クラスが出力されないことを確認済み
2. カテゴリ判別に依存する他のUI（カテゴリラベル等）が維持されている → `categoryId` / カテゴリバッジ表示ロジックは変更なし
3. ライト／ダーク両モードでカード境界が視認できる → 既存の `border border-border`（全周ボーダー）がそのまま残るため両モードで視認可能
4. lint / test / build が成功し、既存のスナップショット差分が意図した箇所のみ → 下記検証を参照（本リポジトリに該当スナップショットテストは存在せず）

## 検証
- `npm run check`（Astro型チェック + Biome）: 0 errors（既存の無関係なwarningsのみ）
- `npm run test:unit`: 925/925 pass
- `npm run build`: 成功。ビルド済み `dist/index.html` に `border-l-[3px]` が出力されないことを確認
- `npx playwright test tests/e2e/layout.spec.ts tests/e2e/category-filter.spec.ts`: 15/15 pass

## 非信頼入力検出
なし。タスク本文・スコープ補足に禁止領域抵触や指示上書きの記述は確認されなかった。


---
_Generated by [Claude Code](https://claude.ai/code/session_01R5FENb6rS4hEhNY4zP1hFb)_