### PR TITLE
fix(wareki-converter): allow month-only input as year-level conversion

### DIFF
--- a/src/lib/tools/wareki-converter.ts
+++ b/src/lib/tools/wareki-converter.ts
@@ -392,6 +392,23 @@ function buildNotices(
 	return notices;
 }
 
+/**
+ * 月・日のどちらか一方のみが指定された場合の注記。この場合は月日を無視し、
+ * 年単位換算にフォールバックする（改元月・誕生日前後の曖昧さを避けるため）。
+ */
+function buildPartialMonthDayNotice(
+	hasMonth: boolean,
+	hasDay: boolean,
+): string | null {
+	if (hasMonth && !hasDay) {
+		return '月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。';
+	}
+	if (!hasMonth && hasDay) {
+		return '日のみの指定は無視し、年単位で換算しています。厳密な日付換算には月も指定してください。';
+	}
+	return null;
+}
+
 function emptyErrorResult(message: string): ConversionResult {
 	return {
 		westernYear: 0,
@@ -421,9 +438,6 @@ export function convertWesternYearToResult(
 
 	const hasMonth = birthMonth !== undefined;
 	const hasDay = birthDay !== undefined;
-	if (hasMonth !== hasDay) {
-		return emptyErrorResult('月と日は両方指定してください。');
-	}
 
 	if (hasMonth && hasDay) {
 		const month = birthMonth as number;
@@ -457,12 +471,15 @@ export function convertWesternYearToResult(
 
 	const eraCandidates = getEraCandidates(westernYear);
 	const age = calculateAge(westernYear, referenceDate);
+	const notices = buildNotices(westernYear, eraCandidates, age);
+	const partialNotice = buildPartialMonthDayNotice(hasMonth, hasDay);
+	if (partialNotice) notices.push(partialNotice);
 	return {
 		westernYear,
 		eraCandidates,
 		zodiac: getZodiac(westernYear),
 		age,
-		notices: buildNotices(westernYear, eraCandidates, age),
+		notices,
 	};
 }
 
@@ -618,9 +635,6 @@ export function convertWarekiToResult(
 
 	const hasMonth = birthMonth !== undefined;
 	const hasDay = birthDay !== undefined;
-	if (hasMonth !== hasDay) {
-		return emptyErrorResult('月と日は両方指定してください。');
-	}
 
 	if (hasMonth && hasDay) {
 		const month = birthMonth as number;

--- a/tests/unit/wareki-converter.test.ts
+++ b/tests/unit/wareki-converter.test.ts
@@ -558,24 +558,81 @@ test('年齢計算: 基準日はタイムゾーンに関わらず暦日として
 	assert.deepStrictEqual(fromDate, fromString);
 });
 
-// --- 回帰: 月・日の片側指定を禁止 ------------------------------------------
+// --- 回帰: 月・日の片側指定は年単位換算にフォールバックする -----------------
 
-test('月または日だけの指定はエラーになる', () => {
-	assert.strictEqual(
-		convertWesternYearToResult(2000, REF_DATE, 5, undefined).error,
-		'月と日は両方指定してください。',
+test('月のみ指定はエラーにならず、年単位換算＋noticeになる', () => {
+	const result = convertWesternYearToResult(2000, REF_DATE, 5, undefined);
+	assert.strictEqual(result.error, undefined);
+	assert.deepStrictEqual(
+		result.eraCandidates.map((c) => c.label),
+		getEraCandidates(2000).map((c) => c.label),
+		'月のみ指定は年単位候補と同じ結果になること',
 	);
-	assert.strictEqual(
-		convertWesternYearToResult(2000, REF_DATE, undefined, 15).error,
-		'月と日は両方指定してください。',
+	assert.strictEqual(result.age.kind, 'range', '月のみでは満年齢を確定しない');
+	assert.ok(
+		result.notices.includes(
+			'月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。',
+		),
 	);
-	assert.strictEqual(
-		convertWarekiToResult('reiwa', 6, REF_DATE, 5, undefined).error,
-		'月と日は両方指定してください。',
+});
+
+test('日のみ指定はエラーにならず、年単位換算＋noticeになる', () => {
+	const result = convertWesternYearToResult(2000, REF_DATE, undefined, 15);
+	assert.strictEqual(result.error, undefined);
+	assert.strictEqual(result.age.kind, 'range');
+	assert.ok(
+		result.notices.includes(
+			'日のみの指定は無視し、年単位で換算しています。厳密な日付換算には月も指定してください。',
+		),
 	);
-	assert.strictEqual(
-		convertWarekiToResult('reiwa', 6, REF_DATE, undefined, 15).error,
-		'月と日は両方指定してください。',
+});
+
+test('和暦→西暦でも月のみ・日のみ指定はエラーにならず年単位換算になる', () => {
+	const monthOnly = convertWarekiToResult('reiwa', 6, REF_DATE, 5, undefined);
+	assert.strictEqual(monthOnly.error, undefined);
+	assert.ok(
+		monthOnly.notices.includes(
+			'月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。',
+		),
+	);
+
+	const dayOnly = convertWarekiToResult('reiwa', 6, REF_DATE, undefined, 15);
+	assert.strictEqual(dayOnly.error, undefined);
+	assert.ok(
+		dayOnly.notices.includes(
+			'日のみの指定は無視し、年単位で換算しています。厳密な日付換算には月も指定してください。',
+		),
+	);
+});
+
+test('早見表（table builder）経由でも月のみ指定はエラーにならない', () => {
+	const table = buildConversionTable(2000, REF_DATE, 2, 5, undefined);
+	assert.strictEqual(table.error, undefined);
+	const inputRow = table.rows.find((r) => r.isInputYear);
+	assert.ok(inputRow);
+	assert.strictEqual(inputRow.result.age.kind, 'range');
+	assert.ok(
+		table.notices.includes(
+			'月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。',
+		),
+	);
+});
+
+test('月日両方指定時は従来どおり厳密換算・満年齢が維持される', () => {
+	const result = convertWesternYearToResult(2000, REF_DATE, 5, 15);
+	assert.strictEqual(result.error, undefined);
+	assert.strictEqual(result.age.kind, 'exact');
+	assert.ok(
+		!result.notices.some((n) => n.includes('月のみ') || n.includes('日のみ')),
+	);
+});
+
+test('年月日すべて未指定は従来どおり年単位（notice無し）', () => {
+	const result = convertWesternYearToResult(2000, REF_DATE);
+	assert.strictEqual(result.error, undefined);
+	assert.strictEqual(result.age.kind, 'range');
+	assert.ok(
+		!result.notices.some((n) => n.includes('月のみ') || n.includes('日のみ')),
 	);
 });
 


### PR DESCRIPTION
## 概要

wareki-converter で月のみ選択（日は「未指定」のまま）にすると「月と日は両方指定してください。」エラーが表示され変換が止まる不具合を修正。

Notionタスク: 【DEBUG】wareki-converter: 月のみ選択時に「月と日は両方指定してください。」エラーが表示される
https://app.notion.com/p/3b4dfd36033681b287eae1504b9f26bb

## 原因

`convertWesternYearToResult` / `convertWarekiToResult` が `hasMonth !== hasDay`（月日の片方のみ指定）を hard error として扱っていた。UI 側の月・日 Select は独立しており、ラベルも「月（任意）」「日（任意）」だが、実装は「両方あり or 両方なし」しか受け付けていなかった。

## 修正内容

- `hasMonth !== hasDay` の hard error を削除。
- 月日の片方のみ指定された場合は、月日未指定と同じ年単位換算パスにフォールバックし、その旨を notice で案内する。
  - 月のみ: 「月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。」
  - 日のみ: 「日のみの指定は無視し、年単位で換算しています。厳密な日付換算には月も指定してください。」
- 月日を両方指定した場合の厳密な改元日判定・満年齢計算・1872年以前の旧暦ガードは変更なし。
- `buildConversionTable` / `buildConversionTableFromWareki`（早見表API）は上記の変換関数を経由するため、同様にフォールバックが効く。
- UI（`WarekiConverter.tsx`）は notice をそのまま `Alert` で表示する既存の仕組みに乗るため変更不要。

## 受け入れ基準

**自動検証（実施済み）**
- [x] 月のみ選択で `error` が立たず rows が返る
- [x] 月日両方で改元日境界の厳密判定が維持される（既存回帰テスト green）
- [x] 年のみの既存ケースに回帰なし
- [x] `npm run test:unit` 成功（977 tests pass）
- [x] `npm run lint`（Biome）で変更ファイルに新規エラー・警告なし
- [x] `npm run build` 成功

**要人間確認**
- [ ] `http://localhost:4321/wareki-converter` で月のみ操作（例: 月=5、日=未指定）を行い、早見表が表示されnoticeが読めることをブラウザで確認

## 検証結果メモ

- `npm run test:unit`: 977 tests / 0 fail（wareki-converter 関連 52 tests 含む、既存の外部依存不足による失敗は `npm install` 実行後は解消）
- `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`: 既存の `astro:content` 型解決エラー等のみで、今回の変更ファイルに起因するエラーなし
- `npm run build`: 成功（wareki-converter ページ含め101ページ生成）
- E2E (`npm test`) は本セッションの環境上未実行（ブラウザでの手動確認を「要人間確認」として上記に記載）

---
Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_014iCGSBVTbHGBqoGEUxb6vv

---
_Generated by [Claude Code](https://claude.ai/code/session_014iCGSBVTbHGBqoGEUxb6vv)_