### PR TITLE
test(e2e): base64/text-diff/wareki-converter/dummy-data/zenkaku-hankaku に回帰テストを追加

### DIFF
--- a/tests/e2e/base64.spec.ts
+++ b/tests/e2e/base64.spec.ts
@@ -28,4 +28,43 @@ test.describe('Base64 Converter Tool', () => {
 		await page.getByRole('button', { name: /クリア/ }).click();
 		await expect(page.getByRole('textbox').first()).toHaveValue('');
 	});
+
+	test('file tab: toggling Data URI updates output immediately and the overlay does not block other controls', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('base64');
+		await toolPage.goto();
+
+		await page.getByRole('tab', { name: 'ファイル変換' }).click();
+
+		const fileInput = page.locator('input[type="file"]');
+		await fileInput.setInputFiles({
+			name: 'sample.txt',
+			mimeType: 'text/plain',
+			buffer: Buffer.from('hello'),
+		});
+
+		const output = page.getByRole('textbox').last();
+		await expect(output).toContainText('data:text/plain;base64,');
+
+		// トグルOFFで即座に生のBase64（Data URIプレフィックスなし）へ切り替わること
+		await page
+			.getByRole('checkbox', { name: /Data URI 形式を出力する/ })
+			.click();
+		await expect(output).not.toContainText('data:text/plain;base64,');
+		await expect(output).toContainText('aGVsbG8=');
+
+		// トグルONに戻すと再びData URI形式に戻ること
+		await page
+			.getByRole('checkbox', { name: /Data URI 形式を出力する/ })
+			.click();
+		await expect(output).toContainText('data:text/plain;base64,');
+
+		// 回帰: 透明なファイル入力オーバーレイが画面全体のクリックを奪わないこと（#296）
+		await page.getByRole('tab', { name: 'テキスト変換' }).click();
+		await expect(
+			page.getByRole('tab', { name: 'テキスト変換' }),
+		).toHaveAttribute('data-state', 'active');
+	});
 });

--- a/tests/e2e/dummy-data.spec.ts
+++ b/tests/e2e/dummy-data.spec.ts
@@ -31,6 +31,26 @@ test.describe('Dummy Data Generator Tool', () => {
 		await expect(previewContainer).toContainText('氏名');
 		await expect(previewContainer).not.toContainText('"name"');
 	});
+	test('TSV出力の1行目も日本語ラベルになる', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('dummy-data');
+		await toolPage.goto();
+
+		const previewContainer = page.locator('pre');
+		await expect(previewContainer).toBeVisible();
+
+		await page.getByRole('tab', { name: 'TSV' }).click();
+
+		await expect(previewContainer).toContainText('氏名');
+		await expect(previewContainer).not.toContainText('"name"');
+		const headerLine = (await previewContainer.textContent())
+			?.split('\n')[0]
+			?.trim();
+		expect(headerLine).not.toContain('name');
+	});
+
 	test('同一設定の再生成クリックで出力が変わる', async ({
 		page,
 		createToolPage,

--- a/tests/e2e/text-diff.spec.ts
+++ b/tests/e2e/text-diff.spec.ts
@@ -50,4 +50,36 @@ test.describe('Text Diff', () => {
 			expect(resize).toBe('none');
 		}
 	});
+
+	test('split view keeps left/right rows aligned when only one side changes', async ({
+		page,
+	}) => {
+		// Split表示の切替タブは `hidden sm:block` でモバイル幅では非表示のため、デスクトップ幅に固定する
+		await page.setViewportSize({ width: 1280, height: 900 });
+
+		const textboxes = page.getByRole('textbox');
+		await textboxes.first().fill('line1\nline2\nline3');
+		await textboxes.nth(1).fill('line1\nNEW\nline2\nline3');
+
+		await page.getByRole('tab', { name: 'Split' }).click();
+
+		const columns = page.locator('.grid.grid-cols-2 > div');
+		const leftRows = columns.nth(0).locator('.w-full.min-w-max > div');
+		const rightRows = columns.nth(1).locator('.w-full.min-w-max > div');
+
+		// 追加行の分だけ、右側だけでなく左側にもスペーサー行が挿入され行数が揃うこと
+		await expect(leftRows).toHaveCount(4);
+		await expect(rightRows).toHaveCount(4);
+
+		// インデックス1: 右のみ "NEW" が追加され、左はスペーサー（空行）
+		await expect(rightRows.nth(1)).toContainText('NEW');
+		await expect(leftRows.nth(1)).not.toContainText('NEW');
+		await expect(leftRows.nth(1)).not.toContainText('line');
+
+		// インデックス2・3: 共通行が左右で同じ縦位置に揃っていること（回帰: #295）
+		await expect(leftRows.nth(2)).toContainText('line2');
+		await expect(rightRows.nth(2)).toContainText('line2');
+		await expect(leftRows.nth(3)).toContainText('line3');
+		await expect(rightRows.nth(3)).toContainText('line3');
+	});
 });

--- a/tests/e2e/wareki-converter.spec.ts
+++ b/tests/e2e/wareki-converter.spec.ts
@@ -178,6 +178,30 @@ test.describe('Wareki Converter Tool', () => {
 		expect(clipboardText).toContain('西暦');
 	});
 
