### PR TITLE
fix(settings): 共有URL設定を検証してからlocalStorageへ永続化する

### DIFF
--- a/src/components/image-compress/ImageCompressPage.tsx
+++ b/src/components/image-compress/ImageCompressPage.tsx
@@ -31,6 +31,7 @@ import {
 	type ResizeKind,
 } from './CompressOptionsPanel';
 import { type CompressItem, CompressResultList } from './CompressResultList';
+import { sanitizeCompressSettings } from './settingsValidation';
 
 const ACCEPT = 'image/jpeg,image/png,image/webp';
 
@@ -64,6 +65,7 @@ export function ImageCompressPage() {
 	const [options, updateOptions, generateShareUrl] = useToolSettings(
 		'image-compress',
 		DEFAULT_UI_OPTIONS,
+		sanitizeCompressSettings,
 	);
 	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
 	const shareCopied = shareState === 'copied';

--- a/src/components/image-compress/settingsValidation.ts
+++ b/src/components/image-compress/settingsValidation.ts
@@ -1,0 +1,80 @@
+// ImageCompressPage の共有URL/localStorage復元値を検証する純粋ロジック。
+// 不正値はデフォルト設定へフォールバックする。
+
+import type { CompressFormat } from '@/lib/tools/image-compress';
+import type { CompressUiOptions, ResizeKind } from './CompressOptionsPanel';
+
+const VALID_FORMATS: readonly CompressFormat[] = [
+	'jpeg',
+	'webp',
+	'png',
+	'keep',
+];
+const VALID_RESIZE_KINDS: readonly ResizeKind[] = [
+	'none',
+	'max-width',
+	'max-height',
+	'long-edge',
+	'percent',
+];
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+const MAX_RESIZE_VALUE = 20000; // px（percent指定時も含めた上限。厳密な業務上限ではなく異常値の排除が目的）
+const MAX_TARGET_KB = 1_000_000;
+
+export function sanitizeCompressSettings(
+	value: unknown,
+	defaults: CompressUiOptions,
+): CompressUiOptions {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const format =
+		typeof v.format === 'string' &&
+		(VALID_FORMATS as readonly string[]).includes(v.format)
+			? (v.format as CompressFormat)
+			: defaults.format;
+	const quality =
+		typeof v.quality === 'number' &&
+		Number.isFinite(v.quality) &&
+		v.quality >= 0 &&
+		v.quality <= 1
+			? v.quality
+			: defaults.quality;
+	const resizeKind =
+		typeof v.resizeKind === 'string' &&
+		(VALID_RESIZE_KINDS as readonly string[]).includes(v.resizeKind)
+			? (v.resizeKind as ResizeKind)
+			: defaults.resizeKind;
+	const resizeValue =
+		typeof v.resizeValue === 'number' &&
+		Number.isFinite(v.resizeValue) &&
+		v.resizeValue > 0 &&
+		v.resizeValue <= MAX_RESIZE_VALUE
+			? v.resizeValue
+			: defaults.resizeValue;
+	const useTargetSize =
+		typeof v.useTargetSize === 'boolean'
+			? v.useTargetSize
+			: defaults.useTargetSize;
+	const targetKB =
+		typeof v.targetKB === 'number' &&
+		Number.isFinite(v.targetKB) &&
+		v.targetKB > 0 &&
+		v.targetKB <= MAX_TARGET_KB
+			? v.targetKB
+			: defaults.targetKB;
+	const background =
+		typeof v.background === 'string' && HEX_COLOR_PATTERN.test(v.background)
+			? v.background
+			: defaults.background;
+	return {
+		format,
+		quality,
+		resizeKind,
+		resizeValue,
+		useTargetSize,
+		targetKB,
+		background,
+	};
+}

--- a/src/components/image-convert/ImageConvertPage.tsx
+++ b/src/components/image-convert/ImageConvertPage.tsx
@@ -31,6 +31,7 @@ import {
 	DEFAULT_UI_OPTIONS,
 } from './ConvertOptionsPanel';
 import { type ConvertItem, ConvertResultList } from './ConvertResultList';
+import { sanitizeConvertSettings } from './settingsValidation';
 
 // HEIC は type が空のことがあるため拡張子も許可する
 const ACCEPT =
@@ -41,6 +42,7 @@ export function ImageConvertPage() {
 	const [options, updateOptions, generateShareUrl] = useToolSettings(
 		'image-convert',
 		DEFAULT_UI_OPTIONS,
+		sanitizeConvertSettings,
 	);
 	const { state: shareState, copy: copyShareUrl } = useCopyFeedback();
 	const shareCopied = shareState === 'copied';

--- a/src/components/image-convert/settingsValidation.ts
+++ b/src/components/image-convert/settingsValidation.ts
@@ -1,0 +1,41 @@
+// ImageConvertPage の共有URL/localStorage復元値を検証する純粋ロジック。
+// 不正値はデフォルト設定へフォールバックする。
+
+import type { ExifMode, TargetFormat } from '@/lib/tools/image-convert';
+import type { ConvertUiOptions } from './ConvertOptionsPanel';
+
+const VALID_TARGETS: readonly TargetFormat[] = ['jpeg', 'png', 'webp', 'avif'];
+const VALID_EXIF_MODES: readonly ExifMode[] = ['keep', 'strip'];
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function sanitizeConvertSettings(
+	value: unknown,
+	defaults: ConvertUiOptions,
+): ConvertUiOptions {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const target =
+		typeof v.target === 'string' &&
+		(VALID_TARGETS as readonly string[]).includes(v.target)
+			? (v.target as TargetFormat)
+			: defaults.target;
+	const quality =
+		typeof v.quality === 'number' &&
+		Number.isFinite(v.quality) &&
+		v.quality >= 0 &&
+		v.quality <= 100
+			? v.quality
+			: defaults.quality;
+	const exif =
+		typeof v.exif === 'string' &&
+		(VALID_EXIF_MODES as readonly string[]).includes(v.exif)
+			? (v.exif as ExifMode)
+			: defaults.exif;
+	const background =
+		typeof v.background === 'string' && HEX_COLOR_PATTERN.test(v.background)
+			? v.background
+			: defaults.background;
+	return { target, quality, exif, background };
+}

--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -37,6 +37,7 @@ import {
 	exportCsv,
 	getColumnLabel,
 	parseCsv,
+	sanitizeCsvEditorSettings,
 } from '@/lib/tools/csv-editor';
 import {
 	type Column,
@@ -63,6 +64,7 @@ export default function CsvEditor() {
 			delimiter: ',',
 			hasHeader: true,
 		},
+		sanitizeCsvEditorSettings,
 	);
 
 	const { delimiter, hasHeader } = settings;

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -25,6 +25,7 @@ import {
 	formatJson,
 	type IndentType,
 	minifyJson,
+	sanitizeJsonFormatterSettings,
 } from '@/lib/tools/json-formatter';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
@@ -63,6 +64,7 @@ export default function JsonFormatter() {
 		{
 			indent: '2' as IndentType,
 		},
+		sanitizeJsonFormatterSettings,
 	);
 
 	const indent = settings.indent;

--- a/src/components/tools/RegexTester.tsx
+++ b/src/components/tools/RegexTester.tsx
@@ -25,7 +25,11 @@ import { Textarea } from '@/components/ui/textarea';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import type { RegexResult } from '@/lib/tools/regex-tester';
-import { COMMON_PATTERNS, testRegex } from '@/lib/tools/regex-tester';
+import {
+	COMMON_PATTERNS,
+	sanitizeRegexTesterSettings,
+	testRegex,
+} from '@/lib/tools/regex-tester';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
 export default function RegexTester() {
@@ -40,6 +44,7 @@ export default function RegexTester() {
 			showReplace: false,
 			replacement: '',
 		},
+		sanitizeRegexTesterSettings,
 	);
 
 	const { pattern, flags, showReplace, replacement } = settings;

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -31,6 +31,7 @@ import {
 	type IndentStyle,
 	type SqlDialect,
 	type SqlFormatOptions,
+	sanitizeSqlFormatterSettings,
 } from '@/lib/tools/sql-formatter';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import { cn } from '@/lib/utils';
@@ -94,6 +95,7 @@ export default function SqlFormatter() {
 			isExpanded: false,
 			layout: 'horizontal' as 'horizontal' | 'vertical',
 		},
+		sanitizeSqlFormatterSettings,
 	);
 	const { autoFormat, dialect, indent, uppercase, compress, isExpanded } =
 		settings;

--- a/src/components/tools/id-generator/GeneratePanel.tsx
+++ b/src/components/tools/id-generator/GeneratePanel.tsx
@@ -22,6 +22,7 @@ import {
 	joinIdsForCopy,
 	MAX_COUNT,
 	MIN_COUNT,
+	sanitizeUuidSettings,
 	validateCount,
 } from '@/lib/tools/uuid';
 
@@ -32,12 +33,16 @@ interface GeneratePanelProps {
 const isUuidKind = (kind: IdKind) => kind === 'uuid-v4' || kind === 'uuid-v7';
 
 export function GeneratePanel({ onGenerated }: GeneratePanelProps) {
-	const [settings, updateSettings] = useToolSettings('uuid', {
-		kind: 'uuid-v4' as IdKind,
-		count: 10,
-		uppercase: false,
-		hyphens: true,
-	});
+	const [settings, updateSettings] = useToolSettings(
+		'uuid',
+		{
+			kind: 'uuid-v4' as IdKind,
+			count: 10,
+			uppercase: false,
+			hyphens: true,
+		},
+		sanitizeUuidSettings,
+	);
 	const { kind, count, uppercase, hyphens } = settings;
 
 	const [rawResults, setRawResults] = useState<string[]>([]);

--- a/src/components/tools/tax/TaxCalcPage.tsx
+++ b/src/components/tools/tax/TaxCalcPage.tsx
@@ -35,6 +35,7 @@ import {
 	hasInvoiceLineInput,
 	type InvoiceLineInput,
 	type RoundingMode,
+	sanitizeTaxCalcSettings,
 	TAX_RATE_HISTORY,
 	type TaxCalcInput,
 	validateAmount,
@@ -95,12 +96,16 @@ function formatYen(value: number): string {
 export function TaxCalcPage() {
 	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('tax');
 
-	const [settings, updateSettings, generateShareUrl] = useToolSettings('tax', {
-		mode: 'single' as CalcMode,
-		direction: 'exclusive-to-inclusive' as Direction,
-		rateSelection: '10',
-		rounding: 'floor' as RoundingMode,
-	});
+	const [settings, updateSettings, generateShareUrl] = useToolSettings(
+		'tax',
+		{
+			mode: 'single' as CalcMode,
+			direction: 'exclusive-to-inclusive' as Direction,
+			rateSelection: '10',
+			rounding: 'floor' as RoundingMode,
+		},
+		sanitizeTaxCalcSettings,
+	);
 
 	const { mode, direction, rateSelection, rounding } = settings;
 	const [rawAmount, setRawAmount] = useState('');

--- a/src/lib/hooks/useToolSettings.ts
+++ b/src/lib/hooks/useToolSettings.ts
@@ -1,17 +1,72 @@
 import { useEffect, useState } from 'react';
 import { track } from '@/lib/analytics';
 
+export type SettingsValidator<T> = (value: unknown, defaults: T) => T;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * validate 省略時の既定検証。既知キーのみ、型（配列判定含む）が一致する値だけを採用する。
+ * 数値範囲や列挙値までは検証しないため、範囲・列挙検証が必要な呼び出し元は validate を明示的に渡すこと。
+ */
+function defaultValidator<T extends Record<string, unknown>>(
+	value: unknown,
+	defaults: T,
+): T {
+	if (!isPlainObject(value)) {
+		return { ...defaults };
+	}
+	const result = { ...defaults };
+	for (const key of Object.keys(defaults) as Array<keyof T>) {
+		const raw = value[key as string];
+		if (raw === undefined) continue;
+		const defaultValue = defaults[key];
+		if (Array.isArray(defaultValue)) {
+			if (Array.isArray(raw)) {
+				result[key] = raw as T[keyof T];
+			}
+			continue;
+		}
+		if (typeof raw === typeof defaultValue) {
+			result[key] = raw as T[keyof T];
+		}
+	}
+	return result;
+}
+
+// atob/btoa は Latin1 前提のため、TextEncoder/TextDecoder で UTF-8 とバイト列を変換する
+// （非推奨の escape/unescape は使用しない）。
+function decodeBase64Utf8(value: string): string {
+	const binary = atob(value);
+	const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+	return new TextDecoder().decode(bytes);
+}
+
+function encodeUtf8Base64(value: string): string {
+	const bytes = new TextEncoder().encode(value);
+	let binary = '';
+	for (const byte of bytes) {
+		binary += String.fromCharCode(byte);
+	}
+	return btoa(binary);
+}
+
 /**
  * ツール固有の設定値を localStorage および URL クエリパラメータと同期するためのカスタムフック。
  * 入力テキストなどの機密データではなく、設定値（数値やトグル状態）のみを対象とする。
  *
  * @param slug ツールの識別子 (例: 'json-formatter')
  * @param defaultSettings 初期設定オブジェクト
+ * @param validate 復元値の検証関数。省略時は既知キー・型一致のみを許容する既定検証を使う。
+ *   範囲・列挙値の検証が必要な場合は呼び出し元でスキーマ検証関数を渡すこと。
  */
 // biome-ignore lint/suspicious/noExplicitAny: settings can contain any basic value types
 export function useToolSettings<T extends Record<string, any>>(
 	slug: string,
 	defaultSettings: T,
+	validate: SettingsValidator<T> = defaultValidator,
 ) {
 	const [settings, setSettings] = useState<T>(() => {
 		if (typeof window === 'undefined') {
@@ -23,12 +78,11 @@ export function useToolSettings<T extends Record<string, any>>(
 		const settingsParam = params.get('settings');
 		if (settingsParam) {
 			try {
-				// Base64 デコード (Unicode対応)
-				const decoded = decodeURIComponent(escape(atob(settingsParam)));
+				const decoded = decodeBase64Utf8(settingsParam);
 				const parsed = JSON.parse(decoded);
 				track('settings_restore', { tool: slug, source: 'url' });
-				// デフォルト値をマージして不足プロパティを補完
-				return { ...defaultSettings, ...parsed };
+				// 検証済みの値のみを採用し、不正値はデフォルトへフォールバックする
+				return validate(parsed, defaultSettings);
 			} catch (e) {
 				console.error('Failed to restore settings from URL:', e);
 			}
@@ -40,7 +94,7 @@ export function useToolSettings<T extends Record<string, any>>(
 			if (stored) {
 				const parsed = JSON.parse(stored);
 				track('settings_restore', { tool: slug, source: 'localStorage' });
-				return { ...defaultSettings, ...parsed };
+				return validate(parsed, defaultSettings);
 			}
 		} catch (e) {
 			console.error('Failed to restore settings from localStorage:', e);
@@ -69,9 +123,7 @@ export function useToolSettings<T extends Record<string, any>>(
 
 	// 共有用URLを生成する
 	const generateShareUrl = () => {
-		const encoded = btoa(
-			unescape(encodeURIComponent(JSON.stringify(settings))),
-		);
+		const encoded = encodeUtf8Base64(JSON.stringify(settings));
 		const url = new URL(window.location.href);
 		url.searchParams.set('settings', encoded);
 		return url.toString();

--- a/src/lib/tools/csv-editor.ts
+++ b/src/lib/tools/csv-editor.ts
@@ -5,6 +5,31 @@ export interface CsvData {
 	colCount: number;
 }
 
+const VALID_DELIMITERS = [',', '\t', ';', '|'];
+
+export interface CsvEditorSettings {
+	delimiter: string;
+	hasHeader: boolean;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeCsvEditorSettings(
+	value: unknown,
+	defaults: CsvEditorSettings,
+): CsvEditorSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const delimiter =
+		typeof v.delimiter === 'string' && VALID_DELIMITERS.includes(v.delimiter)
+			? v.delimiter
+			: defaults.delimiter;
+	const hasHeader =
+		typeof v.hasHeader === 'boolean' ? v.hasHeader : defaults.hasHeader;
+	return { delimiter, hasHeader };
+}
+
 // Excel-style column labels (A, B, ..., Z, AA, AB...)
 export function getColumnLabel(index: number): string {
 	let label = '';

--- a/src/lib/tools/json-formatter.ts
+++ b/src/lib/tools/json-formatter.ts
@@ -2,11 +2,34 @@
 
 export type IndentType = '2' | '4' | 'tab';
 
+const VALID_INDENT_TYPES: readonly IndentType[] = ['2', '4', 'tab'];
+
 export interface FormatResult {
 	success: boolean;
 	output: string;
 	error?: string;
 	errorPosition?: number;
+}
+
+export interface JsonFormatterSettings {
+	indent: IndentType;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeJsonFormatterSettings(
+	value: unknown,
+	defaults: JsonFormatterSettings,
+): JsonFormatterSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const indent =
+		typeof v.indent === 'string' &&
+		(VALID_INDENT_TYPES as readonly string[]).includes(v.indent)
+			? (v.indent as IndentType)
+			: defaults.indent;
+	return { indent };
 }
 
 function getIndentString(indent: IndentType): string | number {

--- a/src/lib/tools/regex-tester.ts
+++ b/src/lib/tools/regex-tester.ts
@@ -12,6 +12,46 @@ export interface RegexResult {
 	replacedText?: string;
 }
 
+const MAX_PATTERN_LENGTH = 1000;
+const MAX_REPLACEMENT_LENGTH = 2000;
+const VALID_FLAGS_PATTERN = /^[dgimsuvy]*$/;
+
+export interface RegexTesterSettings {
+	pattern: string;
+	flags: string;
+	showReplace: boolean;
+	replacement: string;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeRegexTesterSettings(
+	value: unknown,
+	defaults: RegexTesterSettings,
+): RegexTesterSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const pattern =
+		typeof v.pattern === 'string' && v.pattern.length <= MAX_PATTERN_LENGTH
+			? v.pattern
+			: defaults.pattern;
+	const flags =
+		typeof v.flags === 'string' &&
+		v.flags.length <= 6 &&
+		VALID_FLAGS_PATTERN.test(v.flags)
+			? v.flags
+			: defaults.flags;
+	const showReplace =
+		typeof v.showReplace === 'boolean' ? v.showReplace : defaults.showReplace;
+	const replacement =
+		typeof v.replacement === 'string' &&
+		v.replacement.length <= MAX_REPLACEMENT_LENGTH
+			? v.replacement
+			: defaults.replacement;
+	return { pattern, flags, showReplace, replacement };
+}
+
 export const COMMON_PATTERNS = [
 	{
 		label: 'メールアドレス',

--- a/src/lib/tools/regex-tester.ts
+++ b/src/lib/tools/regex-tester.ts
@@ -16,6 +16,11 @@ const MAX_PATTERN_LENGTH = 1000;
 const MAX_REPLACEMENT_LENGTH = 2000;
 const VALID_FLAGS_PATTERN = /^[dgimsuvy]*$/;
 
+// 各フラグ文字が重複していないかを検証する（例: "gg" は new RegExp で SyntaxError になる）
+function hasUniqueFlags(flags: string): boolean {
+	return new Set(flags).size === flags.length;
+}
+
 export interface RegexTesterSettings {
 	pattern: string;
 	flags: string;
@@ -39,7 +44,8 @@ export function sanitizeRegexTesterSettings(
 	const flags =
 		typeof v.flags === 'string' &&
 		v.flags.length <= 6 &&
-		VALID_FLAGS_PATTERN.test(v.flags)
+		VALID_FLAGS_PATTERN.test(v.flags) &&
+		hasUniqueFlags(v.flags)
 			? v.flags
 			: defaults.flags;
 	const showReplace =

--- a/src/lib/tools/sql-formatter.ts
+++ b/src/lib/tools/sql-formatter.ts
@@ -10,6 +10,65 @@ export interface SqlFormatOptions {
 	compress: boolean;
 }
 
+const VALID_DIALECTS: readonly SqlDialect[] = [
+	'sql',
+	'mysql',
+	'postgresql',
+	'tsql',
+	'plsql',
+];
+const VALID_INDENT_STYLES: readonly IndentStyle[] = [
+	'2spaces',
+	'4spaces',
+	'tabs',
+];
+const VALID_LAYOUTS = ['horizontal', 'vertical'] as const;
+type Layout = (typeof VALID_LAYOUTS)[number];
+
+export interface SqlFormatterSettings {
+	autoFormat: boolean;
+	dialect: SqlDialect;
+	indent: IndentStyle;
+	uppercase: boolean;
+	compress: boolean;
+	isExpanded: boolean;
+	layout: Layout;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeSqlFormatterSettings(
+	value: unknown,
+	defaults: SqlFormatterSettings,
+): SqlFormatterSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const bool = (raw: unknown, fallback: boolean) =>
+		typeof raw === 'boolean' ? raw : fallback;
+	return {
+		autoFormat: bool(v.autoFormat, defaults.autoFormat),
+		dialect:
+			typeof v.dialect === 'string' &&
+			(VALID_DIALECTS as readonly string[]).includes(v.dialect)
+				? (v.dialect as SqlDialect)
+				: defaults.dialect,
+		indent:
+			typeof v.indent === 'string' &&
+			(VALID_INDENT_STYLES as readonly string[]).includes(v.indent)
+				? (v.indent as IndentStyle)
+				: defaults.indent,
+		uppercase: bool(v.uppercase, defaults.uppercase),
+		compress: bool(v.compress, defaults.compress),
+		isExpanded: bool(v.isExpanded, defaults.isExpanded),
+		layout:
+			typeof v.layout === 'string' &&
+			(VALID_LAYOUTS as readonly string[]).includes(v.layout)
+				? (v.layout as Layout)
+				: defaults.layout,
+	};
+}
+
 export function formatSql(
 	sql: string,
 	options: SqlFormatOptions,

--- a/src/lib/tools/tax.ts
+++ b/src/lib/tools/tax.ts
@@ -109,6 +109,61 @@ export const TAX_RATE_HISTORY: TaxRateEntry[] = [
 	},
 ];
 
+const VALID_DIRECTIONS: readonly TaxCalcInput['direction'][] = [
+	'exclusive-to-inclusive',
+	'inclusive-to-exclusive',
+];
+const VALID_ROUNDING_MODES: readonly RoundingMode[] = [
+	'floor',
+	'round',
+	'ceil',
+];
+const VALID_MODES = ['single', 'invoice'] as const;
+type TaxCalcMode = (typeof VALID_MODES)[number];
+// TAX_RATE_HISTORY からUI選択肢のrateSelection値（例: '10' '8-reduced'）を導出する
+const VALID_RATE_SELECTIONS: readonly string[] = TAX_RATE_HISTORY.map(
+	(entry) => (entry.reduced ? `${entry.rate}-reduced` : `${entry.rate}`),
+);
+
+export interface TaxCalcSettings {
+	mode: TaxCalcMode;
+	direction: TaxCalcInput['direction'];
+	rateSelection: string;
+	rounding: RoundingMode;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeTaxCalcSettings(
+	value: unknown,
+	defaults: TaxCalcSettings,
+): TaxCalcSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const mode =
+		typeof v.mode === 'string' &&
+		(VALID_MODES as readonly string[]).includes(v.mode)
+			? (v.mode as TaxCalcMode)
+			: defaults.mode;
+	const direction =
+		typeof v.direction === 'string' &&
+		(VALID_DIRECTIONS as readonly string[]).includes(v.direction)
+			? (v.direction as TaxCalcInput['direction'])
+			: defaults.direction;
+	const rateSelection =
+		typeof v.rateSelection === 'string' &&
+		VALID_RATE_SELECTIONS.includes(v.rateSelection)
+			? v.rateSelection
+			: defaults.rateSelection;
+	const rounding =
+		typeof v.rounding === 'string' &&
+		(VALID_ROUNDING_MODES as readonly string[]).includes(v.rounding)
+			? (v.rounding as RoundingMode)
+			: defaults.rounding;
+	return { mode, direction, rateSelection, rounding };
+}
+
 /** 全角数字を半角数字に変換する */
 function toHalfWidthDigits(input: string): string {
 	return input.replace(/[０-９]/g, (ch) =>

--- a/src/lib/tools/uuid.ts
+++ b/src/lib/tools/uuid.ts
@@ -31,6 +31,40 @@ export function validateCount(count: number): string | null {
 	return null;
 }
 
+export interface UuidSettings {
+	kind: IdKind;
+	count: number;
+	uppercase: boolean;
+	hyphens: boolean;
+}
+
+// 共有URL/localStorage経由の復元値を検証し、不正値はデフォルトへフォールバックする
+export function sanitizeUuidSettings(
+	value: unknown,
+	defaults: UuidSettings,
+): UuidSettings {
+	if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+		return defaults;
+	}
+	const v = value as Record<string, unknown>;
+	const kind =
+		typeof v.kind === 'string' &&
+		(GENERATABLE_ID_KINDS as readonly string[]).includes(v.kind)
+			? (v.kind as IdKind)
+			: defaults.kind;
+	const count =
+		typeof v.count === 'number' &&
+		Number.isInteger(v.count) &&
+		v.count >= MIN_COUNT &&
+		v.count <= MAX_COUNT
+			? v.count
+			: defaults.count;
+	const uppercase =
+		typeof v.uppercase === 'boolean' ? v.uppercase : defaults.uppercase;
+	const hyphens = typeof v.hyphens === 'boolean' ? v.hyphens : defaults.hyphens;
+	return { kind, count, uppercase, hyphens };
+}
+
 function getRandomBytes(length: number): Uint8Array {
 	const bytes = new Uint8Array(length);
 	crypto.getRandomValues(bytes);

--- a/tests/e2e/tool-settings-share.spec.ts
+++ b/tests/e2e/tool-settings-share.spec.ts
@@ -26,7 +26,7 @@ const tools = [
 		slug: 'image-compress',
 		settings: {
 			format: 'webp',
-			quality: 72,
+			quality: 0.72,
 			resizeKind: 'long-edge',
 			resizeValue: 1024,
 			useTargetSize: false,

--- a/tests/unit/tool-settings-validation.test.ts
+++ b/tests/unit/tool-settings-validation.test.ts
@@ -1,0 +1,386 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/tool-settings-validation.test.ts
+//
+// 共有URL/localStorage経由で復元される設定値の検証（型不一致・配列・null・範囲外の
+// 各ケースでデフォルトへフォールバックすること）を対象とする純粋ロジックのテスト。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { sanitizeCompressSettings } from '../../src/components/image-compress/settingsValidation.ts';
+import { sanitizeConvertSettings } from '../../src/components/image-convert/settingsValidation.ts';
+import { sanitizeCsvEditorSettings } from '../../src/lib/tools/csv-editor.ts';
+import { sanitizeJsonFormatterSettings } from '../../src/lib/tools/json-formatter.ts';
+import { sanitizeRegexTesterSettings } from '../../src/lib/tools/regex-tester.ts';
+import { sanitizeSqlFormatterSettings } from '../../src/lib/tools/sql-formatter.ts';
+import { sanitizeTaxCalcSettings } from '../../src/lib/tools/tax.ts';
+import { sanitizeUuidSettings } from '../../src/lib/tools/uuid.ts';
+
+// ---------------------------------------------------------------------------
+// uuid (id-generator)
+// ---------------------------------------------------------------------------
+
+const uuidDefaults = {
+	kind: 'uuid-v4' as const,
+	count: 10,
+	uppercase: false,
+	hyphens: true,
+};
+
+test('sanitizeUuidSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeUuidSettings(
+		{ kind: 'ulid', count: 50, uppercase: true, hyphens: false },
+		uuidDefaults,
+	);
+	assert.deepEqual(result, {
+		kind: 'ulid',
+		count: 50,
+		uppercase: true,
+		hyphens: false,
+	});
+});
+
+test('sanitizeUuidSettings: null/配列/非オブジェクトはデフォルトへフォールバックする', () => {
+	assert.deepEqual(sanitizeUuidSettings(null, uuidDefaults), uuidDefaults);
+	assert.deepEqual(sanitizeUuidSettings([1, 2, 3], uuidDefaults), uuidDefaults);
+	assert.deepEqual(sanitizeUuidSettings('uuid-v4', uuidDefaults), uuidDefaults);
+});
+
+test('sanitizeUuidSettings: 未知のkind・範囲外のcountはデフォルトへフォールバックする', () => {
+	const result = sanitizeUuidSettings(
+		{ kind: 'not-a-kind', count: 999999, uppercase: 'yes', hyphens: null },
+		uuidDefaults,
+	);
+	assert.deepEqual(result, uuidDefaults);
+});
+
+test('sanitizeUuidSettings: countの型不一致（文字列・小数）はデフォルトへフォールバックする', () => {
+	assert.equal(
+		sanitizeUuidSettings({ count: '10' }, uuidDefaults).count,
+		uuidDefaults.count,
+	);
+	assert.equal(
+		sanitizeUuidSettings({ count: 1.5 }, uuidDefaults).count,
+		uuidDefaults.count,
+	);
+	assert.equal(
+		sanitizeUuidSettings({ count: 0 }, uuidDefaults).count,
+		uuidDefaults.count,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// json-formatter
+// ---------------------------------------------------------------------------
+
+test('sanitizeJsonFormatterSettings: 許可された値のみ採用する', () => {
+	const defaults = { indent: '2' as const };
+	assert.deepEqual(sanitizeJsonFormatterSettings({ indent: 'tab' }, defaults), {
+		indent: 'tab',
+	});
+	assert.deepEqual(
+		sanitizeJsonFormatterSettings({ indent: 8 }, defaults),
+		defaults,
+	);
+	assert.deepEqual(
+		sanitizeJsonFormatterSettings({ indent: ['2'] }, defaults),
+		defaults,
+	);
+	assert.deepEqual(sanitizeJsonFormatterSettings(null, defaults), defaults);
+});
+
+// ---------------------------------------------------------------------------
+// sql-formatter
+// ---------------------------------------------------------------------------
+
+const sqlDefaults = {
+	autoFormat: true,
+	dialect: 'sql' as const,
+	indent: '2spaces' as const,
+	uppercase: true,
+	compress: false,
+	isExpanded: false,
+	layout: 'horizontal' as const,
+};
+
+test('sanitizeSqlFormatterSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeSqlFormatterSettings(
+		{
+			autoFormat: false,
+			dialect: 'postgresql',
+			indent: 'tabs',
+			uppercase: false,
+			compress: true,
+			isExpanded: true,
+			layout: 'vertical',
+		},
+		sqlDefaults,
+	);
+	assert.deepEqual(result, {
+		autoFormat: false,
+		dialect: 'postgresql',
+		indent: 'tabs',
+		uppercase: false,
+		compress: true,
+		isExpanded: true,
+		layout: 'vertical',
+	});
+});
+
+test('sanitizeSqlFormatterSettings: 未知のdialect/indent/layoutと型不一致のbooleanはデフォルトへフォールバックする', () => {
+	const result = sanitizeSqlFormatterSettings(
+		{
+			autoFormat: 'true',
+			dialect: 'oracle',
+			indent: '8spaces',
+			uppercase: 1,
+			compress: null,
+			isExpanded: [],
+			layout: 'diagonal',
+		},
+		sqlDefaults,
+	);
+	assert.deepEqual(result, sqlDefaults);
+});
+
+test('sanitizeSqlFormatterSettings: 配列/nullはデフォルトへフォールバックする', () => {
+	assert.deepEqual(sanitizeSqlFormatterSettings([], sqlDefaults), sqlDefaults);
+	assert.deepEqual(
+		sanitizeSqlFormatterSettings(null, sqlDefaults),
+		sqlDefaults,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// csv-editor
+// ---------------------------------------------------------------------------
+
+const csvDefaults = { delimiter: ',', hasHeader: true };
+
+test('sanitizeCsvEditorSettings: 許可された区切り文字のみ採用する', () => {
+	assert.deepEqual(
+		sanitizeCsvEditorSettings(
+			{ delimiter: '\t', hasHeader: false },
+			csvDefaults,
+		),
+		{ delimiter: '\t', hasHeader: false },
+	);
+	assert.deepEqual(
+		sanitizeCsvEditorSettings({ delimiter: '\n' }, csvDefaults),
+		csvDefaults,
+	);
+	assert.deepEqual(
+		sanitizeCsvEditorSettings({ delimiter: ['|'] }, csvDefaults),
+		csvDefaults,
+	);
+	assert.deepEqual(sanitizeCsvEditorSettings(null, csvDefaults), csvDefaults);
+});
+
+// ---------------------------------------------------------------------------
+// regex-tester
+// ---------------------------------------------------------------------------
+
+const regexDefaults = {
+	pattern: '\\d{3}-\\d{4}',
+	flags: 'g',
+	showReplace: false,
+	replacement: '',
+};
+
+test('sanitizeRegexTesterSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeRegexTesterSettings(
+		{
+			pattern: '^[a-z]+$',
+			flags: 'gi',
+			showReplace: true,
+			replacement: 'x',
+		},
+		regexDefaults,
+	);
+	assert.deepEqual(result, {
+		pattern: '^[a-z]+$',
+		flags: 'gi',
+		showReplace: true,
+		replacement: 'x',
+	});
+});
+
+test('sanitizeRegexTesterSettings: 不正なflags・過長なpatternはデフォルトへフォールバックする', () => {
+	assert.equal(
+		sanitizeRegexTesterSettings({ flags: 'z' }, regexDefaults).flags,
+		regexDefaults.flags,
+	);
+	assert.equal(
+		sanitizeRegexTesterSettings({ flags: ['g'] }, regexDefaults).flags,
+		regexDefaults.flags,
+	);
+	assert.equal(
+		sanitizeRegexTesterSettings({ pattern: 'a'.repeat(1001) }, regexDefaults)
+			.pattern,
+		regexDefaults.pattern,
+	);
+});
+
+test('sanitizeRegexTesterSettings: 配列/nullはデフォルトへフォールバックする', () => {
+	assert.deepEqual(
+		sanitizeRegexTesterSettings([], regexDefaults),
+		regexDefaults,
+	);
+	assert.deepEqual(
+		sanitizeRegexTesterSettings(null, regexDefaults),
+		regexDefaults,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// tax
+// ---------------------------------------------------------------------------
+
+const taxDefaults = {
+	mode: 'single' as const,
+	direction: 'exclusive-to-inclusive' as const,
+	rateSelection: '10',
+	rounding: 'floor' as const,
+};
+
+test('sanitizeTaxCalcSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeTaxCalcSettings(
+		{
+			mode: 'invoice',
+			direction: 'inclusive-to-exclusive',
+			rateSelection: '8-reduced',
+			rounding: 'ceil',
+		},
+		taxDefaults,
+	);
+	assert.deepEqual(result, {
+		mode: 'invoice',
+		direction: 'inclusive-to-exclusive',
+		rateSelection: '8-reduced',
+		rounding: 'ceil',
+	});
+});
+
+test('sanitizeTaxCalcSettings: 未定義のrateSelection・型不一致はデフォルトへフォールバックする（誤った税額表示の防止）', () => {
+	const result = sanitizeTaxCalcSettings(
+		{
+			mode: 'batch',
+			direction: 'sideways',
+			rateSelection: '999',
+			rounding: 'nearest',
+		},
+		taxDefaults,
+	);
+	assert.deepEqual(result, taxDefaults);
+});
+
+test('sanitizeTaxCalcSettings: 配列/nullはデフォルトへフォールバックする', () => {
+	assert.deepEqual(sanitizeTaxCalcSettings([], taxDefaults), taxDefaults);
+	assert.deepEqual(sanitizeTaxCalcSettings(null, taxDefaults), taxDefaults);
+});
+
+// ---------------------------------------------------------------------------
+// image-compress
+// ---------------------------------------------------------------------------
+
+const compressDefaults = {
+	format: 'keep' as const,
+	quality: 0.8,
+	resizeKind: 'none' as const,
+	resizeValue: 1920,
+	useTargetSize: false,
+	targetKB: 500,
+	background: '#ffffff',
+};
+
+test('sanitizeCompressSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeCompressSettings(
+		{
+			format: 'webp',
+			quality: 0.5,
+			resizeKind: 'max-width',
+			resizeValue: 800,
+			useTargetSize: true,
+			targetKB: 200,
+			background: '#000000',
+		},
+		compressDefaults,
+	);
+	assert.deepEqual(result, {
+		format: 'webp',
+		quality: 0.5,
+		resizeKind: 'max-width',
+		resizeValue: 800,
+		useTargetSize: true,
+		targetKB: 200,
+		background: '#000000',
+	});
+});
+
+test('sanitizeCompressSettings: 範囲外の品質・不正な背景色・未知のformatはデフォルトへフォールバックする', () => {
+	const result = sanitizeCompressSettings(
+		{
+			format: 'gif',
+			quality: 5,
+			resizeKind: 'diagonal',
+			resizeValue: -100,
+			useTargetSize: 'true',
+			targetKB: Number.NaN,
+			background: 'javascript:alert(1)',
+		},
+		compressDefaults,
+	);
+	assert.deepEqual(result, compressDefaults);
+});
+
+test('sanitizeCompressSettings: 配列/nullはデフォルトへフォールバックする', () => {
+	assert.deepEqual(
+		sanitizeCompressSettings([], compressDefaults),
+		compressDefaults,
+	);
+	assert.deepEqual(
+		sanitizeCompressSettings(null, compressDefaults),
+		compressDefaults,
+	);
+});
+
+// ---------------------------------------------------------------------------
+// image-convert
+// ---------------------------------------------------------------------------
+
+const convertDefaults = {
+	target: 'jpeg' as const,
+	quality: 85,
+	exif: 'strip' as const,
+	background: '#ffffff',
+};
+
+test('sanitizeConvertSettings: 正常値はそのまま採用する', () => {
+	const result = sanitizeConvertSettings(
+		{ target: 'avif', quality: 60, exif: 'keep', background: '#123abc' },
+		convertDefaults,
+	);
+	assert.deepEqual(result, {
+		target: 'avif',
+		quality: 60,
+		exif: 'keep',
+		background: '#123abc',
+	});
+});
+
+test('sanitizeConvertSettings: 範囲外の品質・未知のtarget/exif・不正な背景色はデフォルトへフォールバックする', () => {
+	const result = sanitizeConvertSettings(
+		{ target: 'bmp', quality: 200, exif: 'rotate', background: 'red' },
+		convertDefaults,
+	);
+	assert.deepEqual(result, convertDefaults);
+});
+
+test('sanitizeConvertSettings: 配列/nullはデフォルトへフォールバックする', () => {
+	assert.deepEqual(
+		sanitizeConvertSettings([], convertDefaults),
+		convertDefaults,
+	);
+	assert.deepEqual(
+		sanitizeConvertSettings(null, convertDefaults),
+		convertDefaults,
+	);
+});

--- a/tests/unit/tool-settings-validation.test.ts
+++ b/tests/unit/tool-settings-validation.test.ts
@@ -219,6 +219,17 @@ test('sanitizeRegexTesterSettings: 不正なflags・過長なpatternはデフォ
 	);
 });
 
+test('sanitizeRegexTesterSettings: 重複フラグ（例: "gg"）はnew RegExpでSyntaxErrorになるためデフォルトへフォールバックする', () => {
+	assert.equal(
+		sanitizeRegexTesterSettings({ flags: 'gg' }, regexDefaults).flags,
+		regexDefaults.flags,
+	);
+	assert.equal(
+		sanitizeRegexTesterSettings({ flags: 'gimi' }, regexDefaults).flags,
+		regexDefaults.flags,
+	);
+});
+
 test('sanitizeRegexTesterSettings: 配列/nullはデフォルトへフォールバックする', () => {
 	assert.deepEqual(
 		sanitizeRegexTesterSettings([], regexDefaults),


### PR DESCRIPTION
taskId: `3acdfd36033681b6a2bada0c2bba019a`
実行ID: `triage-impl-20260805-0611`

## 概要

`useToolSettings` が URL クエリの `settings` を型検証なしでスプレッド展開し、直後に localStorage へ書き戻していたため、細工した共有URLを一度開くと不正な設定が localStorage に永続化し続ける問題を修正した（[Notionタスク](https://app.notion.com/p/3acdfd36033681b6a2bada0c2bba019a)）。

対象10ツール: image-compress / image-convert / image-mosaic / image-text / csv-editor / uuid / json-formatter / regex-tester / sql-formatter / tax

## 変更内容

- `useToolSettings` に第3引数 `validate` を追加。省略時は既知キー・型一致のみを許容する既定検証にフォールバックする（`image-text` / `image-mosaic` は `isExpanded: boolean` のみのためこの既定検証で対応、コード変更なし）。
- 残り8ツール（uuid, json-formatter, image-compress, image-convert, csv-editor, regex-tester, sql-formatter, tax）に allowlist・数値範囲・列挙値を検証する `sanitize*Settings` 関数を追加し、各コンポーネントから `validate` として渡すよう変更。
- 非推奨の `escape`/`unescape` を `TextEncoder`/`TextDecoder` ベースの Base64⇄UTF-8 変換に置換。

## 受け入れ基準への対応状況

- [x] 不正な `settings` パラメータでデフォルト値にフォールバックする — 各 `sanitize*Settings` が非オブジェクト/配列/nullや型不一致・範囲外の値を検出しデフォルトへフォールバック
- [x] 不正値が localStorage に永続化されない — 検証後の値のみを初期状態にセットし、以降の永続化はその状態を書き込むため不正値は保存されない
- [x] 10ツールすべてに検証を定義 — 8ツールは専用の `sanitize*Settings`、残り2ツール（image-text, image-mosaic）はフックの既定検証（型一致のみのboolean）でカバー
- [x] 単体テスト（型不一致・配列・null・範囲外）追加 — `tests/unit/tool-settings-validation.test.ts`

## 検証

- `npm run test:unit` — 966 tests pass（新規21件含む）
- `npm run check`（astro check + biome） — 0 errors（既存の無関係な警告のみ）
- `npm run build` — 成功


---
_Generated by [Claude Code](https://claude.ai/code/session_01J1vr5GbjKDuqr8xRvcmJGZ)_