### PR TITLE
test: replace fixed waitForTimeout with event-driven waits in E2E specs

### DIFF
--- a/tests/e2e/csv-fixer.spec.ts
+++ b/tests/e2e/csv-fixer.spec.ts
@@ -158,12 +158,12 @@ test.describe('CSV文字化け修復ツール', () => {
 			page.getByText('エンコーディングの自動検出の信頼度が低いです'),
 		).toBeVisible();
 
-		await page.waitForTimeout(1000);
-		expect(downloadCount).toBe(0);
-
+		// フォールバックボタンの表示を待つことで、自動ダウンロード判定処理が
+		// 完了済みであることを保証してから未発火を検証する
 		await expect(
 			page.getByRole('button', { name: '変換してダウンロード' }),
 		).toBeVisible();
+		expect(downloadCount).toBe(0);
 	});
 
 	test('即時変換モードONで変換に失敗した場合、エラーメッセージが表示されること', async ({

--- a/tests/e2e/image-mosaic.spec.ts
+++ b/tests/e2e/image-mosaic.spec.ts
@@ -151,7 +151,7 @@ test.describe('画像モザイク・ぼかし', () => {
 		});
 		await expect(page.getByText('blue.png')).toBeVisible();
 		await dragOnCanvas(page, canvas, { x: 140, y: 140 }, { x: 220, y: 220 });
-		await page.waitForTimeout(500);
+		// rAF経由の非同期描画完了は poll のリトライで待つ
 		await expect
 			.poll(() => getCanvasPixel(page, 'editor-canvas', 180, 180))
 			.toEqual(BLUE);

--- a/tests/e2e/layout.spec.ts
+++ b/tests/e2e/layout.spec.ts
@@ -42,8 +42,7 @@ test.describe('Layout & Navigation', () => {
 	});
 
 	test('Cmd+K Search focuses search input', async ({ page }) => {
-		// Wait for React SearchModal component to hydrate by checking for an interactive element
-		await page.waitForTimeout(1000);
+		// SearchModal (client:load) のハイドレーションは beforeEach の page.goto 内で待機済み
 
 		// Press Ctrl+K
 		await page.keyboard.press('Control+k');

--- a/tests/e2e/search-navigation.spec.ts
+++ b/tests/e2e/search-navigation.spec.ts
@@ -10,9 +10,8 @@ test.describe('Search after page navigation', () => {
 	test('Search button works after navigating to a tool page', async ({
 		page,
 	}) => {
-		// 1. トップページにアクセス
+		// 1. トップページにアクセス（fixtureのgotoがハイドレーション完了まで待機する）
 		await page.goto('/');
-		await page.waitForTimeout(1000);
 
 		// 2. 検索ボタンが動作することを確認
 		const searchTrigger = page.locator('#search-trigger');
@@ -29,7 +28,6 @@ test.describe('Search after page navigation', () => {
 
 		// 4. ツールページに遷移（View Transitionsによるクライアントサイド遷移）
 		await page.goto('/char-count');
-		await page.waitForTimeout(1000);
 
 		// 5. 遷移後に検索ボタンが動作することを確認
 		const searchTriggerAfter = page.locator('#search-trigger');
@@ -43,13 +41,11 @@ test.describe('Search after page navigation', () => {
 	test('Ctrl+K shortcut works after navigating to a tool page', async ({
 		page,
 	}) => {
-		// 1. トップページにアクセス
+		// 1. トップページにアクセス（fixtureのgotoがハイドレーション完了まで待機する）
 		await page.goto('/');
-		await page.waitForTimeout(1000);
 
 		// 2. ツールページに遷移
 		await page.goto('/zenkaku-hankaku');
-		await page.waitForTimeout(1000);
 
 		// 3. 遷移後にCtrl+Kが動作することを確認
 		await page.keyboard.press('Control+k');
@@ -60,16 +56,16 @@ test.describe('Search after page navigation', () => {
 	});
 
 	test('Search via internal link navigation works', async ({ page }) => {
-		// 1. トップページにアクセス
+		// 1. トップページにアクセス（fixtureのgotoがハイドレーション完了まで待機する）
 		await page.goto('/');
-		await page.waitForTimeout(1000);
 
 		// 2. ツールカードをクリックして内部遷移
 		const toolLink = page.locator('a[href="/char-count"]').first();
 		if (await toolLink.isVisible()) {
 			await toolLink.click();
 			await page.waitForURL('**/char-count');
-			await page.waitForTimeout(1000);
+			// View Transitionによるクライアントサイド遷移の完了を待つ
+			await page.waitForLoadState('networkidle');
 
 			// 3. 遷移後に検索ボタンが動作することを確認
 			const searchTrigger = page.locator('#search-trigger');
@@ -82,9 +78,8 @@ test.describe('Search after page navigation', () => {
 	});
 
 	test('Enter during IME composition does not navigate', async ({ page }) => {
-		// 1. トップページにアクセスして検索モーダルを開く
+		// 1. トップページにアクセスして検索モーダルを開く（fixtureのgotoがハイドレーション完了まで待機する）
 		await page.goto('/');
-		await page.waitForTimeout(1000);
 
 		await page.keyboard.press('Control+k');
 		const searchInput = page.getByPlaceholder(/ツールを検索/i);
@@ -101,22 +96,21 @@ test.describe('Search after page navigation', () => {
 				}),
 			);
 		});
-		await page.waitForTimeout(500);
 
 		// 3. ページ遷移せず、モーダルが開いたままであることを確認
+		// （isComposing判定はハンドラ内で同期的に行われるため、待機なしで検証可能）
 		expect(new URL(page.url()).pathname).toBe('/');
 		await expect(searchInput).toBeVisible();
 
 		// 4. 通常の Enter では選択中ツールへ遷移することを確認
 		await page.keyboard.press('Enter');
-		await page.waitForTimeout(1000);
+		await page.waitForURL((url) => url.pathname !== '/');
 		expect(new URL(page.url()).pathname).not.toBe('/');
 	});
 
 	test('Keyboard shortcut label shows correct OS key', async ({ page }) => {
 		// Playwright runs on non-Mac typically, so expect Ctrl+K
 		await page.goto('/');
-		await page.waitForTimeout(1000);
 
 		const kbdElement = page.locator('#search-kbd');
 		await expect(kbdElement).toBeVisible();
@@ -126,7 +120,6 @@ test.describe('Search after page navigation', () => {
 
 		// ツールページに遷移
 		await page.goto('/json-formatter');
-		await page.waitForTimeout(1000);
 
 		// 遷移後も同じ表記が維持されることを確認
 		const afterNavText = await kbdElement.textContent();

--- a/tests/e2e/upscale.spec.ts
+++ b/tests/e2e/upscale.spec.ts
@@ -74,7 +74,9 @@ test.describe('画像アップスケール', () => {
 		const requests: string[] = [];
 		page.on('request', (r) => requests.push(r.url()));
 		await uploadGeneratedImage(page, 64, 64);
-		await page.waitForTimeout(500);
+		// アップロード処理（解像度検証等の非同期処理）完了後に表示される実行ボタンを
+		// 待つことで、モデル/ランタイム未取得の判定を確定させてから検証する
+		await expect(page.locator('[data-testid="upscale-run"]')).toBeVisible();
 		expect(
 			requests.some((u) => /onnxruntime-web|\.onnx/.test(u)),
 			'アップロード時点ではモデル/ランタイム未取得',


### PR DESCRIPTION
## 概要
固定 `page.waitForTimeout()` を使うE2Eテストが5ファイルあり、flakyの温床になっていた。これらをイベント・状態駆動の待機に置換した。

タスク: https://app.notion.com/p/391dfd3603368117a474da71cdbc6f68

## 変更内容

### `tests/e2e/search-navigation.spec.ts`（1000ms×9回 + 500ms×1回）
- `page.goto()` 直後の待機はすべて削除。`tests/e2e/fixtures/base.ts` の `page.goto` が `client:load` islandのハイドレーション完了(`astro-island[ssr]`の消滅)を既に待機しているため冗長だった
- View Transitionによるクリックベースの内部遷移後は `page.waitForLoadState('networkidle')` に置換
- IME変換中Enterの無視判定はハンドラ内で同期的に行われる（`SearchModal.tsx`で確認）ため待機を削除
- 通常Enterでの実遷移（`window.location.href`代入）は `page.waitForURL()` で待機するよう置換

### `tests/e2e/csv-fixer.spec.ts`（1000ms×1回）
- 「自動ダウンロードが発火しない」の検証を、フォールバックボタンの表示待ち（既存の `expect().toBeVisible()`）を先に実行し、その後に `downloadCount` を検証する順序へ変更。判定処理の完了を状態で確認してから検証する

### `tests/e2e/layout.spec.ts`（1000ms×1回）
- `beforeEach` の `page.goto('/')` で既にSearchModalのハイドレーションを待機済みのため、テスト内の冗長な待機を削除

### `tests/e2e/image-mosaic.spec.ts`（500ms×1回）
- Canvas描画完了待ちとして直後に既に `expect.poll(() => getCanvasPixel(...))` があり、これがリトライ付きで描画完了を検査するため、待機を削除

### `tests/e2e/upscale.spec.ts`（500ms×1回）
- モデル/ランタイム未取得の検証前に、アップロード処理（画像デコード等の非同期処理）完了のマーカーとして実行ボタン（`upscale-run`）の表示を待つよう変更

## 受け入れ基準
1. ✅ 指定5ファイルの固定waitForTimeoutをイベント・状態駆動待機へ置換
2. ✅ 待機理由ごとに適切なPlaywright APIを使用（`waitForLoadState` / `waitForURL` / 既存の `expect.poll` / 状態ベースの `toBeVisible`）
3. ✅ 変更対象E2Eを `--repeat-each=3` で実行しflakyが再現しないことを確認（layout / search-navigation / csv-fixer / image-mosaic は全パス。upscale は対象テスト自体は3回ともパス。同ファイル内の別テスト「極小画像を4xアップスケール」は本サンドボックス環境が `cdn.jsdelivr.net` へアクセスできずONNXランタイム取得に失敗するための既知の環境制約であり、今回の変更とは無関係）
4. ✅ `npm run lint` / `npm run test:unit`（988 tests pass）/ `npm run build` すべて成功

## 制約
- 既存のテストロジック（アサーション内容・操作手順）は変更せず、待機方法のみを置換した

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhQ923R6J2RH62J5qh74sN)_