### PR TITLE
fix: 画面回転時にビューポート中心の画像内座標を保持する（P10）

### DIFF
--- a/src/lib/hooks/useZoomPan.ts
+++ b/src/lib/hooks/useZoomPan.ts
@@ -11,6 +11,7 @@ import {
 } from 'react';
 import {
 	clampScrollPosition,
+	computeCenterPreservingScroll,
 	computeContentOffset,
 	computeFitScale,
 	computeWheelZoom,
@@ -49,6 +50,9 @@ export function useZoomPan(params: {
 	});
 	const [mode, setMode] = useState<'fit' | number>('fit');
 	const pendingAnchorRef = useRef<PendingAnchor>(null);
+	// コンテナサイズの前回値。画面回転・iOSアドレスバー伸縮による中心保持補正の
+	// 基準にする（nullのままなら「まだ実測前」として補正しない）。
+	const prevContainerSizeRef = useRef<ContainerSize | null>(null);
 
 	// resetKey の変化のみを契機とする（本文内では参照しない）
 	// biome-ignore lint/correctness/useExhaustiveDependencies: resetKeyは識別子変更の検知にのみ使う
@@ -95,55 +99,97 @@ export function useZoomPan(params: {
 	const offsetX = computeContentOffset(containerSize.width, displayWidth);
 	const offsetY = computeContentOffset(containerSize.height, displayHeight);
 
-	// カーソル/中心基準ズーム: スケール変更後にスクロール位置を補正して同じ画像内座標を維持する
+	// カーソル/中心基準ズーム: スケール変更後にスクロール位置を補正して同じ画像内座標を維持する。
+	// アンカーが無い場合でも、数値ズーム中にコンテナサイズだけが変化した（画面回転・
+	// iOSアドレスバー伸縮）ときはビューポート中央の画像内座標を保持する。fitモードは
+	// 常にスクロール不要（画像全体が収まる）ため対象外とする。
 	useLayoutEffect(() => {
-		const anchor = pendingAnchorRef.current;
 		const el = containerRef.current;
-		if (!anchor || !el) return;
-		pendingAnchorRef.current = null;
-		const oldOffsetX = computeContentOffset(
-			containerSize.width,
-			contentWidth * anchor.oldScale,
+		const prevSize = prevContainerSizeRef.current;
+		prevContainerSizeRef.current = containerSize;
+		if (!el) return;
+
+		const anchor = pendingAnchorRef.current;
+		if (anchor) {
+			pendingAnchorRef.current = null;
+			const oldOffsetX = computeContentOffset(
+				containerSize.width,
+				contentWidth * anchor.oldScale,
+			);
+			const oldOffsetY = computeContentOffset(
+				containerSize.height,
+				contentHeight * anchor.oldScale,
+			);
+			const rawScrollLeft = computeZoomScrollPosition({
+				pointerInViewport: anchor.pointerX,
+				scrollPosition: anchor.scrollLeft,
+				oldContentOffset: oldOffsetX,
+				newContentOffset: offsetX,
+				oldScale: anchor.oldScale,
+				newScale: scale,
+				containerSize: containerSize.width,
+				contentSize: contentWidth,
+			});
+			const rawScrollTop = computeZoomScrollPosition({
+				pointerInViewport: anchor.pointerY,
+				scrollPosition: anchor.scrollTop,
+				oldContentOffset: oldOffsetY,
+				newContentOffset: offsetY,
+				oldScale: anchor.oldScale,
+				newScale: scale,
+				containerSize: containerSize.height,
+				contentSize: contentHeight,
+			});
+			const maxScrollLeft = Math.max(0, displayWidth - containerSize.width);
+			const maxScrollTop = Math.max(0, displayHeight - containerSize.height);
+			el.scrollLeft = clampScrollPosition(
+				rawScrollLeft - anchor.panDeltaX,
+				maxScrollLeft,
+			);
+			el.scrollTop = clampScrollPosition(
+				rawScrollTop - anchor.panDeltaY,
+				maxScrollTop,
+			);
+			return;
+		}
+
+		const containerSizeChanged =
+			prevSize !== null &&
+			(prevSize.width !== containerSize.width ||
+				prevSize.height !== containerSize.height);
+		if (isFit || prevSize === null || !containerSizeChanged) return;
+		if (prevSize.width <= 0 || prevSize.height <= 0) return;
+
+		const prevOffsetX = computeContentOffset(
+			prevSize.width,
+			contentWidth * scale,
 		);
-		const oldOffsetY = computeContentOffset(
-			containerSize.height,
-			contentHeight * anchor.oldScale,
+		const prevOffsetY = computeContentOffset(
+			prevSize.height,
+			contentHeight * scale,
 		);
-		const rawScrollLeft = computeZoomScrollPosition({
-			pointerInViewport: anchor.pointerX,
-			scrollPosition: anchor.scrollLeft,
-			oldContentOffset: oldOffsetX,
+		el.scrollLeft = computeCenterPreservingScroll({
+			oldContainerSize: prevSize.width,
+			newContainerSize: containerSize.width,
+			scrollPosition: el.scrollLeft,
+			oldContentOffset: prevOffsetX,
 			newContentOffset: offsetX,
-			oldScale: anchor.oldScale,
-			newScale: scale,
-			containerSize: containerSize.width,
+			scale,
 			contentSize: contentWidth,
 		});
-		const rawScrollTop = computeZoomScrollPosition({
-			pointerInViewport: anchor.pointerY,
-			scrollPosition: anchor.scrollTop,
-			oldContentOffset: oldOffsetY,
+		el.scrollTop = computeCenterPreservingScroll({
+			oldContainerSize: prevSize.height,
+			newContainerSize: containerSize.height,
+			scrollPosition: el.scrollTop,
+			oldContentOffset: prevOffsetY,
 			newContentOffset: offsetY,
-			oldScale: anchor.oldScale,
-			newScale: scale,
-			containerSize: containerSize.height,
+			scale,
 			contentSize: contentHeight,
 		});
-		const maxScrollLeft = Math.max(0, displayWidth - containerSize.width);
-		const maxScrollTop = Math.max(0, displayHeight - containerSize.height);
-		el.scrollLeft = clampScrollPosition(
-			rawScrollLeft - anchor.panDeltaX,
-			maxScrollLeft,
-		);
-		el.scrollTop = clampScrollPosition(
-			rawScrollTop - anchor.panDeltaY,
-			maxScrollTop,
-		);
-		// scale 変化のたびに保留中の補正があれば適用する
 	}, [
 		scale,
-		containerSize.width,
-		containerSize.height,
+		isFit,
+		containerSize,
 		contentWidth,
 		contentHeight,
 		offsetX,

--- a/src/lib/tools/zoom-pan.ts
+++ b/src/lib/tools/zoom-pan.ts
@@ -151,6 +151,50 @@ export function computeZoomScrollPosition(params: ZoomScrollParams): number {
 	return Math.min(maxScroll, Math.max(0, rawScroll));
 }
 
+export type CenterPreservingScrollParams = {
+	/** リサイズ前のコンテナサイズ（px、1軸分） */
+	oldContainerSize: number;
+	/** リサイズ後のコンテナサイズ（px、1軸分） */
+	newContainerSize: number;
+	/** リサイズ前のスクロール位置（px） */
+	scrollPosition: number;
+	/** リサイズ前の中央配置オフセット（px） */
+	oldContentOffset: number;
+	/** リサイズ後の中央配置オフセット（px） */
+	newContentOffset: number;
+	/** リサイズ前後で共通の倍率（呼び出し側でfitモードを対象外にすること） */
+	scale: number;
+	/** コンテンツの原寸（スケール適用前、px） */
+	contentSize: number;
+};
+
+/**
+ * コンテナサイズ変化（画面回転・iOSアドレスバー伸縮など、倍率変化を伴わない
+ * リサイズ）の前後で、ビューポート中央にあった画像内座標を維持するスクロール
+ * 位置を計算する。computeZoomScrollPosition と同じ「画像内座標を求めて
+ * 再配置する」手順を、ポインタ位置の代わりにコンテナ中心を基準に適用する。
+ */
+export function computeCenterPreservingScroll(
+	params: CenterPreservingScrollParams,
+): number {
+	const {
+		oldContainerSize,
+		newContainerSize,
+		scrollPosition,
+		oldContentOffset,
+		newContentOffset,
+		scale,
+		contentSize,
+	} = params;
+	if (scale <= 0) return 0;
+	const oldCenter = oldContainerSize / 2;
+	const newCenter = newContainerSize / 2;
+	const imagePoint = (oldCenter + scrollPosition - oldContentOffset) / scale;
+	const rawScroll = imagePoint * scale + newContentOffset - newCenter;
+	const maxScroll = Math.max(0, contentSize * scale - newContainerSize);
+	return clampScrollPosition(rawScroll, maxScroll);
+}
+
 /** 実効倍率を表示用文字列に変換する（例: "18%", "100%"） */
 export function formatZoomPercent(scale: number): string {
 	return `${Math.round(scale * 100)}%`;

--- a/tests/e2e/zoom-pan.spec.ts
+++ b/tests/e2e/zoom-pan.spec.ts
@@ -70,6 +70,34 @@ async function waitForStableGeometry(
 }
 
 /**
+ * 修飾キーなしホイールでのスクロールは、Chromiumのデフォルトのスムーズ
+ * スクロールにより wheel イベント後も数百msかけて目標位置へ遷移する。
+ * scrollLeft/scrollTop が2回連続で同じ値になるまで待ち、アニメーション
+ * 途中の値を「リサイズ前の基準点」として誤って使わないようにする。
+ */
+async function waitForScrollStable(
+	page: Page,
+	canvasTestId: string,
+): Promise<ZoomGeometry> {
+	let previous: { left: number; top: number } | null = null;
+	await expect
+		.poll(
+			async () => {
+				const current = await getZoomGeometry(page, canvasTestId);
+				const stable =
+					previous !== null &&
+					previous.left === current.scrollLeft &&
+					previous.top === current.scrollTop;
+				previous = { left: current.scrollLeft, top: current.scrollTop };
+				return stable;
+			},
+			{ intervals: [50, 50, 100], timeout: 5000 },
+		)
+		.toBe(true);
+	return getZoomGeometry(page, canvasTestId);
+}
+
+/**
  * canvas 自身の boundingBox を返す（zoom-scroll-container ではなく canvas 本体）。
  * モバイル幅では画像がコンテナ内でレターボックス表示され、コンテナ基準の座標が
  * 余白（非canvas領域）に落ちてタッチイベントが一切届かなくなることがあるため、
@@ -411,6 +439,91 @@ for (const tool of TOOLS) {
 			}
 			await expect(percentLabel).toHaveText('400%');
 			await expect(page.getByRole('button', { name: '拡大' })).toBeDisabled();
+		});
+	});
+
+	test.describe(`${tool.id}: アンカー無しのコンテナリサイズ（画面回転・アドレスバー伸縮相当）`, () => {
+		test.beforeEach(async ({ page, createToolPage }) => {
+			const toolPage = createToolPage(tool.id);
+			await toolPage.goto();
+			await expect(
+				page.getByText('画像をドラッグ＆ドロップ、またはクリックして選択'),
+			).toBeVisible({ timeout: 10000 });
+		});
+
+		test('ズーム操作を伴わない純粋なコンテナリサイズでも、ビューポート中央の画像内座標が保持される', async ({
+			page,
+		}) => {
+			await uploadLargePannableImage(page, tool.canvasTestId);
+
+			// ズーム由来のアンカーが残らないよう、素のホイールスクロール（修飾キーなし）で
+			// コンテンツを中央からずらしておく。0,0のままだと既にクランプ端にあり、
+			// 補正が効かなくても偶然「ずれない」ケースを検証してしまうため。
+			const containerBoxBefore = await getContainerBox(page);
+			await page.mouse.move(
+				containerBoxBefore.x + containerBoxBefore.width / 2,
+				containerBoxBefore.y + containerBoxBefore.height / 2,
+			);
+			await page.mouse.wheel(250, 200);
+			// Chromiumの既定スムーズスクロールでwheel後もscrollLeft/Topが遷移し続けるため、
+			// 静定するまで待ってから基準点を記録する（アニメーション途中の値を使うと
+			// リサイズ後の中心保持検証が偽陽性/偽陰性になる）。
+			await waitForScrollStable(page, tool.canvasTestId);
+
+			// getContainerBox はコンテナをビューポート内へスクロールしうる。1回目の
+			// 呼び出しでそのスクロールを確定させ、幾何情報の安定を待ってから、
+			// スクロールが既に不要（no-op）になった状態で2回目を呼んで
+			// containerBox と幾何情報（containerTop等）を同じ瞬間の値として揃える
+			// （順序を誤ると getContainerBox の副作用でページが動き、containerTop
+			// だけ古い値のままずれる）。
+			await getContainerBox(page);
+			const before = await waitForStableGeometry(page, tool.canvasTestId);
+			const containerBox = await getContainerBox(page);
+			const centerBefore = {
+				x: containerBox.x + containerBox.width / 2,
+				y: containerBox.y + containerBox.height / 2,
+			};
+			const beforePoint = imagePointFromClientPoint(
+				before,
+				centerBefore.x,
+				centerBefore.y,
+			);
+
+			const viewport = page.viewportSize();
+			if (!viewport) throw new Error('viewportSizeが取得できません');
+			try {
+				// 画面回転相当: 縦横を入れ替える。ズームやポインタ操作を伴わない
+				// 「アンカー無しのコンテナリサイズ」だけを発生させる
+				// （P10: useZoomPan.ts のcontainerSize変化検知の回帰テスト）。
+				await page.setViewportSize({
+					width: viewport.height,
+					height: viewport.width,
+				});
+				await getContainerBox(page);
+				const after = await waitForStableGeometry(page, tool.canvasTestId);
+				const containerBoxAfter = await getContainerBox(page);
+				const centerAfter = {
+					x: containerBoxAfter.x + containerBoxAfter.width / 2,
+					y: containerBoxAfter.y + containerBoxAfter.height / 2,
+				};
+				const afterPoint = imagePointFromClientPoint(
+					after,
+					centerAfter.x,
+					centerAfter.y,
+				);
+
+				const tolerance = toleranceFor(after) + 5;
+				expect(
+					Math.abs(beforePoint.x - afterPoint.x),
+					`x座標のずれ（許容${tolerance.toFixed(1)}px）`,
+				).toBeLessThanOrEqual(tolerance);
+				expect(
+					Math.abs(beforePoint.y - afterPoint.y),
+					`y座標のずれ（許容${tolerance.toFixed(1)}px）`,
+				).toBeLessThanOrEqual(tolerance);
+			} finally {
+				await page.setViewportSize(viewport);
+			}
 		});
 	});
 
@@ -793,8 +906,21 @@ for (const tool of TOOLS) {
 				.evaluate((el) => (el as HTMLElement).click());
 			await waitForStableGeometry(page, tool.canvasTestId);
 
+			// フルサイズ切替はピンチ由来のアンカーが消費された後に発生する、アンカー無しの
+			// コンテナリサイズ（P10修正の対象）。コンテナの高さが変わるため、リサイズ前の
+			// 固定ページ座標ではなくコンテナ自身の中心を基準に「同じ画像内座標が
+			// ビューポート中央に留まるか」を検証する。
+			const containerBoxAfter = await getContainerBox(page);
+			const centerAfter = {
+				x: containerBoxAfter.x + containerBoxAfter.width / 2,
+				y: containerBoxAfter.y + containerBoxAfter.height / 2,
+			};
 			const after = await getZoomGeometry(page, tool.canvasTestId);
-			const afterPoint = imagePointFromClientPoint(after, center.x, center.y);
+			const afterPoint = imagePointFromClientPoint(
+				after,
+				centerAfter.x,
+				centerAfter.y,
+			);
 			const tolerance = toleranceFor(after) + 5;
 			expect(Math.abs(beforePoint.x - afterPoint.x)).toBeLessThanOrEqual(
 				tolerance,

--- a/tests/unit/zoom-pan.test.ts
+++ b/tests/unit/zoom-pan.test.ts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import {
 	clampScrollPosition,
 	clampZoom,
+	computeCenterPreservingScroll,
 	computeContentOffset,
 	computeDistance,
 	computeFitScale,
@@ -191,6 +192,49 @@ test('computeZoomScrollPosition: 中央配置オフセットがある場合も�
 		contentSize: 400,
 	});
 	assert.ok(scroll >= 0);
+});
+
+test('computeCenterPreservingScroll: コンテナリサイズ前後でビューポート中央の画像内座標を維持する', () => {
+	// コンテナ800→600（回転相当）、倍率3固定、中央配置オフセットなし
+	const scroll = computeCenterPreservingScroll({
+		oldContainerSize: 800,
+		newContainerSize: 600,
+		scrollPosition: 300,
+		oldContentOffset: 0,
+		newContentOffset: 0,
+		scale: 3,
+		contentSize: 1000,
+	});
+	// oldCenter=400 → imagePoint=(400+300)/3=233.33 → newScroll=233.33*3-300=400
+	assert.equal(scroll, 400);
+});
+
+test('computeCenterPreservingScroll: 結果は最大スクロール量を超えない', () => {
+	const scroll = computeCenterPreservingScroll({
+		oldContainerSize: 50,
+		newContainerSize: 90,
+		scrollPosition: 50,
+		oldContentOffset: 0,
+		newContentOffset: 0,
+		scale: 1,
+		contentSize: 100,
+	});
+	assert.equal(scroll, 10); // maxScroll = 100 - 90 = 10 でクランプされる
+});
+
+test('computeCenterPreservingScroll: scaleが0以下なら0を返す（ゼロ除算回避）', () => {
+	assert.equal(
+		computeCenterPreservingScroll({
+			oldContainerSize: 100,
+			newContainerSize: 100,
+			scrollPosition: 50,
+			oldContentOffset: 0,
+			newContentOffset: 0,
+			scale: 0,
+			contentSize: 100,
+		}),
+		0,
+	);
 });
 
 test('formatZoomPercent: 倍率を%表示に変換する', () => {


### PR DESCRIPTION
taskId: `3bdad2809b09423abe097f914a486f99`
実行ID: `triage-impl-20260808-0615`

対象タスク: [P10: 画面回転時にビューポート中心が保持されない（拡大中の回転で表示位置が端に寄る）](https://app.notion.com/p/3bdad2809b09423abe097f914a486f99)

## 症状・原因

`/image-mosaic` や `/image-text` で数値ズーム（例: 300%）中に画面を回転すると、表示位置が画像の端へ移動する。

`useZoomPan` のスクロール補正（`useLayoutEffect`）は、ズーム操作由来のアンカー（`pendingAnchorRef`）がある場合にのみ動作していた。画面回転は `ResizeObserver` による `containerSize` の変化だけを引き起こし、この経路ではアンカーが積まれないため補正が一切走らず、スクロール可能範囲（`maxScroll`）が縮んだ分だけ生のスクロール値がクランプされ、表示位置が端に寄っていた。

## 対応内容

- `src/lib/tools/zoom-pan.ts`: 純粋関数 `computeCenterPreservingScroll` を追加。コンテナサイズ変化の前後で、ビューポート中央にあった画像内座標を維持するスクロール位置を計算する（既存の `computeZoomScrollPosition` と同じ「画像内座標を求めて再配置する」手順を、ポインタ位置の代わりにコンテナ中心を基準に適用）。
- `src/lib/hooks/useZoomPan.ts`: 既存のスクロール補正 `useLayoutEffect` に、アンカーが無い場合の分岐を追加。直前の `containerSize` を `prevContainerSizeRef` で保持し、数値ズーム中に純粋なコンテナリサイズ（画面回転・iOSアドレスバー伸縮など）が起きた場合のみ `computeCenterPreservingScroll` で補正する。fitモードは常にスクロール不要（画像全体が収まる）ため対象外。
- `tests/unit/zoom-pan.test.ts`: `computeCenterPreservingScroll` の単体テストを3件追加（中心保持・最大スクロールでのクランプ・scale=0のゼロ除算回避）。
- `tests/e2e/zoom-pan.spec.ts`:
  - アンカー無しの純粋なコンテナリサイズ（`page.setViewportSize` で縦横入れ替え）でもビューポート中央の画像内座標が保持されることを検証するE2Eを追加（image-mosaic / image-text 双方）。
  - 既存の「フルサイズ切替」テストを、コンテナ自身の中心を基準にした検証へ更新（今回の修正でコンテナリサイズ時の意図した挙動が「固定ページ座標を動かさない」から「コンテナ中心の画像内座標を保持する」へ一般化されたため、リサイズ後は再測定したコンテナ中心を基準に比較する）。

## 受け入れ基準への対応

- [x] リサイズ前後で画像座標上のビューポート中心を保持する
- [x] ズーム由来の補正（アンカー経路）との二重適用を防ぐ（アンカーが存在する場合は従来通りそちらを優先し、コンテナリサイズ補正は行わない）
- [x] iOSアドレスバー伸縮を回帰させない（fitモードは対象外、既存のズーム系E2Eは全てグリーン）
- [x] fitモード（`P3` 関連の初期倍率）を回帰させない
- [x] 単体/E2E・lint・test・buildが成功する

## 検証結果

- `npm run test:unit`: 988 pass / 0 fail
- `npm run check`（Astro typecheck + Biome lint）: エラー0、警告16件（全て本PR無関係の `tests/e2e/webmcp.spec.ts` の既存 `noNonNullAssertion` 警告）
- `npm run build`: 成功
- `npx playwright test tests/e2e/zoom-pan.spec.ts`: 80 tests（chromium / mobile-chrome）全てpass
- `npx playwright test tests/e2e/image-mosaic.spec.ts tests/e2e/image-text.spec.ts`: 70 tests全てpass
- サニティチェック: 修正前のコードに戻して同E2Eを実行し、新規テスト4件・既存の「フルサイズ切替」テスト2件が想定通り失敗することを確認済み（テストが実際に不具合を検出できることの確認）


---
_Generated by [Claude Code](https://claude.ai/code/session_01QwweYFokxMaULNKvmZakyq)_