### PR TITLE
fix(a11y): スキップリンク欠如・検索モーダルのdialog非準拠・reduced-motion未対応の解消

### DIFF
--- a/src/components/common/SearchModal.tsx
+++ b/src/components/common/SearchModal.tsx
@@ -1,6 +1,6 @@
 import { Search } from 'lucide-react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { getSearchQueryMetadata, track } from '@/lib/analytics';
 import { toolCatalog } from '@/lib/tools/catalog';
 import { searchTools } from '@/lib/tools/search';
@@ -11,8 +11,14 @@ export default function SearchModal() {
 	const [query, setQuery] = useState('');
 	const [activeIndex, setActiveIndex] = useState(0);
 	const inputRef = useRef<HTMLInputElement>(null);
+	const dialogRef = useRef<HTMLDivElement>(null);
+	const triggerRef = useRef<HTMLElement | null>(null);
+	const titleId = useId();
+	const listboxId = useId();
 
 	const filteredTools = query ? searchTools(query) : toolCatalog;
+	const activeOptionId =
+		filteredTools.length > 0 ? `${listboxId}-option-${activeIndex}` : undefined;
 
 	// Track search_empty when query results in 0 tools
 	const trackedQueryRef = useRef<string>('');
@@ -54,15 +60,65 @@ export default function SearchModal() {
 		};
 	}, [isOpen]);
 
-	// Reset state and focus input when opened
+	// Reset state, remember the trigger element, and focus input when opened.
+	// Restore focus to the trigger when closed (WCAG 2.4.3 focus order).
 	useEffect(() => {
 		if (isOpen) {
+			triggerRef.current = document.activeElement as HTMLElement | null;
 			setQuery('');
 			setActiveIndex(0);
 			setTimeout(() => {
 				inputRef.current?.focus();
 			}, 0);
+		} else if (triggerRef.current) {
+			triggerRef.current.focus();
+			triggerRef.current = null;
 		}
+	}, [isOpen]);
+
+	// Lock background scroll while the modal is open (mobile背景スクロール防止)
+	useEffect(() => {
+		if (!isOpen) return;
+		const original = document.body.style.overflow;
+		document.body.style.overflow = 'hidden';
+		return () => {
+			document.body.style.overflow = original;
+		};
+	}, [isOpen]);
+
+	// Focus trap: keep Tab navigation within the dialog while open
+	useEffect(() => {
+		if (!isOpen) return;
+
+		const handleFocusTrap = (e: KeyboardEvent) => {
+			if (e.key !== 'Tab') return;
+			const container = dialogRef.current;
+			if (!container) return;
+
+			const focusable = Array.from(
+				container.querySelectorAll<HTMLElement>(
+					'a[href], button:not([disabled]), input:not([disabled]), [tabindex]',
+				),
+			).filter((el) => el.tabIndex !== -1);
+			if (focusable.length === 0) return;
+
+			const first = focusable[0];
+			const last = focusable[focusable.length - 1];
+			const active = document.activeElement;
+
+			if (e.shiftKey) {
+				if (active === first || !container.contains(active)) {
+					e.preventDefault();
+					last.focus();
+				}
+			} else if (active === last || !container.contains(active)) {
+				e.preventDefault();
+				first.focus();
+			}
+		};
+
+		window.addEventListener('keydown', handleFocusTrap);
+		return () => window.removeEventListener('keydown', handleFocusTrap);
 	}, [isOpen]);
 
 	// Handle keyboard navigation within the modal
@@ -112,13 +168,31 @@ export default function SearchModal() {
 				if (e.key === 'Escape') setIsOpen(false);
 			}}
 		>
-			<div className="relative w-full max-w-xl mx-4 overflow-hidden bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200">
+			<div
+				ref={dialogRef}
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby={titleId}
+				className="relative w-full max-w-xl mx-4 overflow-hidden bg-card border border-border rounded-xl shadow-2xl animate-in fade-in zoom-in-95 duration-200"
+			>
+				<h2 id={titleId} className="sr-only">
+					ツールを検索
+				</h2>
 				<div className="flex items-center px-4 py-3 border-b border-border">
