### PR TITLE
fix(csv-fixer): 即時変換モードでの変換失敗をサイレント失敗にしない

### DIFF
--- a/src/components/tools/CsvFixer.tsx
+++ b/src/components/tools/CsvFixer.tsx
@@ -64,6 +64,17 @@ export interface FileLoadedEvent {
 	detection: DetectionResult;
 }
 
+function getConversionErrorMessage(e: unknown): string {
+	if (
+		e instanceof RangeError ||
+		e instanceof TypeError ||
+		String(e).includes('memory')
+	) {
+		return 'ファイルが大きすぎます。より小さいファイルでお試しください。';
+	}
+	return '変換中にエラーが発生しました。エンコーディングを変更して再度お試しください。';
+}
+
 // --- Internal Components ---
 
 interface InstantModeToggleProps {
@@ -690,20 +701,7 @@ function DownloadButton({
 		} catch (e: unknown) {
 			console.error('Conversion error:', e);
 			setStatus('error');
-
-			if (
-				e instanceof RangeError ||
-				e instanceof TypeError ||
-				String(e).includes('memory')
-			) {
-				setErrorMessage(
-					'ファイルが大きすぎます。より小さいファイルでお試しください。',
-				);
-			} else {
-				setErrorMessage(
-					'変換中にエラーが発生しました。エンコーディングを変更して再度お試しください。',
-				);
-			}
+			setErrorMessage(getConversionErrorMessage(e));
 		}
 	};
 
@@ -760,6 +758,7 @@ export default function CsvFixer() {
 	const [status, setStatus] = useState<
 		'idle' | 'detecting' | 'ready' | 'converting' | 'done' | 'error'
 	>('idle');
+	const [errorMessage, setErrorMessage] = useState<string | null>(null);
 	const [isPreviewLoading, setIsPreviewLoading] = useState(false);
 
 	const [fileInfo, setFileInfo] = useState<{
@@ -829,6 +828,7 @@ export default function CsvFixer() {
 		setDetection(event.detection);
 		setEffectiveEncoding(event.detection.encoding);
 		setStatus('ready');
+		setErrorMessage(null);
 
 		setFileInfo({
 			name: event.file.name,
@@ -874,6 +874,7 @@ export default function CsvFixer() {
 	) => {
 		if (status === 'converting') return;
 		setStatus('converting');
+		setErrorMessage(null);
 		try {
 			const { blob, fileName: outName } = convertEncoding(
 				buf,
@@ -895,6 +896,7 @@ export default function CsvFixer() {
 		} catch (e) {
 			console.error(e);
 			setStatus('error');
+			setErrorMessage(getConversionErrorMessage(e));
 		}
 	};
 
@@ -905,6 +907,7 @@ export default function CsvFixer() {
 		setPreview(null);
 		setFileInfo(null);
 		setStatus('idle');
+		setErrorMessage(null);
 	};
 
 	return (
@@ -946,6 +949,16 @@ export default function CsvFixer() {
 							別のファイルを変換
 						</button>
 					</div>
+
+					{errorMessage && (
+						<div
+							role="alert"
+							className="flex items-center text-sm text-destructive bg-destructive/10 px-3 py-2 rounded-md"
+						>
+							<AlertCircle className="w-4 h-4 mr-2 shrink-0" />
+							<p>{errorMessage}</p>
+						</div>
+					)}
 
 					{detection && fileInfo && (
 						<EncodingDetector

--- a/tests/e2e/csv-fixer.spec.ts
+++ b/tests/e2e/csv-fixer.spec.ts
@@ -165,4 +165,59 @@ test.describe('CSV文字化け修復ツール', () => {
 			page.getByRole('button', { name: '変換してダウンロード' }),
 		).toBeVisible();
 	});
+
+	test('即時変換モードONで変換に失敗した場合、エラーメッセージが表示されること', async ({
+		page,
+	}) => {
+		// 変換処理そのものではなく、ダウンロードトリガー（URL.createObjectURL）を
+		// 失敗させることで、両モード共通のダウンロード処理経路で例外を再現する。
+		// beforeEach で既に読み込み済みのページには追加時点で反映されないため reload する。
+		await page.addInitScript(() => {
+			window.URL.createObjectURL = () => {
+				throw new Error('mock createObjectURL failure');
+			};
+		});
+		await page.reload();
+		await page.waitForSelector('input[type="file"]', { state: 'attached' });
+
+		await page.getByRole('switch', { name: '即時変換モード' }).click();
+
+		await page
+			.locator('input[type="file"]')
+			.setInputFiles(
+				path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'shift_jis.csv'),
+			);
+
+		await expect(
+			page.getByText(
+				'変換中にエラーが発生しました。エンコーディングを変更して再度お試しください。',
+			),
+		).toBeVisible();
+	});
+
+	test('通常ダウンロードで変換に失敗した場合、エラーメッセージが表示されること', async ({
+		page,
+	}) => {
+		await page.addInitScript(() => {
+			window.URL.createObjectURL = () => {
+				throw new Error('mock createObjectURL failure');
+			};
+		});
+		await page.reload();
+		await page.waitForSelector('input[type="file"]', { state: 'attached' });
+
+		await page
+			.locator('input[type="file"]')
+			.setInputFiles(
+				path.join(process.cwd(), 'tests', 'e2e', 'fixtures', 'shift_jis.csv'),
+			);
+
+		await page.getByRole('button', { name: '変換してダウンロード' }).click();
+
+		await expect(
+			page.getByText(
+				'変換中にエラーが発生しました。エンコーディングを変更して再度お試しください。',
+			),
+		).toBeVisible();
+	});
 });


### PR DESCRIPTION
## Summary
- CSV文字化け解消ツール（csv-fixer）の「即時変換モード」で、`executeInstantDownload` が例外を投げた際に `setStatus('error')` のみが呼ばれ `errorMessage` がセットされず、UI上にエラーが表示されないサイレント失敗になっていた問題を修正
- `executeInstantDownload` の catch ブロックで `setErrorMessage` を呼び、通常ダウンロードボタンと同じ文言・見た目（`text-destructive` + `AlertCircle`）でエラーを表示するようにした
- エラーメッセージ判定ロジック（`RangeError`/`TypeError`/メモリ関連かどうかの分岐）を `getConversionErrorMessage` として共通化し、通常ダウンロードボタンの catch ブロックからも呼び出すよう統一
- 正常系（変換成功時）の挙動、UIコンポーネントの構成は変更なし

## Test plan
- [x] `npm run test:unit`（925件）成功
- [x] `npm run lint` / `npm run check`（型チェック・Biome）成功、既存の無関係な警告のみ
- [x] `npm run build` 成功
- [x] `npx playwright test tests/e2e/csv-fixer.spec.ts` 全9件成功（既存7件 + 新規再現テスト2件）
  - 新規: 即時変換モードONで変換失敗時にエラーメッセージが表示されること
  - 新規: 通常ダウンロードで変換失敗時にエラーメッセージが表示されること（既存動作の一貫性を保証するリグレッションガード）
  - 両テストとも `URL.createObjectURL` をモックして失敗させることで、即時変換ON/OFF共通のダウンロード処理経路で例外を再現
  - 修正前のコードに対して即時変換モードのテストが失敗することを確認済み（サイレント失敗の再現を検証）

## 受け入れ基準
- [x] 即時変換モードで変換失敗時にエラーメッセージがUIに表示される
- [x] 通常ダウンロードのエラー表示と一貫性がある
- [x] 正常系の挙動に変化がない
- [x] ビルド・型チェックが通る

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_011DmptKaFHb9UvoiDhcLina)_