### PR TITLE
fix(zenkaku-hankaku): restore switch unchecked background contrast

### DIFF
--- a/src/components/tools/ZenkakuHankaku.tsx
+++ b/src/components/tools/ZenkakuHankaku.tsx
@@ -53,7 +53,6 @@ export default function ZenkakuHankaku() {
 						onCheckedChange={(checked) =>
 							setDirection(checked ? 'toZenkaku' : 'toHankaku')
 						}
-						className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-primary"
 					/>
 					<Label
 						className={`text-sm font-medium whitespace-nowrap transition-colors ${direction === 'toZenkaku' ? 'text-primary' : 'text-muted-foreground'}`}


### PR DESCRIPTION
## 課題

zenkaku-hankaku の変換方向 Switch が checked/unchecked どちらでも同じ `bg-primary` のため、トグル状態の背景色フィードバックがなかった（ラベル色だけが変化し、スイッチ自体の状態が分かりにくい）。

Notionタスク: 【DEBUG】zenkaku-hankaku: スイッチのトグル状態による背景色視覚フィードバックが不変

## 原因

`ZenkakuHankaku.tsx` の Switch が `className="data-[state=checked]:bg-primary data-[state=unchecked]:bg-primary"` で `src/components/ui/switch.tsx` のデフォルト（`unchecked=bg-input`）を上書きしていた。

## 変更内容

- `src/components/tools/ZenkakuHankaku.tsx`: Switch の redundant な `className` 上書きを削除し、`ui/switch.tsx` のデフォルト（`checked=bg-primary` / `unchecked=bg-input`）に戻した
- 変換ロジック（`src/lib/tools/zenkaku-hankaku.ts`）、`src/components/ui/switch.tsx` のデフォルト、他ツールへの変更なし（差分は `ZenkakuHankaku.tsx` の1ファイルのみ）

## 検証

**自動検証**
- [x] `ZenkakuHankaku.tsx` に `data-[state=unchecked]:bg-primary` が残っていない
- [x] 変換ロジック・他ファイルへの不要変更なし（`git diff` で1ファイル・1行削除のみ確認）
- [x] `npm run lint` 成功（exit 0。既存の `tests/e2e/webmcp.spec.ts` の non-null assertion 警告のみで、今回の変更とは無関係）
- [x] `npm run build` 成功

**要人間確認（未実施）**
- [ ] 実機で checked/unchecked のトラック色が明確に違うこと
- [ ] ダークモードでも識別可能なこと

---
_Generated by [Claude Code](https://claude.ai/code/session_015hasDpy3X1Mme4NdLisxDV)_