-					<Search className="w-5 h-5 text-muted-foreground mr-3" />
+					<Search
+						className="w-5 h-5 text-muted-foreground mr-3"
+						aria-hidden="true"
+					/>
 					<input
 						ref={inputRef}
 						className="flex-1 bg-transparent border-none outline-none text-foreground placeholder:text-muted-foreground"
 						placeholder="ツールを検索... (Enterで移動)"
+						aria-label="ツールを検索"
+						role="combobox"
+						aria-expanded={filteredTools.length > 0}
+						aria-controls={listboxId}
+						aria-autocomplete="list"
+						aria-activedescendant={activeOptionId}
 						value={query}
 						onChange={(e) => {
 							setQuery(e.target.value);
@@ -131,16 +205,28 @@ export default function SearchModal() {
 				</div>
 				<div className="max-h-[60vh] overflow-y-auto p-2">
 					{filteredTools.length === 0 ? (
-						<div className="p-4 text-center text-sm text-muted-foreground">
+						<div
+							className="p-4 text-center text-sm text-muted-foreground"
+							aria-live="polite"
+						>
 							一致するツールが見つかりません。
 						</div>
 					) : (
-						<div className="flex flex-col gap-1">
+						<div
+							id={listboxId}
+							role="listbox"
+							aria-label="検索結果"
+							className="flex flex-col gap-1"
+						>
 							{filteredTools.map((tool, index) => (
 								<a
 									key={tool.id}
+									id={`${listboxId}-option-${index}`}
 									href={tool.href}
 									data-testid="search-result"
+									role="option"
+									aria-selected={index === activeIndex}
+									tabIndex={-1}
 									className={`flex flex-col gap-1 px-4 py-3 rounded-lg transition-colors ${
 										index === activeIndex
 											? 'bg-primary/10 text-foreground'
@@ -166,6 +252,11 @@ export default function SearchModal() {
 									</div>
 								</a>
 							))}
+						</div>
+					)}
+					{query.trim() && filteredTools.length > 0 && (
+						<div role="status" aria-live="polite" className="sr-only">
+							{filteredTools.length}件のツールが見つかりました
 						</div>
 					)}
 				</div>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -87,8 +87,14 @@ const cfBeaconToken = import.meta.env.PUBLIC_CF_BEACON_TOKEN;
   <slot name="head" />
 </head>
 <body class="min-h-screen flex flex-col">
+  <a
+    href="#main"
+    class="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:rounded-lg focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg"
+  >
+    本文へスキップ
+  </a>
   <Header />
-  <main class="flex-1">
+  <main id="main" tabindex="-1" class="flex-1">
     <slot />
   </main>
   <Footer />

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -168,3 +168,17 @@
 .copy-flash {
     animation: copy-flash 0.8s ease-in-out;
 }
+
+/* ===== Reduced Motion (WCAG 2.3.3) =====
+   OSの「視差効果を減らす」設定を尊重し、アニメーション・トランジションを実質的に無効化する。
+   個別対応（例: CameraScanner, QrReader）より後に評価されるよう最後に配置する。 */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}

--- a/tests/e2e/accessibility.spec.ts
+++ b/tests/e2e/accessibility.spec.ts
@@ -1,0 +1,141 @@
+import { expect, test } from './fixtures/base';
+
+test.describe('Accessibility: skip link', () => {
+	test('スキップリンクがTabキー1回目で出現し本文へ移動できる', async ({
+		page,
+	}) => {
+		await page.goto('/');
+
+		// ページ読み込み直後、最初のTabでスキップリンクにフォーカスが当たる
+		await page.keyboard.press('Tab');
+		const skipLink = page.getByRole('link', { name: '本文へスキップ' });
+		await expect(skipLink).toBeFocused();
+		await expect(skipLink).toHaveAttribute('href', '#main');
+
+		// Enterで本文（#main）へ移動できる
+		await page.keyboard.press('Enter');
+		await expect(page).toHaveURL(/#main$/);
+		await expect(page.locator('main#main')).toBeVisible();
+	});
+});
+
+test.describe('Accessibility: search modal dialog, reduced motion', () => {
+	// 検索モーダルはデスクトップサイズでのみ操作可能なため、モバイルテストはスキップ
+	test.skip(
+		({ isMobile }) => isMobile,
+		'Search modal is only operable on desktop',
+	);
+
+	test('検索モーダルがdialogロールとaria-modalを持つ', async ({ page }) => {
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+		await page.keyboard.press('Control+k');
+
+		const dialog = page.getByRole('dialog');
+		await expect(dialog).toBeVisible({ timeout: 5000 });
+		await expect(dialog).toHaveAttribute('aria-modal', 'true');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toHaveAttribute('aria-label', 'ツールを検索');
+	});
+
+	test('検索モーダルを開くとフォーカスがトラップされ、閉じるとトリガーへ復帰する', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+
+		const searchTrigger = page.locator('#search-trigger');
+		await searchTrigger.focus();
+		await searchTrigger.click();
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await expect(searchInput).toBeFocused();
+
+		// モーダル内でTabを押しても、フォーカスは入力欄内にとどまる（背後の要素へ抜けない）
+		await page.keyboard.press('Tab');
+		await expect(searchInput).toBeFocused();
+
+		// Escで閉じると、元のトリガー要素にフォーカスが戻る
+		await page.keyboard.press('Escape');
+		await expect(searchInput).not.toBeVisible();
+		await expect(searchTrigger).toBeFocused();
+	});
+
+	test('検索モーダル表示中は背景のスクロールがロックされる', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+		await expect(page.locator('body')).toHaveCSS('overflow', 'hidden');
+
+		await page.keyboard.press('Escape');
+		await expect(searchInput).not.toBeVisible();
+		await expect(page.locator('body')).not.toHaveCSS('overflow', 'hidden');
+	});
+
+	test('検索結果がlistbox/option/aria-selectedで表現される', async ({
+		page,
+	}) => {
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+		await searchInput.fill('csv');
+
+		const listbox = page.getByRole('listbox', { name: '検索結果' });
+		await expect(listbox).toBeVisible();
+
+		const options = page.getByRole('option');
+		await expect(options.first()).toHaveAttribute('aria-selected', 'true');
+
+		// ArrowDownでaria-activedescendantと選択状態のoptionが連動する
+		await page.keyboard.press('ArrowDown');
+		await expect(options.nth(1)).toHaveAttribute('aria-selected', 'true');
+		await expect(options.nth(0)).toHaveAttribute('aria-selected', 'false');
+
+		const activeDescendant = await searchInput.getAttribute(
+			'aria-activedescendant',
+		);
+		const secondOptionId = await options.nth(1).getAttribute('id');
+		expect(activeDescendant).toBe(secondOptionId);
+	});
+
+	test('OSのreduced-motion設定でアニメーションが実質停止する', async ({
+		page,
+	}) => {
+		await page.emulateMedia({ reducedMotion: 'reduce' });
+		await page.goto('/');
+		await page.waitForTimeout(1000);
+		await page.keyboard.press('Control+k');
+
+		const searchInput = page.getByPlaceholder(/ツールを検索/i);
+		await expect(searchInput).toBeVisible({ timeout: 5000 });
+
+		const dialog = page.getByRole('dialog');
+		// ブラウザは "0.01ms" を "1e-05s" のように ms/s いずれの単位でも正規化して
+		// 返しうるため、表記ではなく実際の秒数(0.00001s = 10μs以下)へ揃えて判定する。
+		const durationsInSeconds = await dialog.evaluate((el) => {
+			const toSeconds = (value: string) =>
+				value.endsWith('ms')
+					? Number.parseFloat(value) / 1000
+					: Number.parseFloat(value);
+			const style = window.getComputedStyle(el);
+			return {
+				animationDuration: toSeconds(style.animationDuration),
+				transitionDuration: toSeconds(style.transitionDuration),
+			};
+		});
+
+		expect(durationsInSeconds.animationDuration).toBeLessThanOrEqual(0.00001);
+		expect(durationsInSeconds.transitionDuration).toBeLessThanOrEqual(0.00001);
+	});
+});


### PR DESCRIPTION
taskId: `3acdfd3603368152a170d7d20f4a5a80`
実行ID: `triage-impl-20260809-0611`

## 概要

lintでは検出できない実装レベルのa11y欠落3件を修正しました（Cowork調査 `docs/investigation-latent-issues-2026-07-29.md` 項目5〜7）。

## 変更内容

### A. スキップリンク（WCAG 2.4.1 Level A）
- `BaseLayout.astro` の `<body>` 先頭に `#main` へのスキップリンクを追加（`sr-only focus:not-sr-only`、フォーカス時のみ可視）。
- `<main>` に `id="main"` `tabindex="-1"` を付与し、リンク先へフォーカス移動できるようにした。

### B. 検索モーダルのdialog準拠
`SearchModal.tsx` に以下を実装:
- `role="dialog"` `aria-modal="true"` `aria-labelledby`（視覚的に隠したタイトル要素を参照）
- フォーカストラップ（Tabキーでモーダル背後へ抜けないようwindowレベルでラップ）
- クローズ時のフォーカス復帰（開いた時点の`document.activeElement`を記憶し、閉じたら復帰）
- bodyスクロールロック（開いている間 `overflow: hidden`、閉じたら元の値に復元）
- 検索inputに `aria-label` を追加（`placeholder`のみだった状態を解消）
- `role="combobox"` + `role="listbox"`/`role="option"` + `aria-activedescendant`/`aria-selected` によるコンボボックス・リストボックスパターン（矢印キーでの選択が支援技術に伝わるように）
- 結果件数・0件時の `aria-live="polite"` 通知（既存の「一致するツールが見つかりません。」文言はそのまま維持し `aria-live` を付与、新規に一致件数を通知するsr-only領域を追加）

既存の検索挙動（`data-testid="search-result"`、`span.font-medium`、Ctrl+K/Cmd+K、矢印キー・Enter・Escでの操作、IME中Enterの無視）は変更していません。

### C. prefers-reduced-motion（WCAG 2.3.3）
`global.css` にグローバルな `@media (prefers-reduced-motion: reduce)` を追加し、アニメーション・トランジションを実質無効化（既存の個別対応箇所とは非競合）。

## 受け入れ基準への対応

- [x] スキップリンクが全ページでキーボード操作可能 → BaseLayout.astro に追加、E2Eで検証
- [x] 検索モーダルがダイアログのARIA・フォーカス・スクロール要件を満たす → role/aria-modal/フォーカストラップ/フォーカス復帰/スクロールロックを実装、E2Eで検証
- [x] reduced-motion設定でアニメーションを抑制 → global.cssにグローバル対応、E2Eで検証（`animation-duration`/`transition-duration`が実質0であることを確認）
- [x] E2E・lint・test・buildが成功する → 下記参照

## 検証

- `npm run check`（astro check + biome）: エラー0（既存の無関係な警告16件のみ）
- `npm run test:unit`: 985 tests / 985 pass
- `npm run build`: 成功（99ページ）
- `npx playwright test`（chromium, 新規 `accessibility.spec.ts` 6件 + `layout.spec.ts` / `search-ranking.spec.ts` / `search-navigation.spec.ts` 全件）: 全パス
- `npx playwright test`（chromium, フルスイート 541件）: 524 passed / 16 skipped（ピンチズーム等タッチ専用テストで意図的スキップ）/ 1 failed（`upscale.spec.ts` の4xアップスケールE2Eが90秒タイムアウト。AIモデル推論の実行環境依存によるもので、本PRの変更とは無関係。同テストはmainブランチ・本変更前でも同様に環境依存で不安定）

---
_Generated by [Claude Code](https://claude.ai/code/session_01UXgmFi5ed924qicNHH3YUg)_