### PR TITLE
fix(FileDropzone): multiple時にサイレント無効化されるmaxSizeBytes/validateを型で誤用防止

### DIFF
--- a/src/components/common/FileDropzone.tsx
+++ b/src/components/common/FileDropzone.tsx
@@ -3,23 +3,13 @@ import { useCallback, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-export interface FileDropzoneProps {
+interface FileDropzoneCommonProps {
 	/** 検証を通過したファイルのみ通知される（単一選択時） */
 	onFileSelect: (file: File) => void;
-	/** 複数選択を許可する（デフォルト false）。既存の単一選択挙動は不変 */
-	multiple?: boolean;
-	/** multiple 時に選択された全ファイルを通知する（ドメイン検証は呼び出し側で行う） */
-	onFilesSelect?: (files: File[]) => void;
 	/** 検証失敗時のエラーメッセージ通知（表示は呼び出し側で行う） */
 	onValidationError?: (message: string) => void;
 	/** input の accept 属性（例: '.json,.csv,.txt'）。未指定は任意ファイル */
 	accept?: string;
-	/** ファイルサイズ上限（バイト）。超過時は validationMessage を通知 */
-	maxSizeBytes?: number;
-	/** maxSizeBytes 超過時のメッセージ */
-	validationMessage?: string;
-	/** 追加の検証フック。エラーメッセージを返すと選択を拒否（null = OK） */
-	validate?: (file: File) => string | null;
 	label?: string;
 	description?: string;
 	privacyNote?: string;
@@ -32,6 +22,36 @@ export interface FileDropzoneProps {
 	className?: string;
 	'data-testid'?: string;
 }
+
+interface FileDropzoneSingleProps extends FileDropzoneCommonProps {
+	/** 複数選択を許可する（デフォルト false）。既存の単一選択挙動は不変 */
+	multiple?: false;
+	onFilesSelect?: never;
+	/** ファイルサイズ上限（バイト）。超過時は validationMessage を通知（単一選択時のみ有効） */
+	maxSizeBytes?: number;
+	/** maxSizeBytes 超過時のメッセージ */
+	validationMessage?: string;
+	/** 追加の検証フック。エラーメッセージを返すと選択を拒否（null = OK）（単一選択時のみ有効） */
+	validate?: (file: File) => string | null;
+}
+
+interface FileDropzoneMultipleProps extends FileDropzoneCommonProps {
+	multiple: true;
+	/** multiple 時に選択された全ファイルを通知する。サイズ・独自検証は呼び出し側の onFilesSelect で行う */
+	onFilesSelect: (files: File[]) => void;
+	/**
+	 * multiple 時は handleFile を経由しないため maxSizeBytes は評価されない。
+	 * 誤用防止のため型で受け付けない。検証は onFilesSelect 内で行うこと
+	 */
+	maxSizeBytes?: never;
+	validationMessage?: never;
+	/** multiple 時は評価されない。誤用防止のため型で受け付けない（理由は maxSizeBytes と同様） */
+	validate?: never;
+}
+
+export type FileDropzoneProps =
+	| FileDropzoneSingleProps
+	| FileDropzoneMultipleProps;
 
 function matchesAccept(file: File, accept?: string): boolean {
 	if (!accept) return true;
@@ -174,17 +194,18 @@ export function FileDropzone({
 						{privacyNote}
 					</p>
 				</div>
-				<input
-					ref={fileInputRef}
-					type="file"
-					accept={accept}
-					multiple={multiple}
-					aria-label={inputAriaLabel}
-					data-testid={dataTestId}
-					onChange={handleInputChange}
-					className="hidden"
-				/>
 			</button>
+			{/* HTML仕様上 button の内容にインタラクティブ要素は置けないため、input は button の外に置く */}
+			<input
+				ref={fileInputRef}
+				type="file"
+				accept={accept}
+				multiple={multiple}
+				aria-label={inputAriaLabel}
+				data-testid={dataTestId}
+				onChange={handleInputChange}
+				className="hidden"
+			/>
 			{selectedFileName && (
 				<div className="mt-2 flex items-center gap-2 rounded-lg border border-border bg-muted/30 px-3 py-2 text-sm">
 					<span className="truncate font-mono" title={selectedFileName}>

--- a/src/components/image-metadata/ImageMetadataPage.tsx
+++ b/src/components/image-metadata/ImageMetadataPage.tsx
@@ -17,7 +17,6 @@ import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { createId, downloadBlob } from '@/lib/tools/image-common';
 import {
 	MAX_METADATA_FILE_COUNT,
-	MAX_METADATA_FILE_SIZE,
 	type StripMetadataOptions,
 	type StripMetadataResult,
 	stripImageMetadata,
@@ -141,8 +140,6 @@ export function ImageMetadataPage() {
 				onFileSelect={(file) => onFiles([file])}
 				onFilesSelect={onFiles}
 				onValidationError={setError}
-				maxSizeBytes={MAX_METADATA_FILE_SIZE}
-				validationMessage="25MB以下の画像を選択してください。"
 			/>
 
 			<div className="rounded-xl border border-border bg-card p-4">

--- a/tests/e2e/image-compress.spec.ts
+++ b/tests/e2e/image-compress.spec.ts
@@ -174,6 +174,17 @@ test.describe('画像圧縮・リサイズ', () => {
 		await expect(page.getByRole('alert')).toContainText('対応していない形式');
 	});
 
+	test('上限枚数を超えるドロップは件数エラーになり処理されない', async ({
+		page,
+	}) => {
+		const files = Array.from({ length: 31 }, () => SAMPLE);
+		await fileInput(page).setInputFiles(files);
+		await expect(page.getByRole('alert')).toContainText(
+			'一度に処理できるのは30枚までです。',
+		);
+		await expect(page.getByTestId('compress-result-list')).toBeHidden();
+	});
+
 	test('処理中にキャンセルすると中断され、未処理のアイテムはpendingのまま残る', async ({
 		page,
 	}) => {


### PR DESCRIPTION
taskId: `3acdfd3603368175a53eeb2a8df8b388`
実行ID: `triage-impl-20260807-0615`

## 概要

`FileDropzone` の `multiple` 経路は `handleFile` を通らないため、`accept` / `maxSizeBytes` / `validate` の3検証がすべてスキップされていた（props は受け付けるので呼び出し側が「効いている」と誤認する）。

調査の結果、`multiple` を使う7ツール（image-compress / image-convert / image-edit / image-merge / image-metadata / pdf-merge / exif）は**いずれも呼び出し側の `onFilesSelect` 内で独自にドメイン検証（種別・サイズ・件数）を実施済み**でした。`maxSizeBytes` / `validate` を実際に渡していたのは `image-metadata` のみで、その値は同ページの `validateMetadataImageFile` が既に完全にカバーしていたため実害はありませんでした（デッドprops状態）。

このため、ランタイムでの検証追加（他ツールの既存検証と二重化・エラーメッセージの不整合リスクがある）ではなく、受け入れ基準が許容する**型レベルでの誤用防止**を採用しました。

## 変更内容

1. `FileDropzoneProps` を `multiple` で判別する discriminated union に変更。`multiple: true` のときは `maxSizeBytes` / `validationMessage` / `validate` を型エラーにして渡せないようにした（単一選択時は従来通り利用可能、他5ツールの単一選択利用箇所は無変更）。
2. 上記の型変更に伴い、`image-metadata` の唯一のデッドprops利用（`maxSizeBytes` / `validationMessage`）を削除。検証は既存の `onFiles` 内 `validateMetadataImageFile` のみで完結（メッセージ・挙動とも従来と同一）。
3. `<input type="file">` が `<button>` の子孫になっていた不正なHTMLネストを解消（input を button の外側の兄弟要素へ移動。`hidden` のままで挙動・アクセシビリティツリーへの影響なし）。
4. `image-compress` に上限枚数超過ドロップのE2E回帰テストを追加。

## 受け入れ基準への対応

- [x] multiple時もaccept・maxSizeBytes・validateが適用される、**または型で誤用を防止** → 型レベルで誤用防止を実装
- [x] 対象8ツールで既存検証と二重にならない → ランタイム検証は追加していないため二重化なし（`image-metadata` のみデッドpropsを削除）
- [x] file inputの不正な入れ子を解消 → button外へ移動
- [x] 上限超過ドロップのE2E、lint・test・buildが成功する → 下記参照

## 検証

- `npm run check`（astro check + biome）: 成功（既存の無関係な警告16件のみ、エラー0）
- `npm run test:unit`: 985 tests / 985 pass
- `npm run build`: 成功
- `npx playwright test`（image-compress / image-convert / image-edit / image-merge / image-metadata / pdf-merge / favicon / image-base64, chromium）: 64 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeQDpisThMSvqCpLB2fvHD)_