### PR TITLE
fix(dummy-data): use Japanese labels for CSV/TSV headers

### DIFF
--- a/src/components/tools/DummyDataGenerator.tsx
+++ b/src/components/tools/DummyDataGenerator.tsx
@@ -24,6 +24,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	type ExportFormat,
+	FIELD_LABELS,
 	type FieldType,
 	generateDummyData,
 	validateDummyDataInput,
@@ -40,18 +41,9 @@ interface FieldItem {
 	label: string;
 }
 
-const ALL_FIELDS: FieldItem[] = [
-	{ id: 'name', label: '氏名' },
-	{ id: 'kana', label: 'フリガナ' },
-	{ id: 'email', label: 'メールアドレス' },
-	{ id: 'phone', label: '電話番号' },
-	{ id: 'zipcode', label: '郵便番号' },
-	{ id: 'address', label: '住所' },
-	{ id: 'company', label: '会社名' },
-	{ id: 'department', label: '部署名' },
-	{ id: 'date', label: '日付' },
-	{ id: 'number', label: '数値' },
-];
+const ALL_FIELDS: FieldItem[] = (Object.keys(FIELD_LABELS) as FieldType[]).map(
+	(id) => ({ id, label: FIELD_LABELS[id] }),
+);
 
 export default function DummyDataGenerator() {
 	const { trackRunDebounced } = useToolAnalytics('dummy-data');

--- a/src/lib/tools/dummy-data.ts
+++ b/src/lib/tools/dummy-data.ts
@@ -18,6 +18,20 @@ export interface FieldConfig {
 
 export type ExportFormat = 'json' | 'csv' | 'tsv';
 
+// CSV/TSVヘッダー用の日本語ラベル（正本）。JSON出力のキーは英語IDのまま維持する。
+export const FIELD_LABELS: Record<FieldType, string> = {
+	name: '氏名',
+	kana: 'フリガナ',
+	email: 'メールアドレス',
+	phone: '電話番号',
+	zipcode: '郵便番号',
+	address: '住所',
+	company: '会社名',
+	department: '部署名',
+	date: '日付',
+	number: '数値',
+};
+
 // --- Dictionaries ---
 const SURNAMES = [
 	{ kanji: '佐藤', kana: 'サトウ', romaji: 'sato' },
@@ -205,22 +219,21 @@ export function generateDummyData(
 	}
 
 	const separator = format === 'csv' ? ',' : '\t';
-	const header = fields.join(separator);
+	const escapeCell = (val: string) => {
+		if (
+			format === 'csv' &&
+			(val.includes(',') || val.includes('"') || val.includes('\n'))
+		) {
+			return `"${val.replace(/"/g, '""')}"`;
+		}
+		return val;
+	};
+
+	const header = fields.map((f) => escapeCell(FIELD_LABELS[f])).join(separator);
 
 	const body = rows
 		.map((r) =>
-			fields
-				.map((f) => {
-					const val = String(r[f] ?? '');
-					if (
-						format === 'csv' &&
-						(val.includes(',') || val.includes('"') || val.includes('\n'))
-					) {
-						return `"${val.replace(/"/g, '""')}"`;
-					}
-					return val;
-				})
-				.join(separator),
+			fields.map((f) => escapeCell(String(r[f] ?? ''))).join(separator),
 		)
 		.join('\n');
 

--- a/tests/unit/dummy-data.test.ts
+++ b/tests/unit/dummy-data.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
+	FIELD_LABELS,
 	generateDummyData,
 	validateDummyDataInput,
 } from '../../src/lib/tools/dummy-data.ts';
@@ -33,4 +34,34 @@ test('generateDummyData: 正常系および範囲外件数でのエラー送出'
 	assert.throws(() => {
 		generateDummyData(['name'], 1001, 'json');
 	}, /1〜1000/);
+});
+
+test('generateDummyData: CSV/TSVヘッダーは日本語ラベル、JSONキーは英語IDのまま、列順はfields順', () => {
+	const fields = ['email', 'name', 'phone'] as const;
+
+	const csv = generateDummyData([...fields], 3, 'csv');
+	const csvHeader = csv.split('\n')[0];
+	assert.strictEqual(
+		csvHeader,
+		fields.map((f) => FIELD_LABELS[f]).join(','),
+		'CSVヘッダーはfields順の日本語ラベル',
+	);
+
+	const tsv = generateDummyData([...fields], 3, 'tsv');
+	const tsvHeader = tsv.split('\n')[0];
+	assert.strictEqual(
+		tsvHeader,
+		fields.map((f) => FIELD_LABELS[f]).join('\t'),
+		'TSVヘッダーはfields順の日本語ラベル',
+	);
+
+	const json = generateDummyData([...fields], 3, 'json');
+	const parsed = JSON.parse(json);
+	for (const row of parsed) {
+		assert.deepStrictEqual(
+			Object.keys(row),
+			[...fields],
+			'JSONのキーは英語IDのままfields順',
+		);
+	}
 });


### PR DESCRIPTION
## 課題
dummy-data ツールで CSV/TSV 出力すると、1行目ヘッダーが UI の日本語ラベル（氏名・メールアドレス等）ではなく内部 field ID（`name`, `email` 等）になっていた。日本語ファーストの方針と不一致だったため修正。

Notionタスク: https://app.notion.com/p/3b4dfd36033681b185fad7f341c90410

## 変更内容
- `src/lib/tools/dummy-data.ts` に `FIELD_LABELS: Record<FieldType, string>` を正本として追加
- CSV/TSV のヘッダー生成をラベルベースに変更（既存のCSVエスケープルールをヘッダーにも適用）
- `src/components/tools/DummyDataGenerator.tsx` の `ALL_FIELDS` ラベル定義を `FIELD_LABELS` からの生成に置き換え、二重定義を解消
- JSON 出力のオブジェクトキーは英語IDのまま変更なし
- ヘッダー言語トグル等の追加オプションは実装しない（YAGNI、要件外）

## 受け入れ基準
### 自動検証
- [x] CSV 先頭行が `氏名,メールアドレス,...` のような日本語ラベル
- [x] TSV も同様
- [x] JSON のキーは `"name"` 等の英語IDのまま
- [x] フィールド順が引数 `fields` 順
- [x] unit / lint / build 成功
  - `npm run test:unit` — 973 tests pass
  - `npm run lint` — 対象ファイルにエラーなし（既存の無関係な警告のみ残存）
  - `npm run check` — 0 errors
  - `npm run build` — 成功

### 要人間確認
- [ ] UIプレビュー（`/dummy-data`）の CSV/TSV 表示が日本語ヘッダーになっていることの目視確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01TAQoXc331vrbLegXhPJJJA)_