### PR TITLE
docs: ツール数およびWorker構成などの各種ドキュメントを最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CODE:LIFE Tools
 
-**完全クライアントサイドで動く、日本語の業務向けWebツール集（全45種・無料）。**
+**完全クライアントサイドで動く、日本語の業務向けWebツール集（全48種・無料）。**
 
 すべてのデータ処理はお使いのブラウザ内で完結し、入力データがサーバーへ送信されることは一切ありません。Cookieなし・個人追跡なし・広告なし・オープンソースで運営しています。
 
@@ -18,7 +18,7 @@
 | [郵便番号→住所変換](https://tools.codelife.cafe/zipcode) | 郵便番号リストから住所を一括変換。Excel貼り付け・CSV出力対応 |
 | [消費税・税込計算](https://tools.codelife.cafe/tax) | 税込⇔税抜の即時計算。軽減税率・過去税率・端数処理（切り捨て/四捨五入/切り上げ）対応 |
 
-## 📦 収録ツール（45種）
+## 📦 収録ツール（48種）
 
 ### テキスト処理
 
@@ -31,6 +31,7 @@
 | [Markdownプレビュー](https://tools.codelife.cafe/markdown) | GFM対応のリアルタイムプレビュー。HTMLコピー・ダウンロード対応（データは外部送信なし） |
 | [JWTデコーダー](https://tools.codelife.cafe/jwt-decoder) | JWTのヘッダー・ペイロードをブラウザ内でデコード。署名検証なしで内容確認 |
 | [ワードクラウド生成](https://tools.codelife.cafe/wordcloud) | 日本語テキストを形態素解析しワードクラウド・頻度表（CSV）化（データは外部送信なし） |
+| [文字起こし（ローカル）](https://tools.codelife.cafe/transcribe) | 会議録音や動画をブラウザ内AIで文字起こし。音声はこの端末から出ません（データは外部送信なし） |
 
 ### データ処理
 
@@ -89,6 +90,8 @@
 | [画像Base64変換](https://tools.codelife.cafe/image-base64) | 画像をBase64/Data URIへ相互変換。`<img>`タグ・CSS `url()` スニペット出力。逆変換対応 |
 | [UNIXタイムスタンプ⇔日時変換](https://tools.codelife.cafe/unix-time) | 秒/ミリ秒/マイクロ秒/ナノ秒/Slack TSを自動判定し日時と相互変換。ISO 8601・RFC 3339・和暦・Discord形式も同時出力 |
 | [cron式チェッカー](https://tools.codelife.cafe/cron-checker) | cron式を日本語解説・次回実行10件（JST/UTC）で確認。日本語→cron式の逆引き生成、危険パターンの警告、GitHub Actions/AWS EventBridge形式変換にも対応 |
+| [UUID / ULID 生成ツール](https://tools.codelife.cafe/uuid) | UUID v4/v7・ULID・nanoidを一括生成。表示形式変換・種類判定・時刻抽出に対応 |
+| [YAML ⇔ JSON ⇔ TOML 変換](https://tools.codelife.cafe/yaml-json-toml) | YAML・JSON・TOMLを相互変換。構文エラーは行・列付きの日本語で表示 |
 
 ## 🛡️ セキュリティ・プライバシー
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -71,7 +71,10 @@ src/
 │   └── global.css       # Tailwind CSS v4 設定、カラーテーマ、アニメーション定義
 └── workers/
     ├── bg-remove.worker.ts # 重量処理（AI背景削除）のためのWeb Worker
-    └── upscale.worker.ts   # 重量処理（画像アップスケール・ノイズ除去）のためのWeb Worker
+    ├── qr-reader.worker.ts # QRコード読み取り処理のためのWeb Worker
+    ├── transcribe.worker.ts # 重量処理（音声文字起こし）のためのWeb Worker
+    ├── upscale.worker.ts   # 重量処理（画像アップスケール・ノイズ除去）のためのWeb Worker
+    └── wordcloud.worker.ts # 形態素解析処理のためのWeb Worker
 ```
 
 ---
@@ -137,6 +140,7 @@ flowchart TD
 | Service Worker テンプレート・生成物 | `public/sw.js`、`scripts/generate-sw.mjs`、`dist/sw.js` | プリキャッシュ対象の注入、Cache First / Network First、オフラインフォールバック | 許可。同一オリジンの静的ファイル取得・キャッシュに限定 |
 | 郵便番号チャンク取得 | `/data/zipcode/*.json` などの静的JSON | 郵便番号検索・変換に必要な辞書データを必要分だけ取得 | 例外的に許可。静的データのダウンロードのみで、検索語や入力内容は送信しない |
 | AIモデルファイル取得 | Cloudflare R2 等で配信されるモデル・WASM・関連ファイル | AI背景削除などのブラウザ内推論に必要なモデルを取得 | 例外的に許可。モデルファイル取得のみで、画像などの処理対象データは送信しない |
+| 文字起こしモデルプロキシ通信 | `/models/transcribe/*` (Pages Function `functions/models/transcribe/[[path]].ts`) | 音声文字起こし用AIモデル・WASMを同一オリジン経由で取得（CSP `connect-src: 'self'` 遵守） | 例外的に許可。モデル静的ファイル取得のみで、音声データは送信しない |
 | 完全匿名イベント計測 | Pages Function (`/api/event`) → Cloudflare Analytics Engine | ツール利用頻度・回遊効果等の実地検証（Cookie・個人特定なし） | 許可。Allowlistプロパティのみ。入力テキストやファイル等の具体的データは一切送信しない |
 | Web Analytics (RUM) | Cloudflare Web Analytics ビーコン | ページビュー・パフォーマンス統計の収集 | 許可。ファーストパーティ・Cookieレス・個人特定なしのアクセス解析のみ |
 | ユーザー入力データ送信 | 入力テキスト、アップロード画像、PDF、CSV/JSON 等 | なし | 禁止。外部API、トラッキング、個人プロファイリング目的の送信を行わない |

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -49,7 +49,7 @@ npm run build
 # PowerShell での確認例 (dist ディレクトリ内の SoftwareApplication 件数カウント)
 (Get-ChildItem -Path dist -Recurse -Filter *.html | Select-String -Pattern '"@type":"SoftwareApplication"').Count
 ```
-※全ツールの数（例: 37件以上）と出力件数が一致することを確認します。
+※全ツールの数（例: 48件）と出力件数が一致することを確認します。
 
 ### 3.3 Schema Markup Validator での検証
 1. [Google Rich Results Test](https://search.google.com/test/rich-results) または [Schema Markup Validator](https://validator.schema.org/) を開きます。


### PR DESCRIPTION
## 概要
最新の実装状態に合わせて、記載漏れや旧情報の残っていたドキュメントを最新化しました。

### 主な変更点
- **`README.md`**: 全ツール数を 45種 → 48種 へ修正し、`transcribe`, `uuid`, `yaml-json-toml` の 3 ツールを一覧テーブルに追記
- **`docs/architecture.md`**: `src/workers/` 配下の構成に `qr-reader.worker.ts`, `transcribe.worker.ts`, `wordcloud.worker.ts` を追記、および通信境界テーブルに `/transcribe` の同一オリジンモデルプロキシ通信を追記
- **`docs/seo.md`**: 構造化データ検証例のツール数カウント例を 48件 に更新

## 今回の最新コミット
- `2a36fce` docs: ツール数およびWorker構成などの各種ドキュメントを最新化

## 検証結果
- `npm run lint`: Biome 静的解析エラーなし (exit code 0)
- `npm run test:unit`: 972 件すべての単体テスト成功
- `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`: 型チェックエラーなし (exit code 0)

## 意図的に含めなかった未ステージ変更
- `.claude/settings.json`
- `docs/investigation-latent-issues-2026-07-29.md`
- `scripts/test_tools_advanced.mjs`
- `scripts/test_tools_basic.mjs`
