### PR TITLE
fix(tax): インボイス明細で単価入力・数量空の場合にバリデーションエラーを表示

### DIFF
--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -32,6 +32,7 @@ import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
 	calculateInvoiceTax,
 	calculateTax,
+	hasInvoiceLineInput,
 	type InvoiceLineInput,
 	type RoundingMode,
 	TAX_RATE_HISTORY,
@@ -158,7 +159,7 @@ export function TaxCalcPage() {
 			if (!amount.ok && line.amount.trim() !== '') {
 				errors.push(`${index + 1}行目: ${amount.message}`);
 			}
-			if (!quantity.ok && line.quantity.trim() !== '') {
+			if (!quantity.ok && hasInvoiceLineInput(line)) {
 				errors.push(`${index + 1}行目: ${quantity.message}`);
 			}
 			if (amount.ok && quantity.ok) {

--- a/src/lib/tools/tax.ts
+++ b/src/lib/tools/tax.ts
@@ -180,6 +180,18 @@ export function validateAmount(raw: string): AmountValidation {
 	return { ok: true, amount, normalizedInput };
 }
 
+/**
+ * インボイス明細1行に単価または数量の入力があるかを判定する。
+ * 単価が入力されているのに数量が空の場合、数量バリデーションエラーを表示するかどうかの
+ * 判定に用いる。両方とも空（=行全体が未入力）の場合はエラーを表示せず従来どおりスキップする。
+ */
+export function hasInvoiceLineInput(fields: {
+	amount: string;
+	quantity: string;
+}): boolean {
+	return fields.amount.trim() !== '' || fields.quantity.trim() !== '';
+}
+
 /** 数量入力文字列を正規化・検証する。 */
 export function validateQuantity(raw: string): QuantityValidation {
 	const normalizedInput = normalizeNumericInput(raw);

--- a/tests/unit/tax.test.ts
+++ b/tests/unit/tax.test.ts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import {
 	calculateInvoiceTax,
 	calculateTax,
+	hasInvoiceLineInput,
 	MAX_AMOUNT,
 	MAX_QUANTITY,
 	TAX_RATE_HISTORY,
@@ -380,6 +381,40 @@ test('validateQuantity: 0・小数・上限超過はエラー', () => {
 
 	const overMax = validateQuantity(String(MAX_QUANTITY + 1));
 	assert.equal(overMax.ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// hasInvoiceLineInput
+// ---------------------------------------------------------------------------
+
+test('hasInvoiceLineInput: 単価のみ入力済みならtrue（数量エラー表示のトリガー）', () => {
+	assert.equal(hasInvoiceLineInput({ amount: '1000', quantity: '' }), true);
+});
+
+test('hasInvoiceLineInput: 数量のみ入力済みならtrue', () => {
+	assert.equal(hasInvoiceLineInput({ amount: '', quantity: 'abc' }), true);
+});
+
+test('hasInvoiceLineInput: 単価・数量ともに空なら行全体が未入力としてfalse', () => {
+	assert.equal(hasInvoiceLineInput({ amount: '', quantity: '' }), false);
+});
+
+test('hasInvoiceLineInput: 前後空白のみの入力は未入力扱いでfalse', () => {
+	assert.equal(hasInvoiceLineInput({ amount: '  ', quantity: '\t' }), false);
+});
+
+test('明細行バリデーション統合: 単価入力済み・数量空はエラー対象、行全体未入力はスキップ対象', () => {
+	// 単価入力済み・数量空 → 数量バリデーションはNGで、hasInvoiceLineInputもtrueのためエラー表示対象
+	const filledAmountEmptyQuantity = { amount: '1000', quantity: '' };
+	const quantityResult = validateQuantity(filledAmountEmptyQuantity.quantity);
+	assert.equal(quantityResult.ok, false);
+	assert.equal(hasInvoiceLineInput(filledAmountEmptyQuantity), true);
+
+	// 行全体が未入力 → hasInvoiceLineInputがfalseのためエラー非表示（従来どおりスキップ）
+	const emptyLine = { amount: '', quantity: '' };
+	const emptyQuantityResult = validateQuantity(emptyLine.quantity);
+	assert.equal(emptyQuantityResult.ok, false);
+	assert.equal(hasInvoiceLineInput(emptyLine), false);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
taskId: `391dfd360336818c922cf628a5b88416`
実行ID: `triage-impl-20260802-0609`

## 概要

消費税計算ツール（tax）のインボイス（複数明細）モードで、単価入力済み・数量が空の明細行がエラー表示なくサイレントに計算対象外となる不具合を修正しました。

原因: `line.quantity.trim() === ''` のときバリデーションエラー（`ok: false`）がエラー一覧に追加されない仕様になっており、単価が入力済みの行でも数量を空にすると何のエラーも出さずにその行が計算から除外されていました。

## 修正内容

- `src/lib/tools/tax.ts` に純粋関数 `hasInvoiceLineInput` を追加。明細行の単価・数量いずれかに入力があるかを判定します。
- `src/components/tools/tax/TaxCalcPage.tsx` の数量バリデーションエラー表示条件を `line.quantity.trim() !== ''` から `hasInvoiceLineInput(line)` に変更。単価が入力済みなら数量が空でもエラーを表示するようにしました。
- 単価・数量ともに空（行全体が未入力）の場合は、従来どおりエラーなしでスキップされる挙動を維持しています。
- `tests/unit/tax.test.ts` に `hasInvoiceLineInput` の単体テストと、バリデーション統合を確認するテストを追加しました。

## 受け入れ基準への対応状況

- [x] 単価入力済み・数量空の行でバリデーションエラーが表示される（実ブラウザで確認: 「1行目: 数量を入力してください。」）
- [x] 行全体が未入力の場合はエラーなしでスキップされる（実ブラウザで確認）
- [x] サイレントな計算漏れが発生しない
- [x] 既存の正常系計算結果に変化がない（数量を再入力すると即座に正しく計算される）
- [x] 単体テスト・lint・buildが成功する

## 検証結果

- `npm run test:unit`: tax.test.ts 29/29 成功。他ファイルの既存失敗27件は本変更と無関係の環境起因（変更前のベースブランチでも同数再現を確認済み）。
- `npm run check`（astro check + biome）: エラー0件（既存の警告のみ、本変更ファイルは警告0件）。
- `npm run build`: 成功。
- 実ブラウザ（Playwright, pinned chromium）でのUI動作確認: 単価入力・数量クリアでエラー表示、数量復元で正しく再計算されることを確認。
- Playwright E2E（`npm test`）はサンドボックス環境のブラウザバイナリのバージョン不一致（pinned r1228 vs pre-installed r1194）により実行不可のため、上記の手動ブラウザ検証で代替しました。


---
_Generated by [Claude Code](https://claude.ai/code/session_01E6rKSxborh3kiJGMECNyE8)_