### PR TITLE
fix(base64): recompute file output when Data URI toggle changes

### DIFF
--- a/src/components/tools/Base64Converter.tsx
+++ b/src/components/tools/Base64Converter.tsx
@@ -20,6 +20,7 @@ import {
 	fileToBase64,
 	getBase64ByteSize,
 	getByteSize,
+	stripDataUriPrefix,
 } from '@/lib/tools/base64';
 
 export default function Base64Converter() {
@@ -31,11 +32,17 @@ export default function Base64Converter() {
 	const [direction, setDirection] = useState<'encode' | 'decode'>('encode');
 
 	// File Tab State
-	const [fileOutput, setFileOutput] = useState('');
+	// 常に完全な Data URI (data:*;base64,...) を保持し、表示用文字列は withDataUri から派生する
+	const [fileRawDataUrl, setFileRawDataUrl] = useState('');
 	const [withDataUri, setWithDataUri] = useState(true);
 	const [dragOver, setDragOver] = useState(false);
 	const [fileName, setFileName] = useState('');
 	const [loading, setLoading] = useState(false);
+
+	const fileOutput = useMemo(() => {
+		if (!fileRawDataUrl) return '';
+		return withDataUri ? fileRawDataUrl : stripDataUriPrefix(fileRawDataUrl);
+	}, [fileRawDataUrl, withDataUri]);
 
 	// Computed Text Result
 	const textResult = useMemo(() => {
@@ -74,8 +81,8 @@ export default function Base64Converter() {
 				setLoading(true);
 				try {
 					setFileName(file.name);
-					const b64 = await fileToBase64(file, withDataUri);
-					setFileOutput(b64);
+					const rawDataUrl = await fileToBase64(file, true);
+					setFileRawDataUrl(rawDataUrl);
 					// ファイルのBase64変換が完了した時点で実行を計測
 					trackRun();
 				} catch (_err) {
@@ -85,7 +92,7 @@ export default function Base64Converter() {
 				}
 			}
 		},
-		[withDataUri, trackRun],
+		[trackRun],
 	);
 
 	// Download decoded text
@@ -236,7 +243,7 @@ export default function Base64Converter() {
 									setDragOver(true);
 								}}
 								onDragLeave={() => setDragOver(false)}
-								className={`flex flex-col items-center justify-center min-h-[240px] rounded-xl border-2 border-dashed transition-colors ${
+								className={`relative flex flex-col items-center justify-center min-h-[240px] rounded-xl border-2 border-dashed transition-colors ${
 									dragOver
 										? 'border-primary bg-primary/5'
 										: 'border-border bg-card hover:bg-muted/50'
@@ -248,9 +255,9 @@ export default function Base64Converter() {
 									</div>
 								) : fileName ? (
 									<div className="flex flex-col items-center p-4">
-										{fileOutput?.startsWith('data:image/') && (
+										{fileRawDataUrl?.startsWith('data:image/') && (
 											<img
-												src={fileOutput}
+												src={fileRawDataUrl}
 												alt={fileName}
 												className="max-h-32 max-w-full rounded-md object-contain mb-3 shadow-sm border border-border"
 											/>
@@ -280,8 +287,8 @@ export default function Base64Converter() {
 											setLoading(true);
 											try {
 												setFileName(file.name);
-												const b64 = await fileToBase64(file, withDataUri);
-												setFileOutput(b64);
+												const rawDataUrl = await fileToBase64(file, true);
+												setFileRawDataUrl(rawDataUrl);
 												// ファイルのBase64変換が完了した時点で実行を計測
 												trackRun();
 											} catch (_err) {
@@ -305,7 +312,7 @@ export default function Base64Converter() {
 										variant="outline"
 										size="sm"
 										onClick={() => {
-											setFileOutput('');
+											setFileRawDataUrl('');
 											setFileName('');
 										}}
 										disabled={!fileOutput}

--- a/src/lib/tools/base64.ts
+++ b/src/lib/tools/base64.ts
@@ -33,6 +33,12 @@ export function decodeBase64(base64: string): string {
 	}
 }
 
+// Data URI (e.g. data:image/png;base64,...) から base64 部分のみを取り出す
+export function stripDataUriPrefix(dataUri: string): string {
+	const base64Index = dataUri.indexOf('base64,') + 7;
+	return dataUri.substring(base64Index);
+}
+
 export function fileToBase64(
 	file: File,
 	withDataUri: boolean = true,
@@ -41,13 +47,7 @@ export function fileToBase64(
 		const reader = new FileReader();
 		reader.onload = () => {
 			const result = reader.result as string;
-			if (withDataUri) {
-				resolve(result);
-			} else {
-				// Remove the data URI prefix (e.g. data:image/png;base64,)
-				const base64Index = result.indexOf('base64,') + 7;
-				resolve(result.substring(base64Index));
-			}
+			resolve(withDataUri ? result : stripDataUriPrefix(result));
 		};
 		reader.onerror = () =>
 			reject(new Error('ファイルの読み込みに失敗しました。'));

--- a/tests/unit/base64.test.ts
+++ b/tests/unit/base64.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { decodeBase64, encodeBase64 } from '../../src/lib/tools/base64.ts';
+import {
+	decodeBase64,
+	encodeBase64,
+	stripDataUriPrefix,
+} from '../../src/lib/tools/base64.ts';
 
 test('encodeBase64 & decodeBase64: 日本語・絵文字を含むテキストの往復変換が無損失', () => {
 	const text = 'こんにちは、世界！🎉';
@@ -19,4 +23,9 @@ test('decodeBase64: URL-Safe Base64 (- と _) 入力およびパディング欠�
 
 	const decoded = decodeBase64(urlSafeNoPadding);
 	assert.strictEqual(decoded, text);
+});
+
+test('stripDataUriPrefix: Data URI から base64, 以降のみを残す', () => {
+	const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+	assert.strictEqual(stripDataUriPrefix(dataUri), 'iVBORw0KGgoAAAANSUhEUg==');
 });


### PR DESCRIPTION
## 課題

Notionタスク: [【DEBUG】base64: ファイル選択後に「Data URI 形式を出力する」トグルを変更しても出力結果が更新されない](https://app.notion.com/p/3b4dfd3603368195a41fc642d874914a)

`base64` の「ファイル変換」タブで、ファイル読込後に「Data URI 形式を出力する」トグルを変更しても出力結果が更新されず、再ドロップが必要だった。

## 原因

`withDataUri` は読込時の `fileToBase64(file, withDataUri)` にしか使われず、変換結果の文字列だけが state (`fileOutput`) に残っていた。トグル変更時に `fileOutput` を再計算する処理が存在しなかった。

加えて、ファイル読込用の非表示 `<input type="file">`（`absolute inset-0`）を配置しているドロップゾーンの `<div>` に `position: relative` が指定されておらず、position した祖先が存在しないため、この `<input>` がビューポート全体を覆っていた。ファイル変換タブが表示されている間、トグルのチェックボックスやタブ切替を含む画面全体のクリックがこの透明な `<input>` に奪われる状態になっていた（実ブラウザで検証し確認）。

## 修正内容

1. **`src/lib/tools/base64.ts`**: Data URI プレフィックスを取り除く純粋関数 `stripDataUriPrefix` を追加し、`fileToBase64` から共通利用。
2. **`src/components/tools/Base64Converter.tsx`**:
   - 読込済みファイルの完全な Data URL (`fileRawDataUrl`) を state として保持し、表示用の `fileOutput` を `withDataUri` から `useMemo` で派生。
   - 画像プレビューは常に `fileRawDataUrl`（完全な Data URI）を参照するよう変更し、トグルOFF時でもプレビューが維持されるようにした。
   - ドロップゾーンの `<div>` に `relative` を追加し、ファイル選択用 `<input>` の絶対配置をこの `<div>` にスコープ。
3. **`tests/unit/base64.test.ts`**: `stripDataUriPrefix` のユニットテストを追加。

テキスト変換タブのロジック・UIは変更していません。

## 検証結果

**自動検証**
- [x] `npm run lint` — exit 0（既存の `tests/e2e/webmcp.spec.ts` 非nullアサーション警告14件のみ、本修正と無関係）
- [x] `npm run test:unit` — 973 tests pass, 0 fail（`stripDataUriPrefix` の新規テスト含む）
- [x] `npm run build` — 成功
- [x] `stripDataUriPrefix` が `base64,` 以降のみを残すことをユニットテストで確認

**実ブラウザでの動作確認**（Playwright + プリインストール済みChromiumで手動スクリプト実行、リポジトリのE2Eスイートはこの環境のPlaywrightブラウザバージョン不一致のため実行不可）
- [x] ファイル選択 → トグルOFF → 出力がData URIプレフィックスなしに即時更新
- [x] トグルON → 出力が元のData URI形式に復元
- [x] トグルOFFでも画像プレビューが表示され続ける
- [x] チェックボックスの実クリックで正常に切替（`relative` 修正前は画面全体のクリックが透明な `<input>` に奪われ、チェックボックスやタブ切替が機能しない状態だった）

**要人間確認**（受け入れ基準に記載の通り、CI環境のPlaywrightブラウザバージョン不一致のためリポジトリのE2Eスイートは未実行）
- [ ] 実際のドラッグ&ドロップでのトグル即時反映（クリック選択は上記で確認済み）
- [ ] 各種ブラウザ・実デバイスでの画像プレビュー表示

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLXH6uMytVkt6S1TZKRfeP)_