### PR TITLE
fix(text-diff): align split view rows with spacer lines

### DIFF
--- a/src/components/tools/TextDiff.tsx
+++ b/src/components/tools/TextDiff.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
+	buildSplitPairs,
 	computeDiff,
 	type DiffMode,
 	readFileAsText,
@@ -107,43 +108,10 @@ export default function TextDiff() {
 		return lines;
 	}, [result]);
 
-	// split ビュー用の行番号付きパート計算
-	const splitLines = useMemo(() => {
-		if (!result) return { left: [], right: [] };
-		const left: Array<{
-			type: 'removed' | 'unchanged';
-			content: string;
-			lineNum: number;
-		}> = [];
-		const right: Array<{
-			type: 'added' | 'unchanged';
-			content: string;
-			lineNum: number;
-		}> = [];
-		let lineA = 1;
-		let lineB = 1;
-
-		for (const part of result.parts) {
-			const partLines = part.value.split('\n');
-			if (part.value.endsWith('\n')) {
-				partLines.pop();
-			}
-			for (const line of partLines) {
-				if (part.type === 'removed') {
-					left.push({ type: 'removed', content: line, lineNum: lineA });
-					lineA++;
-				} else if (part.type === 'added') {
-					right.push({ type: 'added', content: line, lineNum: lineB });
-					lineB++;
-				} else {
-					left.push({ type: 'unchanged', content: line, lineNum: lineA });
-					right.push({ type: 'unchanged', content: line, lineNum: lineB });
-					lineA++;
-					lineB++;
-				}
-			}
-		}
-		return { left, right };
+	// split ビュー用の行ペア計算（左右の縦位置を揃えるためスペーサーを含む）
+	const splitPairs = useMemo(() => {
+		if (!result) return [];
+		return buildSplitPairs(result.parts);
 	}, [result]);
 
 	return (
@@ -279,22 +247,34 @@ export default function TextDiff() {
 									テキストA（変更前）
 								</div>
 								<div className="w-full min-w-max">
-									{splitLines.left.map((line) => (
+									{splitPairs.map((pair, i) => (
 										<div
-											key={`l-${line.lineNum}`}
-											className={`flex min-w-max ${line.type === 'removed' ? 'bg-red-500/10 text-red-700 dark:text-red-300' : ''}`}
+											key={`l-${i}`}
+											className={`flex min-w-max ${
+												pair.left === null
+													? 'bg-muted/20'
+													: pair.left.type === 'removed'
+														? 'bg-red-500/10 text-red-700 dark:text-red-300'
+														: ''
+											}`}
 										>
 											<span className="inline-block w-10 shrink-0 text-right pr-2 text-xs text-muted-foreground select-none border-r border-border/50 py-0.5 bg-muted/30">
-												{line.lineNum}
+												{pair.left?.lineNum ?? ''}
 											</span>
 											<span className="px-2 py-0.5">
-												{line.type === 'removed' && (
-													<span className="select-none opacity-50">- </span>
+												{pair.left === null ? (
+													' '
+												) : (
+													<>
+														{pair.left.type === 'removed' && (
+															<span className="select-none opacity-50">- </span>
+														)}
+														{pair.left.type === 'unchanged' && (
+															<span className="select-none opacity-30"> </span>
+														)}
+														{pair.left.content}
+													</>
 												)}
-												{line.type === 'unchanged' && (
-													<span className="select-none opacity-30"> </span>
-												)}
-												{line.content}
 											</span>
 										</div>
 									))}
@@ -305,22 +285,34 @@ export default function TextDiff() {
 									テキストB（変更後）
 								</div>
 								<div className="w-full min-w-max">
-									{splitLines.right.map((line) => (
+									{splitPairs.map((pair, i) => (
 										<div
-											key={`r-${line.lineNum}`}
-											className={`flex min-w-max ${line.type === 'added' ? 'bg-green-500/10 text-green-700 dark:text-green-300' : ''}`}
+											key={`r-${i}`}
+											className={`flex min-w-max ${
+												pair.right === null
+													? 'bg-muted/20'
+													: pair.right.type === 'added'
+														? 'bg-green-500/10 text-green-700 dark:text-green-300'
+														: ''
+											}`}
 										>
 											<span className="inline-block w-10 shrink-0 text-right pr-2 text-xs text-muted-foreground select-none border-r border-border/50 py-0.5 bg-muted/30">
-												{line.lineNum}
+												{pair.right?.lineNum ?? ''}
 											</span>
 											<span className="px-2 py-0.5">
-												{line.type === 'added' && (
-													<span className="select-none opacity-50">+ </span>
+												{pair.right === null ? (
+													' '
+												) : (
+													<>
+														{pair.right.type === 'added' && (
+															<span className="select-none opacity-50">+ </span>
+														)}
+														{pair.right.type === 'unchanged' && (
+															<span className="select-none opacity-30"> </span>
+														)}
+														{pair.right.content}
+													</>
 												)}
-												{line.type === 'unchanged' && (
-													<span className="select-none opacity-30"> </span>
-												)}
-												{line.content}
 											</span>
 										</div>
 									))}

--- a/src/lib/tools/text-diff.ts
+++ b/src/lib/tools/text-diff.ts
@@ -65,6 +65,56 @@ export function computeDiff(
 	return { parts, addedLines, removedLines, addedChars, removedChars };
 }
 
+export interface SplitCell {
+	type: 'added' | 'removed' | 'unchanged';
+	content: string;
+	lineNum: number;
+}
+
+export interface SplitPair {
+	left: SplitCell | null;
+	right: SplitCell | null;
+}
+
+// Split（左右分割）表示用の行ペアを構築する。
+// 追加・削除で片側だけ行が増える場合、反対側に null（スペーサー）を入れて
+// 同じインデックスの左右が同じ縦位置になるようにする。
+export function buildSplitPairs(parts: DiffPart[]): SplitPair[] {
+	const pairs: SplitPair[] = [];
+	let lineA = 1;
+	let lineB = 1;
+
+	for (const part of parts) {
+		const partLines = part.value.split('\n');
+		if (part.value.endsWith('\n')) {
+			partLines.pop();
+		}
+		for (const line of partLines) {
+			if (part.type === 'removed') {
+				pairs.push({
+					left: { type: 'removed', content: line, lineNum: lineA },
+					right: null,
+				});
+				lineA++;
+			} else if (part.type === 'added') {
+				pairs.push({
+					left: null,
+					right: { type: 'added', content: line, lineNum: lineB },
+				});
+				lineB++;
+			} else {
+				pairs.push({
+					left: { type: 'unchanged', content: line, lineNum: lineA },
+					right: { type: 'unchanged', content: line, lineNum: lineB },
+				});
+				lineA++;
+				lineB++;
+			}
+		}
+	}
+	return pairs;
+}
+
 export function readFileAsText(file: File): Promise<string> {
 	return new Promise((resolve, reject) => {
 		const reader = new FileReader();

--- a/tests/unit/text-diff.test.ts
+++ b/tests/unit/text-diff.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { computeDiff } from '../../src/lib/tools/text-diff.ts';
+import { buildSplitPairs, computeDiff } from '../../src/lib/tools/text-diff.ts';
 
 test('computeDiff: 末尾への行追加で既存行が未変更として維持される', () => {
 	const textA = 'line1\nline2';
@@ -26,4 +26,58 @@ test('computeDiff: 先頭追加・中間挿入で最小diffが生成される', 
 	const result = computeDiff(textA, textB, 'lines');
 	assert.strictEqual(result.removedLines, 0);
 	assert.strictEqual(result.addedLines, 2);
+});
+
+test('buildSplitPairs: 片側のみの追加行に反対側スペーサー(null)が入り左右の行数が揃う', () => {
+	const textA = '行1\n行2\n行3';
+	const textB = '行1\n追加行A\n追加行B\n行2\n行3';
+
+	const result = computeDiff(textA, textB, 'lines');
+	const pairs = buildSplitPairs(result.parts);
+
+	// 追加2行 + 共通3行 = 5ペア
+	assert.strictEqual(pairs.length, 5);
+
+	// 追加行のペアは left が null（スペーサー）で right のみ内容を持つ
+	const addedPairs = pairs.filter((p) => p.right?.type === 'added');
+	assert.strictEqual(addedPairs.length, 2);
+	for (const p of addedPairs) {
+		assert.strictEqual(p.left, null);
+	}
+
+	// 追加行の後、共通行「行2」「行3」は同じインデックスで左右とも内容を持つ
+	const line2Index = pairs.findIndex((p) => p.left?.content === '行2');
+	assert.notStrictEqual(line2Index, -1);
+	assert.strictEqual(pairs[line2Index].right?.content, '行2');
+
+	const line3Index = pairs.findIndex((p) => p.left?.content === '行3');
+	assert.notStrictEqual(line3Index, -1);
+	assert.strictEqual(pairs[line3Index].right?.content, '行3');
+});
+
+test('buildSplitPairs: 片側のみの削除行に反対側スペーサー(null)が入る', () => {
+	const textA = '行1\n削除行\n行2';
+	const textB = '行1\n行2';
+
+	const result = computeDiff(textA, textB, 'lines');
+	const pairs = buildSplitPairs(result.parts);
+
+	const removedPairs = pairs.filter((p) => p.left?.type === 'removed');
+	assert.strictEqual(removedPairs.length, 1);
+	assert.strictEqual(removedPairs[0].right, null);
+});
+
+test('buildSplitPairs: 変更なしの場合は左右とも同一内容のペアになる', () => {
+	const textA = '行1\n行2';
+	const textB = '行1\n行2';
+
+	const result = computeDiff(textA, textB, 'lines');
+	const pairs = buildSplitPairs(result.parts);
+
+	assert.strictEqual(pairs.length, 2);
+	for (const p of pairs) {
+		assert.strictEqual(p.left?.type, 'unchanged');
+		assert.strictEqual(p.right?.type, 'unchanged');
+		assert.strictEqual(p.left?.content, p.right?.content);
+	}
 });


### PR DESCRIPTION
## 課題

Notionタスク: [🐛 【DEBUG】text-diff: Split（左右分割）表示モードで差分行の縦位置（アライメント）がズレる](https://app.notion.com/p/3b4dfd36033681eaa30cc67b1bda9c9e)

text-diff の Split 表示で、追加・削除により左右の行数がずれると、以降の共通行の縦位置が揃わず対比しづらい問題を修正しました。

## 原因

`TextDiff.tsx` の `splitLines` が左右を独立配列として構築しており、片側だけの add/remove 時に反対側へスペーサー行を入れていなかったため、`left.map` / `right.map` のインデックスが意味的に対応していませんでした。

## 修正内容

- `src/lib/tools/text-diff.ts` に純粋関数 `buildSplitPairs(parts: DiffPart[])` を追加。行の追加・削除を `{ left: SplitCell | null, right: SplitCell | null }` のペア配列として構築し、片側のみの add/remove では反対側に `null`（スペーサー）を入れる。
- `TextDiff.tsx` の Split 描画を、この共通ペア配列（`splitPairs`）を左右それぞれ同じインデックスで描画する方式に変更。スペーサー行は薄いプレースホルダー背景（`bg-muted/20`）で表示。
- Unified 表示・`computeDiff` の統計計算ロジックには変更なし。

## 自動検証

- [x] `npm run lint`（Biome）: エラー0件（既存の `tests/e2e/webmcp.spec.ts` の non-null assertion 警告16件は本修正と無関係、AGENTS.md記載の既知警告）
- [x] `npm run test:unit`: 975件 全てpass（`buildSplitPairs` の新規テスト3件を含む）
- [x] `npm run build`: 成功
- [x] `tests/e2e/text-diff.spec.ts`（既存6件）: 全てpass（回帰なし）
- [x] Playwright での実ブラウザ手動検証: A=`行1/行2/行3`、B=`行1/追加行A/追加行B/行2/行3` で Split 表示時、左右5行ずつ生成され、共通行「行2」「行3」の bounding box の Y座標が左右で一致（誤差1px以内）することを確認。スクリーンショットでも視覚的に整列を確認済み。

## 要人間確認

- [ ] 実ブラウザでの最終見た目確認（文字単位モード・水平スクロール時の崩れがないか等）
- [ ] 長い行や日本語混在時の折り返し・パフォーマンス

---
_Generated by [Claude Code](https://claude.ai/code/session_01GzmLEnWrPSWjEAypVao7b6)_