### PR TITLE
fix(json-formatter): correct error line after large-int placeholder

### DIFF
--- a/src/lib/tools/json-formatter.ts
+++ b/src/lib/tools/json-formatter.ts
@@ -131,6 +131,22 @@ function restoreLargeInts(output: string): string {
 	return output.replace(BIGINT_PLACEHOLDER_RE, '$1');
 }
 
+/**
+ * 構文エラー発生時、置換後文字列ではなく元入力を再度 JSON.parse して
+ * position を取得する。replaceLargeInts は大整数を有効なJSON文字列へ
+ * 置換するだけで構文構造は変えないため、置換後parseが失敗する箇所は
+ * 元入力でも同じ理由で失敗し、position が元入力のオフセットと一致する。
+ */
+function getOriginalErrorPosition(input: string): number | undefined {
+	try {
+		JSON.parse(input);
+		return undefined;
+	} catch (e) {
+		const match = (e as SyntaxError).message.match(/position (\d+)/i);
+		return match ? parseInt(match[1], 10) : undefined;
+	}
+}
+
 export function formatJson(
 	input: string,
 	indent: IndentType = '2',
@@ -145,13 +161,11 @@ export function formatJson(
 		return { success: true, output: restoreLargeInts(formatted) };
 	} catch (e) {
 		const error = e as SyntaxError;
-		const match = error.message.match(/position (\d+)/i);
-		const errorPosition = match ? parseInt(match[1], 10) : undefined;
 		return {
 			success: false,
 			output: input,
 			error: `JSON構文エラー: ${error.message}`,
-			errorPosition,
+			errorPosition: getOriginalErrorPosition(input),
 		};
 	}
 }

--- a/tests/unit/json-formatter.test.ts
+++ b/tests/unit/json-formatter.test.ts
@@ -123,6 +123,45 @@ test('formatJson: 配列内の大整数も精度を保持', async () => {
 });
 
 // ============================================================
+// formatJson: 大整数プレースホルダーによる errorPosition ズレ回帰テスト
+// ============================================================
+
+test('formatJson: 大整数を含む不正JSONでもエラー行が元入力基準になる', () => {
+	// 大整数の後にカンマ抜け → 元入力のposition 24でエラーになるはずが、
+	// 置換後文字列でposition取得すると余分に加算されたoffsetになっていた
+	const big = '9007199254740993';
+	const input = `{"big":${big} "next":1}`;
+	const result = formatJson(input);
+	assert.equal(result.success, false);
+	assert.equal(
+		result.errorPosition,
+		24,
+		`期待: 元入力基準のposition 24\n実際: ${result.errorPosition}`,
+	);
+});
+
+test('formatJson: 複数の大整数があってもエラー行が元入力基準になる', () => {
+	const input = `{"a":9007199254740993,"b":9007199254740994 "c":1}`;
+	const result = formatJson(input);
+	assert.equal(result.success, false);
+	// 元入力中で実際にエラーとなる位置（"c" の直前の空白の次）
+	const expectedPosition = input.indexOf('"c"');
+	assert.equal(
+		result.errorPosition,
+		expectedPosition,
+		`期待: ${expectedPosition}\n実際: ${result.errorPosition}`,
+	);
+});
+
+test('formatJson: 大整数なしの不正JSONは従来どおり正しいposition', () => {
+	const input = '{"a":1 "b":2}';
+	const result = formatJson(input);
+	assert.equal(result.success, false);
+	const expectedPosition = input.indexOf('"b"');
+	assert.equal(result.errorPosition, expectedPosition);
+});
+
+// ============================================================
 // minifyJson: 大整数精度保持
 // ============================================================
 


### PR DESCRIPTION
## 課題要約

`json-formatter` で MAX_SAFE_INTEGER を超える大整数を含む不正な JSON を整形しようとすると、エラー行番号・行ハイライトが実際の構文エラー位置より後ろにズレて表示される。

原因: `formatJson` / `minifyJson` は大整数を一時的な文字列プレースホルダー（`"__LOSSLESS_INT__{n}__END__"`）へ置換してから `JSON.parse` する。置換後は文字数が増えるため、置換後文字列に対する `JSON.parse` の失敗 `position` を、UI がそのまま元入力のオフセットとして扱うと、大整数以降の行番号がずれる。

Notionタスク: https://www.notion.so/3b4dfd3603368106a066e04cec80695a

## 設計判断

詳細設計書の採用方針2（元 input を再度 `JSON.parse` して position のみ取得する）を採用。

- `replaceLargeInts` は大整数を有効な JSON 文字列へ置換するだけで構文構造そのものは変えないため、置換後の parse が失敗する箇所は元入力でも同じ理由で失敗し、`position` が元入力のオフセットと一致する。
- エラーメッセージ本文は既存どおり置換後 parse のものを使用し、`errorPosition` のみ元入力の再 parse から取得するよう変更（UI 側のロジック・意味は変更なし）。
- 成功パス（`replaceLargeInts` → parse → stringify → `restoreLargeInts`）は無変更。
- `validateJson` は通常 parse のみで元々 position ズレの影響を受けないため変更なし。

## 変更ファイル一覧

- `src/lib/tools/json-formatter.ts`: `getOriginalErrorPosition` を追加し、`formatJson` の catch で使用
- `tests/unit/json-formatter.test.ts`: 回帰テストを3件追加（大整数+エラー、複数大整数+エラー、大整数なしの既存動作維持）

## 自動検証結果

- 再現ケース（大整数の後にカンマ抜け）でエラー位置が元入力基準の正しいオフセットと一致することを確認（`node --test tests/unit/json-formatter.test.ts` で新規3テストが pass）
- 大整数なしの不正 JSON のエラー位置は従来どおり変化なし（回帰テストで確認）
- 大整数の精度保持整形（成功パス）は既存テストがすべて pass のまま変更なし
- `npm run test:unit`: json-formatter 関連 20/20 pass。全体は 856件中 fail 28件だが、変更前の base ブランチ（`d558328`）でも同一の28件が fail することを確認済み（markdown/pdf/csv等、本修正と無関係の既存failure）
- `npm run lint`: exit code 0（`tests/e2e/webmcp.spec.ts` の non-null assertion 警告14件は既知の無関係警告、AGENTS.md記載どおり）
- `npm run build`: 成功

## 要人間確認（未実施）

- [ ] 実機ブラウザでの行ガターの赤ハイライト目視確認

## 残件

なし。スコープ内の修正は完了。

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01KmZDJoZbHuDdBJhiy1iPcj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KmZDJoZbHuDdBJhiy1iPcj)_