### PR TITLE
fix(zipcode): 一括変換の行数表示と実行時の空行判定基準を統一

### DIFF
--- a/src/components/zipcode/BulkConvertPanel.tsx
+++ b/src/components/zipcode/BulkConvertPanel.tsx
@@ -19,6 +19,7 @@ import {
 	type BulkResult,
 	bulkConvert,
 	MAX_BULK_LINES,
+	splitBulkLines,
 } from '@/lib/tools/zipcode';
 import { fetchZipChunk } from './fetchChunk';
 
@@ -50,12 +51,11 @@ export function BulkConvertPanel({ onRun }: { onRun: () => void }) {
 	const [converting, setConverting] = useState(false);
 	const [progress, setProgress] = useState({ done: 0, total: 0 });
 
-	const lineCount =
-		text === '' ? 0 : text.split(/\r?\n/).filter(Boolean).length;
+	const lineCount = text === '' ? 0 : splitBulkLines(text).length;
 	const overLimit = lineCount > MAX_BULK_LINES;
 
 	const handleConvert = useCallback(async () => {
-		const lines = text.split(/\r?\n/).filter((l) => l.trim() !== '');
+		const lines = splitBulkLines(text);
 		if (lines.length === 0 || lines.length > MAX_BULK_LINES) return;
 		setConverting(true);
 		setResults(null);

--- a/src/lib/tools/zipcode.ts
+++ b/src/lib/tools/zipcode.ts
@@ -69,6 +69,14 @@ function extractZipFromLine(line: string): string | null {
 	return null;
 }
 
+/**
+ * 一括変換対象のテキストを行に分解する（空白のみの行は除外）。
+ * 行数表示・上限判定・実際の変換対象で必ず同じ結果になるよう、分割基準をここに一元化する。
+ */
+export function splitBulkLines(text: string): string[] {
+	return text.split(/\r?\n/).filter((l) => l.trim() !== '');
+}
+
 /** 複数行テキストを行ごとに分解し、各行の抽出結果を返す（空行も保持） */
 export function extractZipsFromLines(
 	text: string,

--- a/tests/unit/zipcode.test.ts
+++ b/tests/unit/zipcode.test.ts
@@ -9,7 +9,9 @@ import {
 	type FetchChunk,
 	formatAddress,
 	lookupZip,
+	MAX_BULK_LINES,
 	normalizeZip,
+	splitBulkLines,
 	type ZipRecord,
 } from '../../src/lib/tools/zipcode.ts';
 
@@ -58,6 +60,51 @@ test('normalizeZip: 不正入力は null', () => {
 	assert.equal(normalizeZip('12345678'), null);
 	assert.equal(normalizeZip('abcdefg'), null);
 	assert.equal(normalizeZip('100-000a'), null);
+});
+
+// ---------------------------------------------------------------------------
+// splitBulkLines
+// ---------------------------------------------------------------------------
+
+test('splitBulkLines: 空白のみの行を除外する（行数表示と実行時の判定基準を統一）', () => {
+	assert.deepEqual(splitBulkLines('100-0001\n \n0600000\n'), [
+		'100-0001',
+		'0600000',
+	]);
+	assert.deepEqual(splitBulkLines('100-0001\n　\n0600000'), [
+		'100-0001',
+		'0600000',
+	]); // 全角空白のみの行も除外
+});
+
+test('splitBulkLines: 末尾改行の有無で件数が変わらない', () => {
+	const withTrailingNewline = splitBulkLines('100-0001\n0600000\n');
+	const withoutTrailingNewline = splitBulkLines('100-0001\n0600000');
+	assert.deepEqual(withTrailingNewline, withoutTrailingNewline);
+	assert.equal(withTrailingNewline.length, 2);
+});
+
+test('splitBulkLines: 上限ちょうどの行数は上限を超えない', () => {
+	const text = Array.from({ length: MAX_BULK_LINES }, (_, i) => `${i}`).join(
+		'\n',
+	);
+	assert.equal(splitBulkLines(text).length, MAX_BULK_LINES);
+});
+
+test('splitBulkLines: 上限+1件は上限を超える', () => {
+	const text = Array.from(
+		{ length: MAX_BULK_LINES + 1 },
+		(_, i) => `${i}`,
+	).join('\n');
+	assert.equal(splitBulkLines(text).length, MAX_BULK_LINES + 1);
+});
+
+test('splitBulkLines: 空白のみの行が混在しても上限判定が変換対象と一致する', () => {
+	// 上限ちょうどの実データ行に空白のみの行を1つ挟んでも、実質件数は上限のまま
+	const dataLines = Array.from({ length: MAX_BULK_LINES }, (_, i) => `${i}`);
+	dataLines.splice(1, 0, '   '); // 空白のみの行を混入
+	const text = dataLines.join('\n');
+	assert.equal(splitBulkLines(text).length, MAX_BULK_LINES);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
taskId: `3acdfd3603368182af3ade08b996c5b4`
実行ID: `triage-impl-20260806-0615`

## 概要

`BulkConvertPanel.tsx` にて、行数表示・上限判定（`filter(Boolean)`）と実際の変換対象（`filter((l) => l.trim() !== '')`）とで空行の除外基準が異なっていた。空白のみの行（Excelの列コピー由来など）が混ざると、実質件数が上限（`MAX_BULK_LINES`）以下でも「上限を超えています」と表示され、変換ボタンが `disabled` のままになる不具合があった。

## 変更内容

- `src/lib/tools/zipcode.ts` に純粋関数 `splitBulkLines(text: string): string[]` を追加し、行分割・空白のみの行除外の基準を一箇所に統一。
- `BulkConvertPanel.tsx` の行数表示（`lineCount`）と実行時分割（`handleConvert`内の`lines`）の両方をこの関数に置き換え、判定基準の再乖離を構造的に防止。
- スコープ補足に従い、`bulkConvert` への AbortSignal 追加は対象外（別タスク）。

## 受け入れ基準への対応状況

1. ✅ 行数カウントの判定基準が入力検証時と実行時で一致している（空行・末尾改行の扱いを含む）— `splitBulkLines` に一元化
2. ✅ 上限ちょうど・上限＋1・末尾改行あり・空行混在の各ケースを検証する単体テストを `tests/unit/zipcode.test.ts` に追加
3. ✅ 上限内の入力（空白のみの行を含む）が変換不可にならない
4. ✅ lint / test / build が成功する

## 検証結果

- `npm run test:unit`: 972 pass / 0 fail（zipcode関連の新規テスト5件含む）
- `npm run lint`: exit 0（既存の無関係な14件の警告のみ、biomeエラーなし）
- `npm run check`: 0 errors
- `npm run build`: 成功（101ページビルド）

---
_Generated by [Claude Code](https://claude.ai/code/session_01BKUSBV51GwGLH3LZqeoCn6)_