### PR TITLE
fix: category直リンクアクセス時の自動スクロール位置を修正

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -138,7 +138,7 @@ const schema = {
     </div>
 
     <!-- 4. すべてのツール（カテゴリ絞り込み） -->
-    <div id="all-tools-section" class="mb-12">
+    <div id="all-tools-section" class="mb-12 scroll-mt-20">
       <h2 class="text-xl font-bold mb-6 flex items-center gap-2">
         <LayoutGrid className="h-6 w-6 text-primary" aria-hidden="true" /> すべてのツール
       </h2>
@@ -363,12 +363,14 @@ const schema = {
   }
 
   // 初回ロード時に実行
-  setupCategoryFilter();
+  // setupRecentTools() を先に実行し、「最近使ったツール」セクションの表示/非表示を確定させてから
+  // setupCategoryFilter() の自動スクロールを行う（順序が逆だとスクロール後にレイアウトが伸び、見出しが中央にずれる）
   setupRecentTools();
+  setupCategoryFilter();
 
   // AstroのView Transitionsに対応するための再バインド処理
   document.addEventListener('astro:after-swap', () => {
-    setupCategoryFilter();
     setupRecentTools();
+    setupCategoryFilter();
   });
 </script>


### PR DESCRIPTION
## Summary

`https://tools.codelife.cafe/?category=ai-image` のようにカテゴリ指定付きで直アクセスすると、自動スクロールで「すべてのツール」見出しが画面中央付近に来てしまい、ヘッダー直下に来る想定の表示になっていませんでした。

原因は `src/pages/index.astro` の初期化処理の実行順序でした。

1. `setupCategoryFilter()` が `?category=` を検出して `#all-tools-section` へ `scrollIntoView` する
2. その直後に `setupRecentTools()` が実行され、localStorage に閲覧履歴があると「最近使ったツール」セクションの `hidden` を解除する
3. これにより `#all-tools-section` より上の高さが増え、スクロール完了後にレイアウトが下へ伸びて見出しが画面中央あたりにずれる

## Changes

- `setupRecentTools()` → `setupCategoryFilter()` の順に実行するよう入れ替え（初回ロード時・`astro:after-swap` 時の両方）。レイアウトが確定してからスクロール位置を計算するようにした
- `#all-tools-section` に `scroll-mt-20` を追加し、sticky ヘッダー（`h-16`）に見出しが隠れないよう余白を確保

## Test plan

- [x] `npm run test:unit`（985 tests pass）
- [x] `npx playwright test tests/e2e/category-filter.spec.ts`（6 tests pass）
- [x] ローカルでビルド・起動し、`localStorage` に最近使ったツール履歴がある状態で `/?category=ai-image` へアクセスし、見出しがヘッダー直下（約15px下）に表示されることをスクリーンショットで確認

---
_Generated by [Claude Code](https://claude.ai/code/session_01FTzVtgCrf3mr13gtkEn8f9)_