### PR TITLE
fix(a11y): Biome a11yルールを段階的にerror化

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,15 +19,15 @@
 			"recommended": true,
 			"a11y": {
 				"useSemanticElements": "error",
-				"useKeyWithClickEvents": "warn",
-				"useButtonType": "warn",
-				"noAriaHiddenOnFocusable": "warn",
-				"noInteractiveElementToNoninteractiveRole": "warn",
-				"noNoninteractiveElementToInteractiveRole": "warn",
-				"noStaticElementInteractions": "warn",
-				"noLabelWithoutControl": "warn",
-				"useAriaPropsForRole": "warn",
-				"useAriaPropsSupportedByRole": "warn"
+				"useKeyWithClickEvents": "error",
+				"useButtonType": "error",
+				"noAriaHiddenOnFocusable": "error",
+				"noInteractiveElementToNoninteractiveRole": "error",
+				"noNoninteractiveElementToInteractiveRole": "error",
+				"noStaticElementInteractions": "error",
+				"noLabelWithoutControl": "error",
+				"useAriaPropsForRole": "error",
+				"useAriaPropsSupportedByRole": "error"
 			},
 			"suspicious": {
 				"noArrayIndexKey": "warn",

--- a/biome.json
+++ b/biome.json
@@ -18,7 +18,7 @@
 		"rules": {
 			"recommended": true,
 			"a11y": {
-				"useSemanticElements": "warn",
+				"useSemanticElements": "error",
 				"useKeyWithClickEvents": "warn",
 				"useButtonType": "warn",
 				"noAriaHiddenOnFocusable": "warn",

--- a/src/components/tools/CronChecker.tsx
+++ b/src/components/tools/CronChecker.tsx
@@ -204,11 +204,7 @@ export default function CronChecker() {
 					autoComplete="off"
 					spellCheck={false}
 				/>
-				<div
-					className="mt-2 flex flex-wrap gap-2"
-					role="group"
-					aria-label="プリセット"
-				>
+				<fieldset className="mt-2 flex flex-wrap gap-2" aria-label="プリセット">
 					{PRESETS.map((p) => (
 						<button
 							key={p.label}
@@ -219,7 +215,7 @@ export default function CronChecker() {
 							{p.label}
 						</button>
 					))}
-				</div>
+				</fieldset>
 			</div>
 
 			{'error' in parseResult && (

--- a/src/components/tools/UnixTime.tsx
+++ b/src/components/tools/UnixTime.tsx
@@ -257,9 +257,8 @@ export default function UnixTime() {
 					</div>
 
 					{candidates.length > 1 && (
-						<div
+						<fieldset
 							className="flex flex-wrap gap-2"
-							role="group"
 							aria-label="解釈候補の切り替え"
 						>
 							{candidates.map((c) => (
@@ -278,7 +277,7 @@ export default function UnixTime() {
 									{c.confidence === 'low' && '（低確度）'}
 								</button>
 							))}
-						</div>
+						</fieldset>
 					)}
 
 					{showUnableToParse && (

--- a/src/lib/tools/image-base64.ts
+++ b/src/lib/tools/image-base64.ts
@@ -78,7 +78,10 @@ export function buildSnippet(dataUri: string, kind: SnippetKind): string {
 		case 'raw-base64':
 			return toBase64(dataUri);
 		case 'img':
-			return `<img src="${dataUri}" alt="" />`;
+			// この画像がユーザーのサイト上でどんな意味を持つかは判別できないため、
+			// 空alt（装飾画像扱い）をデフォルトにはせず、説明文の入力を促すプレースホルダーにする。
+			// 本当に装飾目的の場合はユーザー側でalt=""に書き換えてもらう想定。
+			return `<img src="${dataUri}" alt="画像の説明を入力してください" />`;
 		case 'css-bg':
 			return `background-image: url("${dataUri}");`;
 	}

--- a/tests/unit/image-base64.test.ts
+++ b/tests/unit/image-base64.test.ts
@@ -123,7 +123,10 @@ test('buildSnippet: raw-base64 は Base64 本体のみ', () => {
 
 test('buildSnippet: img タグ', () => {
 	const result = buildSnippet('data:image/png;base64,abc', 'img');
-	assert.equal(result, '<img src="data:image/png;base64,abc" alt="" />');
+	assert.equal(
+		result,
+		'<img src="data:image/png;base64,abc" alt="画像の説明を入力してください" />',
+	);
 });
 
 test('buildSnippet: css-bg', () => {


### PR DESCRIPTION
## 概要

`biome.json` の `linter.rules.a11y` 配下10ルールが `warn` のままだったため、a11y違反が検出されても強制されていなかった問題を解消。Notionタスク「Biome a11yルールの段階的error化」（https://app.notion.com/p/391dfd360336817489adffc22f6b7ecd ）の受け入れ基準に従い、1ルールずつ `error` 化 → `npx biome check src/ tests/` で違反を洗い出し → 修正、を10ルール分繰り返した。あわせて `image-base64.ts` の `alt=""` の妥当性も確認し、修正した。

## 変更内容（ルールごとの対応）

| ルール | 結果 | 対応 |
|---|---|---|
| `useSemanticElements` | 違反2件 → 修正 | `CronChecker.tsx`・`UnixTime.tsx` の `<div role="group">`（プリセット/候補切替のボタン群）を `<fieldset>` に変更 |
| `useKeyWithClickEvents` | 違反0件 | ルールをerror化のみ |
| `useButtonType` | 違反0件 | ルールをerror化のみ |
| `noAriaHiddenOnFocusable` | 違反0件 | ルールをerror化のみ |
| `noInteractiveElementToNoninteractiveRole` | 違反0件 | ルールをerror化のみ |
| `noNoninteractiveElementToInteractiveRole` | 違反0件 | ルールをerror化のみ |
| `noStaticElementInteractions` | 違反0件 | ルールをerror化のみ |
| `noLabelWithoutControl` | 違反0件 | ルールをerror化のみ |
| `useAriaPropsForRole` | 違反0件 | ルールをerror化のみ |
| `useAriaPropsSupportedByRole` | 違反0件 | ルールをerror化のみ |

10ルールすべてを `error` に変更済み。`biome-ignore` によるルール抑制は一切使用していない（正当な例外なし）。

`useSemanticElements` の修正で `<div role="group">` → `<fieldset>` に変更した箇所は、Tailwind v4 の preflight（グローバルCSSリセット）により `fieldset` のデフォルト枠線・余白・最小幅がすべてリセットされるため、見た目に変化はない（同種のパターンは既存コード `src/components/phone-formatter/ResultTable.tsx` にも前例あり）。実際にビルド後のページをスクリーンショットで目視確認済み（後述）。

## image-base64のalt判断とその理由

対象: `src/lib/tools/image-base64.ts` の `buildSnippet()` 内、`kind === 'img'` のケース。

**調査結果**: この関数が返す文字列は、本アプリ内で実際に `<img>` としてレンダリングされるものではなく、`ImageBase64Page.tsx` でテキストとして画面表示・コピーボタンでコピーされる「ユーザーが自分のサイトに貼り付けるためのHTMLコード片」である（`{truncate(full)}` で `<p>` タグ内にプレーンテキスト表示、`dangerouslySetInnerHTML` は不使用）。

**判断**: `alt=""` から `alt="画像の説明を入力してください"` に変更した。

**理由**:
- ユーザーがアップロードする画像は任意の画像であり、装飾目的か情報を伝える画像かをツール側では判別できない。WCAG的には装飾画像の空altは正当だが、「わからないので空にする」をデフォルトにすると、情報を持つ画像に対しても空altのコードがそのままコピペされ、ユーザーの実サイトに不十分なアクセシビリティが伝播するリスクがある。
- 本リポジトリの他の`alt=`はすべて意味のある説明文（例: `alt="元の画像"`、`alt="デコード結果"`、`alt={item.file.name}` 等）を用いており、空altは`image-base64.ts`のみの例外だった。
- 生成されるのはあくまで「たたき台のコード」であり、開発者が実際にサイトへ貼り付ける前に内容を確認・編集するはずという前提のもと、プレースホルダーで入力を促す方が既存の空altより安全側に倒せると判断した。
- 本当に装飾目的の画像であれば、利用者が生成後に `alt=""` へ書き換える想定（空alt自体を禁止するわけではない）。

対応する単体テスト（`tests/unit/image-base64.test.ts`）も新しい文言に更新済み。

## 検証結果

実行したもの（すべて成功）:
- ✅ `npm run lint`（`biome check src/ tests/`）: 0 errors / 14 warnings（すべて本変更と無関係な既存警告。内訳は `tests/e2e/webmcp.spec.ts` の `noNonNullAssertion` 等）
- ✅ `npm run check`（`astro check && biome check src/ tests/`）: astro側 0 errors / 0 warnings（46 hints、すべて既存のz.deprecated等）、biome側 0 errors / 14 warnings
- ✅ `npm run test:unit`: 990 tests / 990 pass / 0 fail
- ✅ `npm run build`: 成功（99ページ生成、OG画像生成、SW生成まで完走）
- ✅ `npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`（AGENTS.md記載の補助チェック）: エラーなし
- ✅ `npm audit --audit-level=high`: 0 vulnerabilities

E2E（Playwright）:
- ✅ 変更したツールの専用spec: `tests/e2e/cron-checker.spec.ts`（7件）・`tests/e2e/unix-time.spec.ts`（10件）・`tests/e2e/image-base64.spec.ts`（8件）— 全25件成功
- ✅ フルE2Eスイート（65 spec files）も時間の許す範囲で実行: **532 passed / 1 failed / 16 skipped**
  - 失敗1件（`tests/e2e/upscale.spec.ts` の4xアップスケールテスト）は本変更と無関係。原因はサンドボックス環境からの `https://cdn.jsdelivr.net/npm/onnxruntime-web@1.27.0/...` 取得がネットワークポリシーでブロックされ、WASM推論バックエンドが初期化できないため（`no available backend found. ERR: [wasm] TypeError: Failed to fetch dynamically imported module`）。単独実行でも再現し、リトライしても同じ結果。今回のdiffは `upscale` 関連ファイルに一切触れていない。CI（`mcr.microsoft.com/playwright` 公式コンテナ + 通常のネットワーク環境）では発生しないはずの、ローカルサンドボックス固有の制約と判断。
  - 16件skipはピンチズーム/タッチ操作系（`zoom-pan.spec.ts`）で、`mobile-chrome` プロジェクトを対象にしたテストのため、今回`chromium`プロジェクトのみで実行した環境要因によるskip（本変更と無関係）。
- ⚠️ 実行環境の制約: このサンドボックスの `/opt/pw-browsers` にキャッシュ済みのChromiumリビジョンが、`package-lock.json` に固定された `@playwright/test@1.62.1` が要求するリビジョンと一致せず（`playwright install` はネットワークポリシーでブロックされるため実行不可）、標準の `npx playwright test` はそのままでは起動できなかった。検証のためテスト対象外の一時的なPlaywright設定（`launchOptions.executablePath` で `/opt/pw-browsers/chromium` を明示指定、コミットには含めていない）を使い実行した。実際のCI（`.github/workflows/e2e.yml`）は `mcr.microsoft.com/playwright:v1.62.1-jammy` の公式コンテナイメージを使うためリビジョンは一致し、この問題は発生しない見込み。

## UI変更時のスクリーンショット確認結果

`useSemanticElements` 対応で `<div role="group">` → `<fieldset>` に変更した2箇所は、`role="group"` を除去した以外は元のCSSクラス・DOM階層をそのまま維持しており、Tailwind preflightによりfieldsetの既定スタイルは無効化される。ビルド後のページをPlaywrightでスクリーンショットして目視確認した:
- `/cron-checker`: プリセットボタン群（毎分・毎時0分・毎日0時 等）が変更前と同じ丸ピル型ボタンの横並びで表示されることを確認。
- `/unix-time`: あいまいな入力値（`1783385779123`）で解釈候補切替ボタン（UNIXミリ秒・UNIXマイクロ秒（低確度）・UNIXナノ秒（低確度））が変更前と同じ丸ピル型ボタンの横並びで表示されることを確認。

`image-base64.ts` のalt変更はコード生成ロジックのみの変更で、本アプリ自体のUI/DOMには影響しないため、スクリーンショット確認は不要と判断した（`ImageBase64Page.tsx`側のE2Eテストが8件とも成功していることで動作を確認済み）。

## 意図的に含めなかった未ステージ変更

- `npm install` 実行時に `package-lock.json` に `libc` フィールドの差分（npmバージョン差による無害な整形差分）が発生したため、作業スコープ外として `git checkout -- package-lock.json` で復元し、コミットに含めていない。
- 検証用に作成した一時ファイル（`pw-local.config.ts`、`tests/e2e/zz-screenshot.spec.ts`）はコミット前にすべて削除済み。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UCQ2RmYtJRC8zFacKNjk8b)_