### PR TITLE
fix: ダークモードのセーフティバッジのコントラスト確認・改善

### DIFF
--- a/src/components/layout/SafetyBadge.tsx
+++ b/src/components/layout/SafetyBadge.tsx
@@ -14,7 +14,7 @@ export default function SafetyBadge() {
 			<PopoverTrigger asChild>
 				<button
 					type="button"
-					className="inline-flex items-center gap-2 rounded-lg border border-safety/30 bg-safety/5 px-3 py-1.5 text-sm font-medium text-safety hover:bg-safety/10 transition-colors cursor-pointer"
+					className="inline-flex items-center gap-2 rounded-lg border border-safety/30 bg-safety/5 px-3 py-1.5 text-sm font-medium text-[#047857] hover:bg-safety/10 transition-colors cursor-pointer dark:text-safety"
 					aria-label="セキュリティ情報を表示"
 				>
 					<ShieldCheck className="h-4 w-4" />

--- a/tests/unit/safety-badge-contrast.test.ts
+++ b/tests/unit/safety-badge-contrast.test.ts
@@ -1,0 +1,104 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/safety-badge-contrast.test.ts
+//
+// SafetyBadge（ツールページの「入力データ非送信」バッジ）の文字色が、
+// 実際の背景（bg-safety/5 をページ背景に重ねた色）に対してWCAG AA基準の
+// 通常文字コントラスト比 4.5:1 以上を満たすことを回帰的に検証する。
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { test } from 'node:test';
+import { hexToRgb, type Rgb } from '../../src/lib/tools/color.ts';
+
+const repoRoot = path.resolve(import.meta.dirname, '../..');
+const globalCss = fs.readFileSync(
+	path.join(repoRoot, 'src/styles/global.css'),
+	'utf-8',
+);
+const safetyBadgeSource = fs.readFileSync(
+	path.join(repoRoot, 'src/components/layout/SafetyBadge.tsx'),
+	'utf-8',
+);
+
+function requireHex(rgb: Rgb | null): Rgb {
+	assert.ok(rgb, 'hex color must parse');
+	return rgb as Rgb;
+}
+
+/** :root {...} または .dark {...} ブロックから `--name: #hex;` の値を抽出する */
+function readCssVar(css: string, blockSelector: string, varName: string): Rgb {
+	const blockMatch = css.match(
+		new RegExp(`${blockSelector.replace('.', '\\.')}\\s*\\{([^}]*)\\}`),
+	);
+	assert.ok(blockMatch, `CSS block ${blockSelector} must exist`);
+	const varMatch = blockMatch[1].match(
+		new RegExp(`--${varName}:\\s*(#[0-9A-Fa-f]{3,8})`),
+	);
+	assert.ok(varMatch, `--${varName} must be defined in ${blockSelector}`);
+	return requireHex(hexToRgb(varMatch[1]));
+}
+
+// WCAG 2.1: 相対輝度とコントラスト比
+function relativeLuminance(rgb: Rgb): number {
+	const channel = (c: number) => {
+		const v = c / 255;
+		return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+	};
+	return (
+		0.2126 * channel(rgb.r) + 0.7152 * channel(rgb.g) + 0.0722 * channel(rgb.b)
+	);
+}
+
+function contrastRatio(a: Rgb, b: Rgb): number {
+	const [l1, l2] = [relativeLuminance(a), relativeLuminance(b)].sort(
+		(x, y) => y - x,
+	);
+	return (l1 + 0.05) / (l2 + 0.05);
+}
+
+/** foreground を alpha 比率で background に重ねた実効色を返す（bg-safety/5 相当の合成） */
+function alphaBlend(foreground: Rgb, alpha: number, background: Rgb): Rgb {
+	return {
+		r: alpha * foreground.r + (1 - alpha) * background.r,
+		g: alpha * foreground.g + (1 - alpha) * background.g,
+		b: alpha * foreground.b + (1 - alpha) * background.b,
+	};
+}
+
+const WCAG_AA_NORMAL_TEXT = 4.5;
+
+test('SafetyBadgeの文字色がライトモードでWCAG AA(4.5:1)を満たす', () => {
+	const pageBg = readCssVar(globalCss, ':root', 'background');
+	const safety = readCssVar(globalCss, ':root', 'safety');
+	const badgeBg = alphaBlend(safety, 0.05, pageBg); // bg-safety/5
+
+	const textHexMatch = safetyBadgeSource.match(/text-\[(#[0-9A-Fa-f]{6})\]/);
+	assert.ok(
+		textHexMatch,
+		'SafetyBadgeのトリガーはライトモード用の明示的な文字色を持つこと',
+	);
+	const lightText = requireHex(hexToRgb(textHexMatch[1]));
+
+	const ratio = contrastRatio(lightText, badgeBg);
+	assert.ok(
+		ratio >= WCAG_AA_NORMAL_TEXT,
+		`ライトモードのコントラスト比 ${ratio.toFixed(2)}:1 が WCAG AA ${WCAG_AA_NORMAL_TEXT}:1 未満`,
+	);
+});
+
+test('SafetyBadgeの文字色がダークモードでWCAG AA(4.5:1)を満たす', () => {
+	const pageBg = readCssVar(globalCss, '.dark', 'background');
+	const safety = readCssVar(globalCss, '.dark', 'safety');
+	const badgeBg = alphaBlend(safety, 0.05, pageBg); // bg-safety/5
+
+	assert.ok(
+		/dark:text-safety\b/.test(safetyBadgeSource),
+		'SafetyBadgeのトリガーはダークモードで --safety トークンを使うこと',
+	);
+
+	const ratio = contrastRatio(safety, badgeBg);
+	assert.ok(
+		ratio >= WCAG_AA_NORMAL_TEXT,
+		`ダークモードのコントラスト比 ${ratio.toFixed(2)}:1 が WCAG AA ${WCAG_AA_NORMAL_TEXT}:1 未満`,
+	);
+});


### PR DESCRIPTION
taskId: `ffbcff2ae68346e3901141e4571bb853`
実行ID: `triage-impl-20260813-0613`

## 背景

タスク「ダークモードのセーフティバッジのコントラスト確認・改善」の受け入れ基準に従い、`SafetyBadge`（ツールページのヒーロー直下にある「入力データ非送信」バッジ）のコントラスト比を実測した。

## 調査結果

`SafetyBadge` トリガーの文字色 (`text-safety`) と実際の背景（`bg-safety/5` をページ背景 `--background` に重ねた合成色）のコントラスト比を WCAG 2.1 の相対輝度式で算出したところ:

| モード | 文字色 | 合成背景 | コントラスト比 | WCAG AA (4.5:1) |
|---|---|---|---|---|
| ライト | `#059669` | `#EDF5F2` 相当 | **3.40:1** | ❌ 未達 |
| ダーク | `#34D399` | `#0E1410` 相当 | **9.70:1** | ✅ 適合 |

タスク名は「ダークモード」だが、実測の結果ライトモード側が未達だった（ダークモードは元々適合済み）。受け入れ基準は「light/dark双方」の確認を求めているため、両方を検証し、未達だったライトモードのみ修正した。

## 対応

- `src/components/layout/SafetyBadge.tsx`: トリガーの文字色をライトモードのみ `#047857`（4.95:1、AA適合）に変更し、`dark:` で既存の `--safety` トークン（9.70:1、変更なし）を維持
- 他コンポーネント（`index.astro` / `about.astro` / `privacy.astro` 等）にも同じ `text-safety` パターンがあるが、本タスクの対象は「ヒーロー直下の完全クライアントサイド処理バッジ」（`SafetyBadge.tsx`）のみのため範囲外とした

## 受け入れ基準への対応状況

1. ✅ セーフティバッジの文字・背景・境界のコントラスト比を測定し、通常文字のWCAG AA 4.5:1以上を満たす（表の通り、修正後は両モードとも4.5:1以上）
2. ✅ light/dark双方を自動検査（`tests/unit/safety-badge-contrast.test.ts`）で確認
3. ✅ lint・test・buildが成功する

## 検証

- `npm run test:unit` — 新規テスト2件 pass（既存の失敗28件は本PR適用前から存在する無関係な既知の失敗で、本変更による増減なし）
- `npm run lint` — エラーなし（既存の警告のみ、本変更による増減なし）
- `npm run check` — 0 errors
- `npm run build` — 成功

## テスト

`tests/unit/safety-badge-contrast.test.ts` を追加。`src/styles/global.css` と `SafetyBadge.tsx` から実際の色定義を読み取り、WCAG相対輝度式でコントラスト比を計算して light/dark 双方が4.5:1以上であることを検証する回帰テスト。修正前のコードに対して実行すると失敗することを確認済み。

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLkP6bVtZygc5MgHXkGKf9)_