+	test('should show a fallback notice instead of an error when only the month is specified', async ({
+		page,
+		createToolPage,
+	}) => {
+		const toolPage = createToolPage('wareki-converter');
+		await toolPage.goto();
+
+		const seirekiInput = page.locator('input[type="number"]');
+		await seirekiInput.fill('2023');
+		await page.getByRole('combobox', { name: '月（任意）' }).click();
+		await page.getByRole('option', { name: '3月', exact: true }).click();
+
+		await expect(
+			page.getByText(
+				'月のみの指定では年単位で換算しています。厳密な日付換算には日も指定してください。',
+			),
+		).toBeVisible();
+		await expect(
+			page.getByText(
+				'存在しない日付です。月・日の入力内容を確認してください。',
+			),
+		).toHaveCount(0);
+	});
+
 	test('should reject a non-existent date', async ({
 		page,
 		createToolPage,

--- a/tests/e2e/zenkaku-hankaku.spec.ts
+++ b/tests/e2e/zenkaku-hankaku.spec.ts
@@ -20,4 +20,24 @@ test.describe('Zenkaku Hankaku Converter', () => {
 		await page.getByRole('button', { name: /クリア/ }).click();
 		await expect(page.getByRole('textbox').first()).toHaveValue('');
 	});
+
+	test('direction switch has a visibly different background between checked and unchecked states', async ({
+		page,
+	}) => {
+		const toggle = page.getByRole('switch');
+
+		await expect(toggle).toHaveAttribute('data-state', 'unchecked');
+		const uncheckedColor = await toggle.evaluate(
+			(el) => getComputedStyle(el).backgroundColor,
+		);
+
+		await toggle.click();
+		await expect(toggle).toHaveAttribute('data-state', 'checked');
+		const checkedColor = await toggle.evaluate(
+			(el) => getComputedStyle(el).backgroundColor,
+		);
+
+		// 回帰: checked/uncheckedが同じ背景色で状態が視認できない不具合（#291）
+		expect(checkedColor).not.toBe(uncheckedColor);
+	});
 });


### PR DESCRIPTION
taskId: `3b4dfd36033681a0a132c12790fe5884`
実行ID: `triage-impl-20260813-0905`

## 背景

2026-08-06 に以下5件のバグ修正PRをレビュー・マージ済み（Notion上は各タスクとも「完了」）。

- #291 fix(zenkaku-hankaku): restore switch unchecked background contrast
- #293 fix(dummy-data): use Japanese labels for CSV/TSV headers
- #294 fix(wareki-converter): allow month-only input as year-level conversion
- #295 fix(text-diff): align split view rows with spacer lines
- #296 fix(base64): recompute file output when Data URI toggle changes

いずれも純粋関数に対する unit テストは追加済みだが、実際に直したUIの挙動を検証する E2E テストが不足しており、同じ不具合が将来再発してもCIでは検知できない状態だった。本PRはテストのみの追加で、プロダクションコードの変更は行っていない。

## 対応内容（受け入れ基準への対応状況）

1. ✅ 各ツールで今回のバグに対応するE2Eケースを追加
   - `base64`: ファイルタブでファイル選択→Data URIトグルのON/OFFで出力が即時切り替わること、透明なファイル入力オーバーレイが他のUI操作（タブ切替）をブロックしないことを検証（#296 の回帰）
   - `text-diff`: Split表示で片側のみ追加行がある場合に、反対側へスペーサー行が挿入されて左右の共通行の縦位置が揃うことを検証（#295 の回帰）
   - `wareki-converter`: 月のみ選択時に「存在しない日付」エラーにならず、年単位換算のnoticeが表示されることを検証（#294 の回帰）
   - `dummy-data`: CSVは既存テストでカバー済みだったため、TSV出力の1行目も日本語ラベルになることを追加検証（#293 の回帰）
   - `zenkaku-hankaku`: 方向Switchのchecked/unchecked状態で背景色（computed `background-color`）が異なることを検証（#291 の回帰）
2. ✅ 既存E2E/unitに回帰なし（対象5ファイル全テスト green、`npm run test:unit` 990件 green）
3. ✅ lint/test:unit/build成功

## 検証結果

- `npm run check`: 0 errors
- `npm run lint`: pass（既存の無関係な警告16件のみ、本PR変更ファイルには0件）
- `npm run test:unit`: 990 tests pass
- `npm run build`: success
- `npx playwright test tests/e2e/{base64,text-diff,wareki-converter,dummy-data,zenkaku-hankaku}.spec.ts`: 52/52 pass（chromium + mobile-chrome）
  - 実行環境のプリインストール済みChromiumリビジョンと `@playwright/test` が要求するリビジョンが不一致だったため、ローカル検証時のみ `launchOptions.executablePath` を一時的に指定して実行し、検証後に `playwright.config.ts` は元に戻して未コミット（本PRのdiffには含まれない）
  - 初回実行でSplit表示切替タブ（`hidden sm:block`）がモバイルビューポートで非表示のためタイムアウトする欠陥をtext-diffのテスト側で発見し、デスクトップビューポート固定で修正済み

## 次の人間アクション

レビューの上マージ判断をお願いします。マージ・デプロイは本Routineでは行いません。

---

Notion実行ログ: 実行台帳 `triage-impl-20260813-0905`（本日2件目の実装実行。1件目 `triage-impl-20260813-0613` は既にマージ済みのPRを作成済みで、日次上限に対する追加実行としてユーザーの明示的な承認を得て実施）

---
_Generated by [Claude Code](https://claude.ai/code/session_01AbKCErANKd14fXAjHmFfAk)_