### PR TITLE
fix(webmcp): align registerTool handling with WebMCP CG-Draft spec

### DIFF
--- a/src/lib/webmcp.ts
+++ b/src/lib/webmcp.ts
@@ -5,6 +5,7 @@ export type WebMcpTool = {
 	description: string;
 	inputSchema: Record<string, unknown>;
 	execute: (input: unknown) => Promise<unknown> | unknown;
+	annotations?: { readOnlyHint?: boolean; untrustedContentHint?: boolean };
 };
 
 type MaybeDisposable =
@@ -28,6 +29,9 @@ function wrapToolForClient(tool: WebMcpToolDefinition): WebMcpTool {
 	if (tool.outputSchema) {
 		(wrapped as Record<string, unknown>).outputSchema = tool.outputSchema;
 	}
+	if (tool.annotations) {
+		wrapped.annotations = tool.annotations;
+	}
 	return wrapped;
 }
 
@@ -40,7 +44,9 @@ export function provideToolsFromFactory(
 export function provideTools(tools: WebMcpTool[]): () => void {
 	if (typeof window === 'undefined') return () => {};
 
-	// 1. 最新 Chrome Imperative API 仕様 (document.modelContext.registerTool)
+	// 1. WebMCP仕様 (document.modelContext.registerTool)
+	// registerTool() は Promise<undefined> を返し、登録解除は AbortSignal 経由のみ
+	// （返り値にdispose/unregisterを持つハンドルは仕様上存在しない）。
 	if (
 		typeof document !== 'undefined' &&
 		document.modelContext &&
@@ -49,37 +55,24 @@ export function provideTools(tools: WebMcpTool[]): () => void {
 		const docCtx = document.modelContext;
 		const controller =
 			typeof AbortController !== 'undefined' ? new AbortController() : null;
-		const disposables: MaybeDisposable[] = [];
 
 		for (const tool of tools) {
 			try {
-				const res = docCtx.registerTool(
-					tool,
-					controller ? { signal: controller.signal } : undefined,
-				) as MaybeDisposable;
-				if (res) disposables.push(res);
+				Promise.resolve(
+					docCtx.registerTool(
+						tool,
+						controller ? { signal: controller.signal } : undefined,
+					),
+				).catch(() => {
+					/* no-op: 同名ツールの重複登録など、登録失敗は無視する */
+				});
 			} catch {
 				/* no-op */
 			}
 		}
 
 		return () => {
-			try {
-				if (controller) {
-					controller.abort();
-				}
-				for (const d of disposables) {
-					if (typeof d === 'function') {
-						d();
-					} else if (d && typeof d.dispose === 'function') {
-						d.dispose();
-					} else if (d && typeof d.unregister === 'function') {
-						d.unregister();
-					}
-				}
-			} catch {
-				/* no-op */
-			}
+			controller?.abort();
 		};
 	}
 

--- a/src/lib/webmcp/tool-factory.ts
+++ b/src/lib/webmcp/tool-factory.ts
@@ -1,10 +1,17 @@
 import type { WebMcpToolResult } from './errors.ts';
 
+/** WebMCP仕様のToolAnnotations相当（readOnlyHint / untrustedContentHint） */
+export interface WebMcpToolAnnotations {
+	readOnlyHint?: boolean;
+	untrustedContentHint?: boolean;
+}
+
 export interface WebMcpToolConfig<TInput, TOutput> {
 	name: string;
 	description: string;
 	inputSchema: Record<string, unknown>;
 	outputSchema?: Record<string, unknown>;
+	annotations?: WebMcpToolAnnotations;
 	validate: (input: unknown) => WebMcpToolResult<TInput>;
 	execute: (input: TInput) => Promise<TOutput> | TOutput;
 }
@@ -14,6 +21,7 @@ export interface WebMcpToolDefinition<TOutput = unknown> {
 	description: string;
 	inputSchema: Record<string, unknown>;
 	outputSchema?: Record<string, unknown>;
+	annotations?: WebMcpToolAnnotations;
 	run: (input: unknown) => Promise<WebMcpToolResult<TOutput>>;
 }
 
@@ -25,6 +33,7 @@ export function createWebMcpTool<TInput, TOutput>(
 		description: config.description,
 		inputSchema: config.inputSchema,
 		outputSchema: config.outputSchema,
+		annotations: config.annotations,
 		run: async (input: unknown): Promise<WebMcpToolResult<TOutput>> => {
 			try {
 				const validated = config.validate(input);

--- a/src/lib/webmcp/tools/hash.webmcp.ts
+++ b/src/lib/webmcp/tools/hash.webmcp.ts
@@ -48,6 +48,7 @@ export const hashTool = createWebMcpTool<HashInput, HashOutput>({
 		},
 		required: ['hash'],
 	},
+	annotations: { readOnlyHint: true },
 	validate(input) {
 		if (!isObject(input))
 			return failure('Input must be an object / 入力値が不正です');

--- a/src/lib/webmcp/tools/site.webmcp.ts
+++ b/src/lib/webmcp/tools/site.webmcp.ts
@@ -62,6 +62,7 @@ export function createSiteTools(
 			'List all web tools available on tools.codelife.cafe. Every tool runs entirely client-side and never sends input data to a server. / サイトで利用できる全Webツールの一覧を返す。全ツールがブラウザ内で完結し、入力データを外部送信しない。',
 		inputSchema: { type: 'object', properties: {} },
 		outputSchema: TOOL_LIST_SCHEMA,
+		annotations: { readOnlyHint: true },
 		validate(input) {
 			// 引数なしツールのため undefined / null / 空オブジェクトのいずれも許容する
 			if (input !== undefined && input !== null && !isObject(input)) {
@@ -92,6 +93,7 @@ export function createSiteTools(
 			required: ['query'],
 		},
 		outputSchema: TOOL_LIST_SCHEMA,
+		annotations: { readOnlyHint: true },
 		validate(input) {
 			if (!isObject(input)) {
 				return failure('Input must be an object / 入力値が不正です');

--- a/src/lib/webmcp/tools/tax.webmcp.ts
+++ b/src/lib/webmcp/tools/tax.webmcp.ts
@@ -85,6 +85,7 @@ export const taxTool = createWebMcpTool<TaxInput, TaxOutput>({
 		},
 		required: ['base', 'tax', 'total', 'result', 'taxAmount'],
 	},
+	annotations: { readOnlyHint: true },
 	validate(input) {
 		if (!isObject(input))
 			return failure('Input must be an object / 入力値が不正です');

--- a/src/lib/webmcp/tools/unix-time.webmcp.ts
+++ b/src/lib/webmcp/tools/unix-time.webmcp.ts
@@ -96,6 +96,7 @@ export const unixTimeTool = createWebMcpTool<UnixTimeInput, UnixTimeOutput>({
 			'relative',
 		],
 	},
+	annotations: { readOnlyHint: true },
 	validate(input) {
 		if (!isObject(input))
 			return failure('Input must be an object / 入力値が不正です');

--- a/src/types/webmcp.d.ts
+++ b/src/types/webmcp.d.ts
@@ -1,21 +1,32 @@
+interface WebMcpToolAnnotations {
+	readOnlyHint?: boolean;
+	untrustedContentHint?: boolean;
+}
+
 type WebMcpToolDefinition = {
 	name: string;
 	description: string;
 	inputSchema: Record<string, unknown>;
 	execute: (input: unknown) => Promise<unknown> | unknown;
+	annotations?: WebMcpToolAnnotations;
 };
 
+/** 旧ドラフト仕様 (navigator.modelContext.provideContext) 向けの互換フォールバック */
 interface ModelContext {
 	provideContext(args: { tools: WebMcpToolDefinition[] }): unknown;
 	clearContext?: () => void;
 }
 
+/**
+ * WebMCP仕様 (document.modelContext) の registerTool は Promise<undefined> を返し、
+ * 登録解除は options.signal の abort でのみ行われる（返り値にunregister手段は無い）。
+ * https://webmachinelearning.github.io/webmcp/
+ */
 interface DocumentModelContext {
 	registerTool(
 		tool: WebMcpToolDefinition,
 		options?: { signal?: AbortSignal },
-	): unknown;
-	unregisterTool?: (name: string) => void;
+	): Promise<undefined>;
 }
 
 interface Navigator {

--- a/tests/e2e/webmcp.spec.ts
+++ b/tests/e2e/webmcp.spec.ts
@@ -41,6 +41,88 @@ const WEBMCP_INIT_SCRIPT = `
 })();
 `;
 
+interface WebMcpDocMockWindow extends Window {
+	__webmcpDocTools: WebMcpMockTool[];
+	__webmcpDocAborted: boolean;
+}
+
+// document.modelContext.registerTool() は現行のWebMCP仕様における主API。
+// ツール単位で呼ばれ、Promise<undefined>を返し、登録解除はoptions.signalのabort経由でのみ行われる。
+const WEBMCP_DOCUMENT_INIT_SCRIPT = `
+(() => {
+  window.__webmcpDocTools = [];
+  window.__webmcpDocAborted = false;
+
+  Object.defineProperty(document, 'modelContext', {
+    configurable: true,
+    value: {
+      registerTool(tool, options) {
+        window.__webmcpDocTools.push(tool);
+        options?.signal?.addEventListener('abort', () => {
+          window.__webmcpDocAborted = true;
+        });
+        return Promise.resolve(undefined);
+      },
+    },
+  });
+})();
+`;
+
+test.describe('WebMCP Tool Registration — document.modelContext (現行仕様)', () => {
+	test('generate_hash is registered via document.modelContext.registerTool', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_DOCUMENT_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const tools = await page.evaluate(
+			() => (window as unknown as WebMcpDocMockWindow).__webmcpDocTools,
+		);
+		const toolNames = tools.map((t) => t.name);
+		expect(toolNames).toContain('generate_hash');
+	});
+
+	test('generate_hash execute() returns a hash via the registered tool', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_DOCUMENT_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		const result = await page.evaluate(async () => {
+			const tool = (
+				window as unknown as WebMcpDocMockWindow
+			).__webmcpDocTools.find((t) => t.name === 'generate_hash');
+			if (!tool) throw new Error('generate_hash tool is not registered');
+			return await tool.execute({ text: 'hello', algorithm: 'md5' });
+		});
+
+		expect(result).toEqual({ hash: '5d41402abc4b2a76b9719d911017c592' });
+	});
+
+	test('registerTool is called with an AbortSignal for spec-defined unregistration', async ({
+		page,
+		createToolPage,
+	}) => {
+		await page.addInitScript(WEBMCP_DOCUMENT_INIT_SCRIPT);
+
+		const toolPage = createToolPage('hash');
+		await toolPage.goto();
+
+		// 仕様上、登録解除はregisterTool()の返り値ではなくoptions.signalのabortでのみ行われる。
+		// signalが渡されていること自体を確認する（未abort状態）。
+		const abortedBefore = await page.evaluate(
+			() => (window as unknown as WebMcpDocMockWindow).__webmcpDocAborted,
+		);
+		expect(abortedBefore).toBe(false);
+	});
+});
+
 test.describe('WebMCP Tool Registration — /hash', () => {
 	test('generate_hash tool is registered via mock modelContext', async ({
 		page,

--- a/tests/unit/phase3h.test.ts
+++ b/tests/unit/phase3h.test.ts
@@ -12,18 +12,17 @@ test('webmcp: window / navigator / document が未定義の環境では no-op �
 	cleanup();
 });
 
-test('webmcp: document.modelContext (最新Chrome仕様) が存在する場合に registerTool が呼ばれ cleanup が機能すること', () => {
+test('webmcp: document.modelContext (WebMCP仕様) が存在する場合に registerTool が呼ばれ、cleanupがAbortSignal経由で機能すること', () => {
 	const registeredTools: unknown[] = [];
-	let unregistered = false;
+	let capturedSignal: AbortSignal | undefined;
 
 	const mockDocModelContext = {
-		registerTool(tool: unknown) {
+		// 仕様上 registerTool() は Promise<undefined> を返し、
+		// 登録解除は戻り値ではなく options.signal の abort でのみ行われる
+		registerTool(tool: unknown, options?: { signal?: AbortSignal }) {
 			registeredTools.push(tool);
-			return {
-				unregister() {
-					unregistered = true;
-				},
-			};
+			capturedSignal = options?.signal;
+			return Promise.resolve(undefined);
 		},
 	};
 
@@ -52,10 +51,10 @@ test('webmcp: document.modelContext (最新Chrome仕様) が存在する場合�
 
 		assert.equal(registeredTools.length, 1);
 		assert.deepEqual(registeredTools[0], tools[0]);
-		assert.equal(unregistered, false);
+		assert.equal(capturedSignal?.aborted, false);
 
 		cleanup();
-		assert.equal(unregistered, true);
+		assert.equal(capturedSignal?.aborted, true);
 	} finally {
 		Object.defineProperty(globalThis, 'document', {
 			value: originalDocument,

--- a/tests/unit/webmcp-factory.test.ts
+++ b/tests/unit/webmcp-factory.test.ts
@@ -506,7 +506,8 @@ test('provideToolsFromFactory: wraps tool results with isError for failures', as
 					registeredTools.push(
 						tool as { execute: (input: unknown) => Promise<unknown> },
 					);
-					return { unregister() {} };
+					// 仕様上 registerTool() は Promise<undefined> を返す
+					return Promise.resolve(undefined);
 				},
 			},
 		},
@@ -573,7 +574,8 @@ test('provideToolsFromFactory: forwards outputSchema to registered tool', async 
 			modelContext: {
 				registerTool(tool: unknown) {
 					registeredTools.push(tool as Record<string, unknown>);
-					return { unregister() {} };
+					// 仕様上 registerTool() は Promise<undefined> を返す
+					return Promise.resolve(undefined);
 				},
 			},
 		},
@@ -620,5 +622,153 @@ test('provideToolsFromFactory: forwards outputSchema to registered tool', async 
 			configurable: true,
 		});
 		registeredTools = [];
+	}
+});
+
+test('provideToolsFromFactory: forwards annotations.readOnlyHint to registered tool', async () => {
+	const { provideToolsFromFactory } = await import('../../src/lib/webmcp.ts');
+
+	let registeredTools: Array<Record<string, unknown>> = [];
+
+	const originalDocument = globalThis.document;
+	const originalWindow = globalThis.window;
+
+	Object.defineProperty(globalThis, 'window', {
+		value: {},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			modelContext: {
+				registerTool(tool: unknown) {
+					registeredTools.push(tool as Record<string, unknown>);
+					return Promise.resolve(undefined);
+				},
+			},
+		},
+		configurable: true,
+	});
+
+	try {
+		const testTool = createWebMcpTool({
+			name: 'test_annotations',
+			description: 'Test annotations forwarding',
+			inputSchema: { type: 'object', properties: {} },
+			annotations: { readOnlyHint: true },
+			validate: () => success({}),
+			execute: () => ({}),
+		});
+
+		provideToolsFromFactory([testTool]);
+
+		assert.equal(registeredTools.length, 1);
+		assert.deepEqual(registeredTools[0].annotations, { readOnlyHint: true });
+	} finally {
+		Object.defineProperty(globalThis, 'document', {
+			value: originalDocument,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+		});
+		registeredTools = [];
+	}
+});
+
+test('provideToolsFromFactory: registerTool rejection does not throw or crash', async () => {
+	const { provideToolsFromFactory } = await import('../../src/lib/webmcp.ts');
+
+	const originalDocument = globalThis.document;
+	const originalWindow = globalThis.window;
+
+	Object.defineProperty(globalThis, 'window', {
+		value: {},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			modelContext: {
+				// 仕様上、同名ツールの重複登録等はPromiseのrejectで表現される
+				registerTool() {
+					return Promise.reject(new Error('InvalidStateError'));
+				},
+			},
+		},
+		configurable: true,
+	});
+
+	try {
+		const testTool = createWebMcpTool({
+			name: 'test_reject',
+			description: 'Test rejection handling',
+			inputSchema: { type: 'object', properties: {} },
+			validate: () => success({}),
+			execute: () => ({}),
+		});
+
+		assert.doesNotThrow(() => provideToolsFromFactory([testTool]));
+		// マイクロタスクキューを1周させ、rejectionが処理されるのを待つ
+		await Promise.resolve();
+		await Promise.resolve();
+	} finally {
+		Object.defineProperty(globalThis, 'document', {
+			value: originalDocument,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+		});
+	}
+});
+
+test('provideToolsFromFactory: cleanup aborts the signal passed to registerTool (no unregister handle used)', async () => {
+	const { provideToolsFromFactory } = await import('../../src/lib/webmcp.ts');
+
+	let capturedSignal: AbortSignal | undefined;
+
+	const originalDocument = globalThis.document;
+	const originalWindow = globalThis.window;
+
+	Object.defineProperty(globalThis, 'window', {
+		value: {},
+		configurable: true,
+	});
+	Object.defineProperty(globalThis, 'document', {
+		value: {
+			modelContext: {
+				registerTool(_tool: unknown, options?: { signal?: AbortSignal }) {
+					capturedSignal = options?.signal;
+					return Promise.resolve(undefined);
+				},
+			},
+		},
+		configurable: true,
+	});
+
+	try {
+		const testTool = createWebMcpTool({
+			name: 'test_cleanup',
+			description: 'Test cleanup via AbortSignal',
+			inputSchema: { type: 'object', properties: {} },
+			validate: () => success({}),
+			execute: () => ({}),
+		});
+
+		const cleanup = provideToolsFromFactory([testTool]);
+		assert.equal(capturedSignal?.aborted, false);
+
+		cleanup();
+		assert.equal(capturedSignal?.aborted, true);
+	} finally {
+		Object.defineProperty(globalThis, 'document', {
+			value: originalDocument,
+			configurable: true,
+		});
+		Object.defineProperty(globalThis, 'window', {
+			value: originalWindow,
+			configurable: true,
+		});
 	}
 });


### PR DESCRIPTION
## Summary

Audited the site's WebMCP implementation (`src/lib/webmcp.ts` and `src/lib/webmcp/**`) against the current WebMCP Web Machine Learning Community Group Draft Report (`document.modelContext`, latest publication April 2026). Found and fixed a real spec-compliance gap plus a few smaller improvements:

- **`registerTool()` return-value handling was spec-incorrect.** Per the current draft, `document.modelContext.registerTool()` returns `Promise<undefined>` and can reject (e.g. `InvalidStateError` for a duplicate tool name); there is no disposable/handle returned, and tool unregistration happens **only** via the `AbortSignal` passed in `options.signal`. The previous code called `registerTool()` synchronously, wrapped it in a sync `try/catch` (which cannot catch a promise rejection), and treated the return value as a `{ dispose() }` / `{ unregister() }` handle that no conforming implementation provides. This risked unhandled promise rejections and dead cleanup code. Fixed to await/`.catch()` the promise per tool and rely solely on `AbortController.abort()` for cleanup.
- **Added `annotations: { readOnlyHint: true }`** to all five tools (`list_tools`, `search_tools`, `generate_hash`, `calc_tax`, `convert_unix_time`) — `ToolAnnotations` is part of the spec's `ModelContextTool` dictionary, and every tool on this site is a pure, side-effect-free computation, so this is an accurate signal for agents.
- **Updated ambient types** (`src/types/webmcp.d.ts`) to match the actual spec shape (`registerTool` returns `Promise<undefined>`, dropped the fictitious `unregisterTool` method that isn't part of the spec).
- `outputSchema` is intentionally left in place — it's explicitly called out as an "open question" (not yet standardized) in the proposal, but it's a harmless/forward-compatible extra dictionary member, and useful as internal documentation of each tool's output shape.
- The legacy `navigator.modelContext.provideContext` fallback branch is unchanged; it was already correctly labeled in comments as the old/pre-standardization draft, kept only for backward compatibility.

## Test coverage gap found & fixed

The existing e2e suite (`tests/e2e/webmcp.spec.ts`) only ever mocked `navigator.modelContext.provideContext` (the legacy draft), so the primary, current-spec `document.modelContext.registerTool` code path had **zero** test coverage. Same issue in `tests/unit/phase3h.test.ts`, whose mock for `document.modelContext.registerTool` returned a synchronous `{ unregister() }` object instead of a `Promise`.

- Added a new e2e `describe` block mocking `document.modelContext.registerTool` correctly (per-tool call, `Promise<undefined>`, unregistration via `options.signal`).
- Fixed `phase3h.test.ts` and `webmcp-factory.test.ts` mocks to return `Promise<undefined>` and assert cleanup via `AbortSignal.aborted`, not a returned handle.
- Added unit tests for: registerTool rejection not crashing, cleanup aborting the correct signal, and `annotations` forwarding.

## Test plan

- [x] `npm run test:unit` — all webmcp-related tests pass (826/826 excluding 28 unrelated pre-existing failures verified against `main`)
- [x] `npx @biomejs/biome check` on touched files — no new warnings (5 pre-existing non-null-assertion warnings in `webmcp.spec.ts`, already documented in `CLAUDE.md`/`AGENTS.md` as unrelated)
- [x] `npx tsc --noEmit` — no new errors (pre-existing config-level `TS5097`/`TS7031` noise confirmed present on `main` too)
- [ ] `npm test` (Playwright e2e) — not run in this sandbox (no browser available); new `document.modelContext` describe block follows the same pattern as existing passing specs in the same file


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gxhs3xjTdvc3V7SciQ25jN)_