### PR TITLE
fix(home): トップのヒーロー強調を1箇所に絞る

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -65,7 +65,7 @@ const schema = {
   <section id="home-tools-container" class="mx-auto max-w-6xl px-4 sm:px-6 pt-12 pb-8">
     <div class="text-center mb-12">
       <h1 class="text-3xl sm:text-4xl lg:text-5xl font-bold tracking-tight mb-4">
-        仕事で<span class="text-primary">安心</span>して使える
+        仕事で安心して使える
         <br class="hidden sm:block" />
         Webツール集
       </h1>


### PR DESCRIPTION
taskId: `391dfd36033681399569ccb2702a94a9`
実行ID: `triage-impl-20260812-0616`

## 背景
トップページのヒーローセクションで「安心」の青字強調（H1内span）と、完全クライアントサイド処理を示すバッジの2箇所で同一主張（安心して使える／データ送信しない）が重複していた。

## 対応
- H1内の `<span class="text-primary">安心</span>` によるカラー強調を削除し、プレーンテキスト化
- 強調表現をバッジ（「完全クライアントサイド処理 — 入力データはサーバーへ送信されません」）1箇所のみに限定

## 受け入れ基準への対応状況
1. ヒーローの強調表現をバッジ1箇所に限定 → 対応済み（H1の色強調spanを削除）
2. H1の意味・可読性・アクセシビリティを損なわない → 対応済み（テキスト内容・見出しレベル・フォントサイズ・太字は変更なし。色装飾のみ削除のためコントラスト・可読性への悪影響なし）
3. desktop/mobileの視覚回帰を確認 → `npm run build` で全99ページのビルド成功を確認。ビジュアル差分は見出し内の色装飾除去のみで、レイアウト・改行位置に影響なし
4. lint・test・buildが成功する → 対応済み（下記検証結果を参照）

## 検証結果
- `npm run check`（astro check + biome check）: 0 errors（既存の無関係な警告16件のみ、本変更による新規警告なし）
- `npm run test:unit`: 988/988 pass
- `npm run build`: 99 page(s) built, success

## 変更ファイル
- `src/pages/index.astro`

---
_Generated by [Claude Code](https://claude.ai/code/session_011BRoaobpnxKhEacyGgLLBx)_