### PR TITLE
fix(deps): npm audit の高深刻度3件を解消（dompurify / js-yaml / nanoid）

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
 				"d3-scale": "4.0.2",
 				"d3-scale-chromatic": "3.1.0",
 				"diff": "^9.0.0",
-				"dompurify": "3.4.12",
+				"dompurify": "3.4.13",
 				"encoding-japanese": "^2.2.0",
 				"js-yaml": "^5.2.1",
 				"libheif-js": "1.19.8",
@@ -197,9 +197,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -215,9 +212,6 @@
 			"integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -235,9 +229,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -253,9 +244,6 @@
 			"integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -848,9 +836,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -868,9 +853,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -888,9 +870,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -908,9 +887,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT OR Apache-2.0",
 			"optional": true,
 			"os": [
@@ -987,9 +963,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1002,9 +975,6 @@
 			"integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -1019,9 +989,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1034,9 +1001,6 @@
 			"integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "MIT",
 			"optional": true,
@@ -5933,9 +5897,9 @@
 			}
 		},
 		"node_modules/astro/node_modules/js-yaml": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+			"version": "4.3.1",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+			"integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -6720,9 +6684,9 @@
 			}
 		},
 		"node_modules/dompurify": {
-			"version": "3.4.12",
-			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-			"integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+			"version": "3.4.13",
+			"resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.13.tgz",
+			"integrity": "sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==",
 			"license": "(MPL-2.0 OR Apache-2.0)",
 			"optionalDependencies": {
 				"@types/trusted-types": "^2.0.7"
@@ -7415,9 +7379,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "5.2.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-			"integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+			"version": "5.2.3",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+			"integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
 			"funding": [
 				{
 					"type": "github",
@@ -7985,9 +7949,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.16",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"funding": [
 				{
 					"type": "github",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"d3-scale": "4.0.2",
 		"d3-scale-chromatic": "3.1.0",
 		"diff": "^9.0.0",
-		"dompurify": "3.4.12",
+		"dompurify": "3.4.13",
 		"encoding-japanese": "^2.2.0",
 		"js-yaml": "^5.2.1",
 		"libheif-js": "1.19.8",


### PR DESCRIPTION
## 背景

PR #298 のCIが `npm audit --audit-level=high` で赤くなり続けていた件の根本対応です。このリポジトリの全PR・全ブランチをブロックしていた問題で、コード差分とは無関係に、既存の `package-lock.json` に対して新規公開されたadvisoryが3件重なっていました（確認時点でmain上でも同一lockfileにつき再現）。

1. `dompurify` <=3.4.12 — XSS via IN_PLACE hook removal（moderate, [GHSA-55q2-fjhq-7xh7](https://github.com/advisories/GHSA-55q2-fjhq-7xh7)）
2. `js-yaml` 4.0.0-4.3.0（`astro` 配下にネスト） — !!omap解決時の二次CPU消費（high, [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj)）
3. `nanoid` <3.3.17（`postcss`/`vite` 配下にネスト） — size=0時の無限ループ（high, [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8)）

## 対応

- `dompurify`: `3.4.12` → `3.4.13`（package.jsonで厳密ピン留めのため明示的にバージョン変更）
- `js-yaml` / `nanoid`: `npm update js-yaml nanoid` のみ。どちらも `astro` / `vite` / `postcss` 自身が宣言するsemver範囲内に既に修正版が存在したため、`package.json` 側の変更やoverridesの追加は不要でした

## 検討して見送った案

`js-yaml` を `overrides` で5系に強制統一する案も試しましたが、`astro` 内部が `js-yaml` をdefault export（CJS互換）でimportしており、5系ではdefault exportが提供されないため **`astro build` がその場で壊れる**ことを確認し、見送りました（`The requested module 'js-yaml' does not provide an export named 'default'`）。今回のnpm update方式は、`astro`/`vite`/`postcss` 自身が対応済みバージョンへ追従してくれたための解決であり、それらのpackage.jsonを直接変更してはいません。

## 検証

- `npm audit --audit-level=high`: 0 vulnerabilities
- `npm run check`（astro check + biome）: エラー0（既存無関係警告16件のみ）
- `npm run build`: 成功
- `npm run test:unit`: 985 tests / 985 pass（`yaml-json-toml`関連26件含む）

---
_Generated by [Claude Code](https://claude.ai/code/session_01SeQDpisThMSvqCpLB2fvHD)_