### PR TITLE
fix(bg-remove): progress混信とイベントリスナーのメモリリークを修正

### DIFF
--- a/src/lib/tools/bg-remove.ts
+++ b/src/lib/tools/bg-remove.ts
@@ -20,6 +20,15 @@ export type ProgressInfo = {
 // --- Worker シングルトン ---
 let worker: Worker | null = null;
 
+// 現在進行中の removeBackground 呼び出し（同時に1件のみ）。
+// 新しい呼び出しで上書きされた場合や Worker 終了時に、
+// 古いリスナーの解除と Promise の reject を確実に行うために保持する。
+let activeCall: {
+	id: string;
+	handler: (e: MessageEvent<WorkerResponse>) => void;
+	reject: (reason: unknown) => void;
+} | null = null;
+
 function getWorker(): Worker {
 	if (!worker) {
 		worker = new Worker(
@@ -28,6 +37,15 @@ function getWorker(): Worker {
 		);
 	}
 	return worker;
+}
+
+/** 進行中の呼び出しがあれば、リスナーを解除し reject してから破棄する */
+function cancelActiveCall(w: Worker, reason: string): void {
+	if (!activeCall) return;
+	const current = activeCall;
+	activeCall = null;
+	w.removeEventListener('message', current.handler);
+	current.reject(new Error(reason));
 }
 
 /**
@@ -48,6 +66,7 @@ export function preload(mode: ModelMode = 'high'): void {
  */
 export function terminateWorker(): void {
 	if (worker) {
+		cancelActiveCall(worker, 'Worker が終了されました');
 		worker.terminate();
 		worker = null;
 	}
@@ -65,11 +84,23 @@ export function removeBackground(
 		const w = getWorker();
 		const id = crypto.randomUUID();
 
+		// 前回呼び出しが完了・失敗していない場合は上書きとみなし、
+		// 古いリスナーを解除してその Promise を reject する（メモリリーク防止）。
+		cancelActiveCall(w, '新しい処理により上書きされました');
+
+		// このハンドラを Worker から確実に外し、activeCall を自分自身に限って解放する
+		const cleanup = () => {
+			w.removeEventListener('message', handler);
+			if (activeCall?.id === id) activeCall = null;
+		};
+
 		const handler = (e: MessageEvent<WorkerResponse>) => {
 			const msg = e.data;
 
-			// progress は id に関係なく全て通知
+			// progress は自分の処理 id に一致するものだけ通知する
+			// （preload や並行処理からの進捗混信を防止）
 			if (msg.type === 'progress') {
+				if (msg.id !== id) return;
 				onProgress?.({
 					status: msg.payload.status,
 					progress: msg.payload.progress ?? 0,
@@ -84,7 +115,7 @@ export function removeBackground(
 			if (!('id' in msg) || msg.id !== id) return;
 
 			if (msg.type === 'result') {
-				w.removeEventListener('message', handler);
+				cleanup();
 
 				// RGBA ピクセルデータを Canvas 経由で PNG Blob に変換
 				const rgba = new Uint8ClampedArray(msg.data);
@@ -112,9 +143,18 @@ export function removeBackground(
 			}
 
 			if (msg.type === 'error') {
-				w.removeEventListener('message', handler);
+				cleanup();
 				reject(new Error(msg.message));
 			}
+		};
+
+		activeCall = {
+			id,
+			handler,
+			reject: (reason) => {
+				cleanup();
+				reject(reason);
+			},
 		};
 
 		w.addEventListener('message', handler);
@@ -133,7 +173,10 @@ export function removeBackground(
 					[buffer],
 				);
 			})
-			.catch(reject);
+			.catch((err) => {
+				cleanup();
+				reject(err);
+			});
 	});
 }
 

--- a/src/workers/bg-remove.worker.ts
+++ b/src/workers/bg-remove.worker.ts
@@ -50,6 +50,9 @@ export interface WorkerRequest {
 
 export interface WorkerProgressMessage {
 	type: 'progress';
+	// どのリクエスト（id）に紐づく進捗かを示す。preload と本処理が並行しても
+	// ラッパー側で自分宛て以外の進捗を無視できるようにするため必須。
+	id: string;
 	payload: {
 		status: string;
 		progress?: number;
@@ -89,7 +92,7 @@ export type WorkerResponse =
 let remover: any = null;
 let currentMode: ModelMode | null = null;
 
-async function ensurePipeline(mode: ModelMode) {
+async function ensurePipeline(mode: ModelMode, id: string) {
 	if (remover && currentMode === mode) return remover;
 
 	const model = MODELS[mode];
@@ -107,6 +110,7 @@ async function ensurePipeline(mode: ModelMode) {
 		}) => {
 			self.postMessage({
 				type: 'progress',
+				id,
 				payload: p,
 			} satisfies WorkerProgressMessage);
 		},
@@ -121,12 +125,13 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
 	const { id, mode, imageData, mimeType, preloadOnly } = e.data;
 
 	try {
-		const pipe = await ensurePipeline(mode);
+		const pipe = await ensurePipeline(mode, id);
 
 		// キャッシュ済みの場合は progress_callback が発火しないため、
 		// 毎回 'ready' を送って UI の loading→processing 遷移を保証する
 		self.postMessage({
 			type: 'progress',
+			id,
 			payload: { status: 'ready' },
 		} satisfies WorkerProgressMessage);
 

--- a/tests/unit/bg-remove.test.ts
+++ b/tests/unit/bg-remove.test.ts
@@ -1,0 +1,167 @@
+// 実行方法: npm run test:unit
+// 単体実行: node --test tests/unit/bg-remove.test.ts
+//
+// 実際のAI推論処理（Worker内のTransformers.jsパイプライン）はブラウザ専用のため
+// E2E で検証する。ここでは Worker ラッパー（bg-remove.ts）の
+// - progress メッセージの id フィルタリング（混信防止）
+// - リスナーの確実な解除（上書き・エラー・Worker終了時のメモリリーク防止）
+// を、Worker をモックして検証する。
+import assert from 'node:assert/strict';
+import { afterEach, test } from 'node:test';
+
+// --- Worker のフェイク実装 ---
+// addEventListener/removeEventListener/postMessage/terminate の呼び出しを記録し、
+// emit() でテストから任意の worker → main メッセージを注入できる。
+class FakeWorker {
+	static instances: FakeWorker[] = [];
+	listeners = new Set<(e: { data: unknown }) => void>();
+	posted: unknown[] = [];
+	terminated = false;
+
+	constructor() {
+		FakeWorker.instances.push(this);
+	}
+
+	addEventListener(_type: string, handler: (e: { data: unknown }) => void) {
+		this.listeners.add(handler);
+	}
+
+	removeEventListener(_type: string, handler: (e: { data: unknown }) => void) {
+		this.listeners.delete(handler);
+	}
+
+	postMessage(data: unknown) {
+		this.posted.push(data);
+	}
+
+	terminate() {
+		this.terminated = true;
+	}
+
+	emit(data: unknown) {
+		for (const listener of [...this.listeners]) listener({ data });
+	}
+}
+
+// bg-remove.ts の `new Worker(...)` が本 Fake を使うようにしてからインポートする
+(globalThis as unknown as { Worker: typeof FakeWorker }).Worker = FakeWorker;
+
+const { removeBackground, terminateWorker } = await import(
+	'../../src/lib/tools/bg-remove.ts'
+);
+
+afterEach(() => {
+	// 各テスト後に Worker シングルトンをリセットし、次のテストで新しい FakeWorker を使う
+	terminateWorker();
+});
+
+function lastWorker(): FakeWorker {
+	const w = FakeWorker.instances.at(-1);
+	assert.ok(w, 'FakeWorker が生成されていません');
+	return w;
+}
+
+function lastRequestId(w: FakeWorker): string {
+	const req = w.posted.at(-1) as { id: string } | undefined;
+	assert.ok(req, 'Worker へリクエストが送信されていません');
+	return req.id;
+}
+
+test('removeBackground: 自分の処理idに一致する progress のみ onProgress に通知される', async () => {
+	const events: unknown[] = [];
+	const file = new Blob(['dummy'], { type: 'image/png' });
+	const promise = removeBackground(file, 'fast', (info) => events.push(info));
+
+	// arrayBuffer() 解決後の postMessage を待つ
+	await new Promise((r) => setTimeout(r, 0));
+	const w = lastWorker();
+	const id = lastRequestId(w);
+
+	// 自分宛て以外（preload や並行処理）の progress は無視される
+	w.emit({
+		type: 'progress',
+		id: 'other-call-id',
+		payload: { status: 'initiate' },
+	});
+	assert.equal(events.length, 0);
+
+	// 自分の id の progress は通知される
+	w.emit({
+		type: 'progress',
+		id,
+		payload: { status: 'download', progress: 50 },
+	});
+	assert.equal(events.length, 1);
+	assert.deepEqual(events[0], {
+		status: 'download',
+		progress: 50,
+		loaded: undefined,
+		total: undefined,
+		file: undefined,
+	});
+
+	// 後片付け（Promise を宙に浮かせない）
+	w.emit({ type: 'error', id, message: 'cleanup' });
+	await assert.rejects(promise);
+});
+
+test('removeBackground: 完了・エラー後にリスナーが解除され、連続実行でも増加しない', async () => {
+	for (let i = 0; i < 3; i++) {
+		const file = new Blob(['x'], { type: 'image/png' });
+		const promise = removeBackground(file, 'fast');
+		await new Promise((r) => setTimeout(r, 0));
+
+		const w = lastWorker();
+		const id = lastRequestId(w);
+		assert.equal(w.listeners.size, 1, `${i}回目: リスナーが1件登録されている`);
+
+		w.emit({ type: 'error', id, message: `boom-${i}` });
+		await assert.rejects(promise);
+		assert.equal(
+			w.listeners.size,
+			0,
+			`${i}回目: エラー後にリスナーが解除される`,
+		);
+	}
+});
+
+test('removeBackground: 新しい呼び出しで前回のリスナーが解除され、前回の Promise は reject される', async () => {
+	const file1 = new Blob(['a'], { type: 'image/png' });
+	const p1 = removeBackground(file1, 'fast');
+	await new Promise((r) => setTimeout(r, 0));
+
+	const w = lastWorker();
+	assert.equal(w.listeners.size, 1);
+
+	// 上書き: 別画像で2回目の呼び出し（旧リスナーは解除され、旧 Promise は reject される）
+	// p1 は removeBackground(file2, ...) の呼び出し中に同期的に reject されるため、
+	// マクロタスク境界（setTimeout）を挟む前にハンドラを付けて unhandledRejection を防ぐ。
+	const file2 = new Blob(['b'], { type: 'image/png' });
+	const p2 = removeBackground(file2, 'fast');
+	await assert.rejects(p1, /上書き/);
+
+	await new Promise((r) => setTimeout(r, 0));
+	assert.equal(
+		w.listeners.size,
+		1,
+		'古いリスナーが残っていない（上書き後も1件のみ）',
+	);
+
+	// 2件目を正常終了させて後片付け
+	const id2 = lastRequestId(w);
+	w.emit({ type: 'error', id: id2, message: 'cleanup' });
+	await assert.rejects(p2);
+	assert.equal(w.listeners.size, 0);
+});
+
+test('terminateWorker: 未解決の呼び出しを reject してから Worker を終了する', async () => {
+	const file = new Blob(['x'], { type: 'image/png' });
+	const promise = removeBackground(file, 'fast');
+	await new Promise((r) => setTimeout(r, 0));
+
+	const w = lastWorker();
+	terminateWorker();
+
+	await assert.rejects(promise);
+	assert.equal(w.terminated, true);
+});


### PR DESCRIPTION
taskId: `391dfd360336816e87d3f8d2540a4614`
実行ID: `triage-impl-20260803-0611`

## 概要
[タスクページ](https://app.notion.com/p/391dfd360336816e87d3f8d2540a4614) の指摘どおり、`src/lib/tools/bg-remove.ts`（Worker ラッパー）に2つの密結合な不具合があったため修正した。

1. `removeBackground` 内の `progress` メッセージハンドラが処理 id を検証しておらず、複数処理や preload が重なると進捗表示が混信する。
2. 処理実行中に別画像で上書きすると、古いイベントリスナーが Worker に登録されたまま残り続け、メモリリークと意図しない状態更新の原因になる。

## 変更内容
- `src/workers/bg-remove.worker.ts`: `WorkerProgressMessage` に `id` を追加し、モデルロード中の `progress_callback` および `ready` 通知の両方でリクエスト元の id を含めて送信するように変更。
- `src/lib/tools/bg-remove.ts`:
  - `progress` メッセージは自分の処理 id と一致する場合のみ `onProgress` へ通知するように変更（preload・並行処理からの混信を防止）。
  - 呼び出し中の処理を追跡する `activeCall` を導入し、新しい `removeBackground` 呼び出しで上書きされた場合に、旧リスナーを `removeEventListener` し旧 Promise を reject するようにした。
  - `terminateWorker()` でも同様に、未解決の呼び出しがあれば reject してから Worker を終了するようにした。
  - 完了・エラー・上書き・Worker終了のすべての経路でリスナー解除処理（`cleanup`）を共通化。
- `tests/unit/bg-remove.test.ts`: Worker をモックした単体テストを新規追加（progress の id フィルタリング、連続実行でのリスナー非増加、上書き時の旧リスナー解除・旧Promiseのreject、Worker終了時の未解決Promiseのrejectを検証）。

背景削除の推論ロジック・出力品質・既存のメッセージ型（`WorkerRequest`/`WorkerResultMessage`/`WorkerErrorMessage`/`WorkerReadyMessage`）には変更なし。

## 受け入れ基準への対応
- [x] progress を処理IDで検証し混信を防止
- [x] 完了・エラー・キャンセル・上書きでリスナーを必ず解除
- [x] 連続実行でリスナー・メモリが増加しない（単体テストで検証）
- [x] 出力品質は不変（Canvas 後処理・推論パイプラインは無変更）
- [x] テスト・lint・build が成功する

## 検証結果
- `npm run test:unit`: 新規追加した `tests/unit/bg-remove.test.ts` 4件はすべて成功。
  - 全体では 27件が失敗するが、`git stash` でこの変更前の状態に戻して同じコマンドを実行しても同一の27件が失敗することを確認済み（`char-count` / `csv-editor` / `json-csv` / `markdown` / `mergePdfs` / `text-diff` / `use-batch-processing` 等、いずれも本PRの変更と無関係な既存の失敗）。本PRによる新規の失敗・リグレッションはなし。
- `npm run lint`: エラー0件（警告14件はすべて本PR対象外ファイルの既存warning）。
- `npx astro check`: エラー0件・警告0件。
- `npm run build`: 成功。

## 非信頼入力検出
タスク本文・AIエージェント実行プロンプトに、権限変更・秘密情報の取得や出力・外部送信・ガードレール解除・優先順位や手順の上書き・マージ/デプロイの実行を求める記述なし。検出事項なし。

---
Generated by an automated Notion タスクボード self-triage routine (トリアージ＋実装). Merge/deploy はこのRoutineでは行わず、人間のレビューを待ちます。


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyRZkqJ4MDTzzyBnsYh4aT)_