### PR TITLE
fix(tool): 「この作業の続きに」カードのレイアウト崩れ修正と簡素化

### DIFF
--- a/src/components/tool/RelatedTools.astro
+++ b/src/components/tool/RelatedTools.astro
@@ -1,9 +1,8 @@
 ---
-import { Check, ClipboardList } from 'lucide-react';
+import { ClipboardList } from 'lucide-react';
 import { getRelatedTools, toolCatalog, type ToolCatalogItem } from '../../lib/tools/catalog';
 import { getWorkflowContext } from '../../lib/tools/workflow-sets';
 import ToolCard from '../common/ToolCard.astro';
-import { ToolIcon } from '../common/ToolIcon';
 
 interface Props {
 	toolId?: string;
@@ -15,6 +14,13 @@ const { toolId, relatedSlugs, excludeIds = [] } = Astro.props;
 
 // ワークフローコンテキストの取得
 const workflowCtx = toolId ? getWorkflowContext(toolId) : null;
+
+// ワークフロー内の他ステップを関連ツールリンクとして表示（現在のツールは除外）
+const relatedWorkflowSteps = workflowCtx
+	? workflowCtx.allSteps
+			.map((step, position) => ({ step, position }))
+			.filter(({ step }) => step.id !== toolId)
+	: [];
 
 // ワークフロー導線で既に表示済みのツールIDを除外対象に含める
 const excludeSet = new Set(excludeIds);
@@ -51,7 +57,7 @@ if (toolId && validTools.length < LIMIT) {
 
 {workflowCtx ? (
 	<section id="related-tools-section" class="mt-8 rounded-2xl border border-border/80 bg-card p-5 sm:p-6 shadow-xs" aria-labelledby="related-tools-heading">
-		<div class="mb-6">
+		<div class="mb-4">
 			<h2 id="related-tools-heading" class="text-lg font-bold text-foreground flex items-center gap-2 mb-1.5">
 				<ClipboardList className="h-5 w-5 text-primary" aria-hidden="true" />
 				この作業の続きに
@@ -60,94 +66,19 @@ if (toolId && validTools.length < LIMIT) {
 				{workflowCtx.set.description}
 			</p>
 		</div>
-		<div class="flex flex-col md:flex-row items-stretch gap-4">
-			{workflowCtx.allSteps.map((step, i) => {
-				const isCurrent = step.id === toolId;
-				const isNext = workflowCtx.currentIndex + 1 === i;
-				const isCompleted = i < workflowCtx.currentIndex;
-				
-				return (
-					<>
-						{i > 0 && (
-							<div class="flex items-center justify-center text-muted-foreground/30 py-1 md:py-0 md:px-1 shrink-0 select-none">
-								<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 hidden md:block">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M13.5 4.5 21 12m0 0-7.5 7.5M21 12H3" />
-								</svg>
-								<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-6 h-6 md:hidden">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 13.5 12 21m0 0-7.5-7.5M12 21V3" />
-								</svg>
-							</div>
-						)}
-						
-						{isCurrent ? (
-							<div
-								class:list={[
-									"flex-1 flex flex-col justify-between overflow-hidden rounded-xl border p-5 shadow-xs transition-all duration-200 border-primary bg-primary/5 dark:bg-primary/10 border-l-[3px] border-l-primary cursor-default"
-								]}
-							>
-								<div>
-									<div class="mb-3 flex items-center justify-between gap-2">
-										<div class="flex items-center gap-2">
-											<span class="text-primary" aria-hidden="true"><ToolIcon name={step.icon} className="h-6 w-6" /></span>
-											<span class="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full">{step.category}</span>
-										</div>
-										<span class="text-xs font-semibold bg-primary text-primary-foreground px-2 py-0.5 rounded-full">現在地</span>
-									</div>
-									<div class="text-xs font-semibold text-primary/80 mb-1">
-										ステップ {i + 1}
-									</div>
-									<h3 class="text-base font-semibold mb-1 text-foreground">{step.title}</h3>
-									<p class="text-xs text-muted-foreground leading-relaxed mb-4">{step.description}</p>
-								</div>
-								<div class="mt-2 text-xs font-medium text-muted-foreground">
-									現在このツールを使用中
-								</div>
-							</div>
-						) : (
-							<a
-								href={step.href}
-								data-track-related-click
-								data-from={toolId ?? ''}
-								data-to={step.id}
-								data-set-id={workflowCtx.set.id}
-								data-position={i}
-								class:list={[
-									"group flex-1 flex flex-col justify-between overflow-hidden rounded-xl border p-5 shadow-xs transition-all duration-200 border-l-[3px] border-l-primary/60 hover:scale-[1.01] hover:shadow-md",
-									isNext 
-										? "border-teal-600/30 dark:border-teal-500/30 hover:border-teal-600 dark:hover:border-teal-500 bg-teal-500/[0.02] dark:bg-teal-500/[0.04]" 
-										: "border-border bg-card hover:border-primary/30",
-									isCompleted ? "opacity-75 hover:opacity-100" : ""
-								]}
-							>
-								<div>
-									<div class="mb-3 flex items-center justify-between gap-2">
-										<div class="flex items-center gap-2">
-											<span class="text-primary" aria-hidden="true"><ToolIcon name={step.icon} className="h-6 w-6" /></span>
-											<span class="text-xs font-medium text-muted-foreground bg-muted px-2 py-0.5 rounded-full">{step.category}</span>
-										</div>
-										{isNext && (
-											<span class="text-xs font-semibold bg-teal-600 dark:bg-teal-500 text-white px-2 py-0.5 rounded-full animate-pulse">次へ進む</span>
-										)}
-										{isCompleted && (
-											<span class="text-xs font-semibold bg-muted text-muted-foreground px-2 py-0.5 rounded-full flex items-center gap-0.5"><Check className="h-3 w-3" aria-hidden="true" /> 完了</span>
-										)}
-									</div>
-									<div class="text-xs font-semibold text-muted-foreground mb-1">
-										ステップ {i + 1}
-									</div>
-									<h3 class="text-base font-semibold mb-1 text-foreground group-hover:text-primary transition-colors">{step.title}</h3>
-									<p class="text-xs text-muted-foreground leading-relaxed mb-4">{step.description}</p>
-								</div>
-								<div class="mt-2 text-xs font-medium">
-									{isNext && <span class="text-teal-600 dark:text-teal-400 group-hover:underline">次を試してみる →</span>}
-									{isCompleted && <span class="text-muted-foreground group-hover:text-primary group-hover:underline">もう一度使う →</span>}
-									{!isNext && !isCompleted && <span class="text-primary group-hover:underline">使ってみる →</span>}
-								</div>
-							</a>
-						)}
-					</>
-				);
-			})}
+		<div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+			{relatedWorkflowSteps.map(({ step, position }) => (
+				<div data-track-related-click data-from={toolId ?? ''} data-to={step.id} data-set-id={workflowCtx.set.id} data-position={position}>
+					<ToolCard
+						id={step.id}
+						title={step.title}
+						description={step.description}
+						href={step.href}
+						icon={step.icon}
+						category={step.category}
+					/>
+				</div>
+			))}
 		</div>
 	</section>
 ) : (

--- a/tests/e2e/related-tools.spec.ts
+++ b/tests/e2e/related-tools.spec.ts
@@ -4,7 +4,7 @@ const section = (page: import('@playwright/test').Page) =>
 	page.locator('section[aria-labelledby="related-tools-heading"]');
 
 test.describe('関連ツール 回遊カード', () => {
-	test('ワークフロー所属ツールはステップカードフロー（現在地非リンク、他ステップリンク）を表示する', async ({
+	test('ワークフロー所属ツールは現在地を除く他ステップへのリンクカードを表示する', async ({
 		page,
 		createToolPage,
 	}) => {
@@ -19,10 +19,8 @@ test.describe('関連ツール 回遊カード', () => {
 		await expect(related.locator('a[href="/json-formatter"]')).toHaveCount(1);
 		await expect(related.locator('a[href="/hash"]')).toHaveCount(1);
 		await expect(related.locator('a[href="/regex-tester"]')).toHaveCount(1);
-		// 現在地の base64 は <a> ではなく <div> として出力されるため、リンクは 0 件
+		// 現在地の base64 はリンクとして表示しない（自分自身を除外）
 		await expect(related.locator('a[href="/base64"]')).toHaveCount(0);
-		// 現在地であることを示すテキストが存在することを確認
-		await expect(related.locator('text=現在地')).toBeVisible();
 	});
 
 	test('related 未指定ツールは同カテゴリで補完表示する', async ({


### PR DESCRIPTION
## 概要

JSON整形ページ等で、ワークフロー導線（「この作業の続きに」カード）のカテゴリチップが「開発ツ／ール」のように文字単位で折り返し、「現在地」「次へ進む」バッジがアイコンと干渉するレイアウト崩れが発生していた。

「ステップ1〜4」の演出（現在地カード・矢印コネクタ・次へ進む/完了バッジ）を廃止し、現在のツールを除く他ステップへのシンプルな関連ツールリンクカード（`ToolCard`、既存の「あわせて使いたいツール」と同じ表示パターン）に置き換えた。バッジが競合するステータス要素自体を無くしたことで、長いカテゴリ名でも崩れなくなる。

対象: `src/components/tool/RelatedTools.astro`

## 対応内容

- ステップ演出（現在地/次へ進む/完了バッジ、矢印コネクタ）を削除し、`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3` の `ToolCard` グリッドに置換
- `tests/e2e/related-tools.spec.ts` を新しいDOM構造に合わせて更新（現在地の div/バッジ表示ではなく、自分自身を除外したリンクのみになったことを検証）

## 受け入れ基準チェック

1. 長いカテゴリ名でもチップ・バッジが崩れない → ✅ 4ステップの「開発者ツール」ワークフロー（最狭幅で発生していたケース）を含め、デスクトップ/モバイル幅・ライト/ダークで目視確認
2. ステップ演出を関連ツールリンクへ簡素化 → ✅
3. 複数ツールページとモバイル幅で回帰確認 → ✅ `json-formatter`（4ステップ）/ `base64` / `csv-fixer` の3ページを 1280px・375px × light/dark の計12パターンでスクリーンショット確認。水平スクロール発生なし
4. lint・test・buildが成功する → ✅（下記）

## 検証結果

- `npm run lint` → 成功（既存の無関係な警告16件のみ、エラー0）
- `npx astro check` → 0 errors / 0 warnings
- `npm run test:unit` → 990/990 pass
- `npm run build` → 成功
- `npx playwright test tests/e2e/related-tools.spec.ts` → 14/14 pass
- `npx playwright test`（全件）→ 1063 passed / 33 skipped / 2 failed
  - 失敗2件は `tests/e2e/upscale.spec.ts`（AIアップスケール処理のダウンロード待機タイムアウト）のみで、本変更が触れていない機能。ローカル検証環境のリソース制約によるタイムアウトと見られ、本PRの変更とは無関係

## 人間確認事項

- なし（自動化可否: 自動実装可、禁止領域: なし）


---
_Generated by [Claude Code](https://claude.ai/code/session_01DowkmTmNhx4WgoyFEHiPMD)_