### PR TITLE
refactor(tools): UI/ロジック分離違反の解消（download / highlightJson / clipboard）

### DIFF
--- a/src/components/tools/Base64Converter.tsx
+++ b/src/components/tools/Base64Converter.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	decodeBase64,
@@ -101,14 +102,7 @@ export default function Base64Converter() {
 			const blob = new Blob([textResult.output], {
 				type: 'text/plain;charset=utf-8',
 			});
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = 'decoded.txt';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-			URL.revokeObjectURL(url);
+			downloadBlob(blob, 'decoded.txt');
 		}
 	}, [direction, textResult]);
 

--- a/src/components/tools/BgRemove.tsx
+++ b/src/components/tools/BgRemove.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	compositeBackground,
@@ -81,6 +82,8 @@ export default function BgRemove() {
 		type: 'transparent',
 	});
 	const [compositeUrl, setCompositeUrl] = useState<string | null>(null);
+	// ダウンロード時に downloadBlob() へ渡すため、表示用URLとは別にBlob実体も保持する
+	const [compositeBlob, setCompositeBlob] = useState<Blob | null>(null);
 
 	// D&D
 	const [isDragOver, setIsDragOver] = useState(false);
@@ -137,6 +140,7 @@ export default function BgRemove() {
 			setResultBlob(null);
 			setResultUrl(null);
 			setCompositeUrl(null);
+			setCompositeBlob(null);
 			setBgOption({ type: 'transparent' });
 
 			try {
@@ -265,6 +269,7 @@ export default function BgRemove() {
 			if (compositeUrlRef.current) URL.revokeObjectURL(compositeUrlRef.current);
 			compositeUrlRef.current = null;
 			setCompositeUrl(null);
+			setCompositeBlob(null);
 			return;
 		}
 
@@ -275,6 +280,7 @@ export default function BgRemove() {
 			const newUrl = URL.createObjectURL(blob);
 			compositeUrlRef.current = newUrl;
 			setCompositeUrl(newUrl);
+			setCompositeBlob(blob);
 		});
 
 		return () => {
@@ -284,18 +290,13 @@ export default function BgRemove() {
 
 	// --- ダウンロード ---
 	const handleDownload = useCallback(() => {
-		const url = compositeUrl ?? resultUrl;
-		if (!url) return;
+		const blob = compositeBlob ?? resultBlob;
+		if (!blob) return;
 
-		const a = document.createElement('a');
-		a.href = url;
 		const baseName = sourceFile?.name?.replace(/\.[^.]+$/, '') ?? 'image';
 		const suffix = bgOption.type === 'transparent' ? '_transparent' : '_bg';
-		a.download = `${baseName}${suffix}.png`;
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-	}, [compositeUrl, resultUrl, sourceFile, bgOption]);
+		downloadBlob(blob, `${baseName}${suffix}.png`);
+	}, [compositeBlob, resultBlob, sourceFile, bgOption]);
 
 	// --- リセット ---
 	const handleReset = useCallback(() => {
@@ -309,6 +310,7 @@ export default function BgRemove() {
 		setResultBlob(null);
 		setResultUrl(null);
 		setCompositeUrl(null);
+		setCompositeBlob(null);
 		setStatus('idle');
 		setProgress(null);
 		setError(null);

--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
@@ -295,14 +296,7 @@ export default function CsvEditor() {
 		if (!csvData) return;
 		const result = exportCsv(csvData, delimiter);
 		const blob = new Blob([result], { type: 'text/csv;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `edited.${delimiter === '\t' ? 'tsv' : 'csv'}`;
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, `edited.${delimiter === '\t' ? 'tsv' : 'csv'}`);
 	};
 
 	const handleDownloadJson = () => {
@@ -325,14 +319,7 @@ export default function CsvEditor() {
 		const blob = new Blob([resultStr], {
 			type: 'application/json;charset=utf-8',
 		});
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = 'exported.json';
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, 'exported.json');
 	};
 
 	const csvResultText = useMemo(

--- a/src/components/tools/CsvFixer.tsx
+++ b/src/components/tools/CsvFixer.tsx
@@ -34,6 +34,7 @@ import {
 } from '@/components/ui/table';
 import { parsePreview } from '@/lib/csv/preview';
 import type { PreviewResult } from '@/lib/csv/types';
+import { downloadBlob } from '@/lib/download';
 import { convertEncoding } from '@/lib/encoding/convert';
 import { detectEncoding } from '@/lib/encoding/detect';
 import { detectLineEnding } from '@/lib/encoding/lineEndings';
@@ -681,16 +682,7 @@ function DownloadButton({
 				originalFilename,
 			);
 
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = fileName;
-			a.dataset.astroReload = 'true';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-
-			setTimeout(() => URL.revokeObjectURL(url), 1000);
+			downloadBlob(blob, fileName);
 
 			setStatus('success');
 			onConverted?.();
@@ -882,15 +874,7 @@ export default function CsvFixer() {
 				settings,
 				fileName,
 			);
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = outName;
-			a.dataset.astroReload = 'true';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-			setTimeout(() => URL.revokeObjectURL(url), 1000);
+			downloadBlob(blob, outName);
 			setStatus('done');
 			trackRun();
 		} catch (e) {

--- a/src/components/tools/DummyDataGenerator.tsx
+++ b/src/components/tools/DummyDataGenerator.tsx
@@ -21,6 +21,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	type ExportFormat,
@@ -156,14 +157,7 @@ export default function DummyDataGenerator() {
 	const handleDownload = () => {
 		if (!outputData || validationError) return;
 		const blob = new Blob([outputData], { type: 'text/plain;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = `dummy-data.${format}`;
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, `dummy-data.${format}`);
 	};
 
 	return (

--- a/src/components/tools/JsonFormatter.tsx
+++ b/src/components/tools/JsonFormatter.tsx
@@ -19,41 +19,17 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
 	formatJson,
+	highlightJson,
 	type IndentType,
 	minifyJson,
 	sanitizeJsonFormatterSettings,
 } from '@/lib/tools/json-formatter';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
-
-function highlightJson(json: string) {
-	if (!json) return '';
-	const jsonStr = json
-		.replace(/&/g, '&amp;')
-		.replace(/</g, '&lt;')
-		.replace(/>/g, '&gt;');
-	return jsonStr.replace(
-		/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
-		(match) => {
-			let cls = 'text-green-600 dark:text-green-400'; // number
-			if (/^"/.test(match)) {
-				if (/:$/.test(match)) {
-					cls = 'text-blue-600 dark:text-blue-400 font-semibold'; // key
-				} else {
-					cls = 'text-amber-600 dark:text-amber-400'; // string
-				}
-			} else if (/true|false/.test(match)) {
-				cls = 'text-purple-600 dark:text-purple-400'; // boolean
-			} else if (/null/.test(match)) {
-				cls = 'text-gray-500 dark:text-gray-400'; // null
-			}
-			return `<span class="${cls}">${match}</span>`;
-		},
-	);
-}
 
 export default function JsonFormatter() {
 	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('json-formatter');
@@ -144,14 +120,7 @@ export default function JsonFormatter() {
 	const handleDownload = useCallback(() => {
 		if (!output) return;
 		const blob = new Blob([output], { type: 'application/json' });
-		const url = URL.createObjectURL(blob);
-		const link = document.createElement('a');
-		link.href = url;
-		link.download = 'formatted.json';
-		document.body.appendChild(link);
-		link.click();
-		document.body.removeChild(link);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, 'formatted.json');
 	}, [output]);
 
 	const handleInputChange = useCallback(

--- a/src/components/tools/Masking.tsx
+++ b/src/components/tools/Masking.tsx
@@ -13,6 +13,7 @@ import {
 	SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import {
 	type MaskChar,
@@ -76,14 +77,7 @@ export default function Masking() {
 	const handleDownload = () => {
 		if (!maskedText) return;
 		const blob = new Blob([maskedText], { type: 'text/plain;charset=utf-8' });
-		const url = URL.createObjectURL(blob);
-		const a = document.createElement('a');
-		a.href = url;
-		a.download = 'masked-text.txt';
-		document.body.appendChild(a);
-		a.click();
-		document.body.removeChild(a);
-		URL.revokeObjectURL(url);
+		downloadBlob(blob, 'masked-text.txt');
 	};
 
 	const handleScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {

--- a/src/components/tools/SqlFormatter.tsx
+++ b/src/components/tools/SqlFormatter.tsx
@@ -24,61 +24,19 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
 import {
 	formatSql,
 	type IndentStyle,
+	SQL_KEYWORDS,
 	type SqlDialect,
 	type SqlFormatOptions,
 	sanitizeSqlFormatterSettings,
 } from '@/lib/tools/sql-formatter';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
 import { cn } from '@/lib/utils';
-
-const SQL_KEYWORDS = [
-	'SELECT',
-	'FROM',
-	'WHERE',
-	'AND',
-	'OR',
-	'JOIN',
-	'LEFT',
-	'RIGHT',
-	'INNER',
-	'OUTER',
-	'ON',
-	'ORDER BY',
-	'GROUP BY',
-	'HAVING',
-	'LIMIT',
-	'OFFSET',
-	'INSERT',
-	'INTO',
-	'VALUES',
-	'UPDATE',
-	'SET',
-	'DELETE',
-	'CREATE',
-	'TABLE',
-	'DROP',
-	'ALTER',
-	'ADD',
-	'COLUMN',
-	'AS',
-	'DISTINCT',
-	'COUNT',
-	'MAX',
-	'MIN',
-	'AVG',
-	'SUM',
-	'IS',
-	'NULL',
-	'NOT',
-	'IN',
-	'BETWEEN',
-	'LIKE',
-];
 
 export default function SqlFormatter() {
 	const { trackRun, trackRunDebounced, trackSharedUrlOpen } =
@@ -273,14 +231,7 @@ export default function SqlFormatter() {
 	const handleDownload = () => {
 		if (output && !error) {
 			const blob = new Blob([output], { type: 'text/sql;charset=utf-8' });
-			const url = URL.createObjectURL(blob);
-			const a = document.createElement('a');
-			a.href = url;
-			a.download = 'query.sql';
-			document.body.appendChild(a);
-			a.click();
-			document.body.removeChild(a);
-			URL.revokeObjectURL(url);
+			downloadBlob(blob, 'query.sql');
 		}
 	};
 

--- a/src/lib/tools/json-formatter.ts
+++ b/src/lib/tools/json-formatter.ts
@@ -189,6 +189,37 @@ export function minifyJson(input: string): FormatResult {
 	}
 }
 
+/**
+ * 整形済みJSON文字列をHTMLエスケープしつつ、文字列/キー/数値/真偽値/nullを
+ * それぞれ色分けする <span> タグ付きのHTML文字列に変換する。
+ * CodeBlock の htmlContent に渡すための表示専用ロジック。
+ */
+export function highlightJson(json: string): string {
+	if (!json) return '';
+	const jsonStr = json
+		.replace(/&/g, '&amp;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+	return jsonStr.replace(
+		/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+-]?\d+)?)/g,
+		(match) => {
+			let cls = 'text-green-600 dark:text-green-400'; // number
+			if (/^"/.test(match)) {
+				if (/:$/.test(match)) {
+					cls = 'text-blue-600 dark:text-blue-400 font-semibold'; // key
+				} else {
+					cls = 'text-amber-600 dark:text-amber-400'; // string
+				}
+			} else if (/true|false/.test(match)) {
+				cls = 'text-purple-600 dark:text-purple-400'; // boolean
+			} else if (/null/.test(match)) {
+				cls = 'text-gray-500 dark:text-gray-400'; // null
+			}
+			return `<span class="${cls}">${match}</span>`;
+		},
+	);
+}
+
 export function validateJson(input: string): FormatResult {
 	if (!input.trim()) {
 		return { success: true, output: '有効なJSONです' };

--- a/src/lib/tools/sql-formatter.ts
+++ b/src/lib/tools/sql-formatter.ts
@@ -1,5 +1,50 @@
 import { format } from 'sql-formatter';
 
+// 出力SQLのシンタックスハイライトで強調表示するキーワード一覧
+export const SQL_KEYWORDS = [
+	'SELECT',
+	'FROM',
+	'WHERE',
+	'AND',
+	'OR',
+	'JOIN',
+	'LEFT',
+	'RIGHT',
+	'INNER',
+	'OUTER',
+	'ON',
+	'ORDER BY',
+	'GROUP BY',
+	'HAVING',
+	'LIMIT',
+	'OFFSET',
+	'INSERT',
+	'INTO',
+	'VALUES',
+	'UPDATE',
+	'SET',
+	'DELETE',
+	'CREATE',
+	'TABLE',
+	'DROP',
+	'ALTER',
+	'ADD',
+	'COLUMN',
+	'AS',
+	'DISTINCT',
+	'COUNT',
+	'MAX',
+	'MIN',
+	'AVG',
+	'SUM',
+	'IS',
+	'NULL',
+	'NOT',
+	'IN',
+	'BETWEEN',
+	'LIKE',
+];
+
 export type SqlDialect = 'sql' | 'mysql' | 'postgresql' | 'tsql' | 'plsql';
 export type IndentStyle = '2spaces' | '4spaces' | 'tabs';
 

--- a/tests/unit/json-formatter.test.ts
+++ b/tests/unit/json-formatter.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import {
 	formatJson,
+	highlightJson,
 	minifyJson,
 	validateJson,
 } from '../../src/lib/tools/json-formatter.ts';
@@ -196,4 +197,86 @@ test('validateJson: 無効なJSONは success=false', () => {
 test('validateJson: 空文字列は有効扱い', () => {
 	const result = validateJson('');
 	assert.equal(result.success, true);
+});
+
+// ============================================================
+// highlightJson: シンタックスハイライトHTML生成
+// ============================================================
+
+test('highlightJson: 空文字列は空文字列を返す', () => {
+	assert.equal(highlightJson(''), '');
+});
+
+test('highlightJson: オブジェクトのキーをハイライトする', () => {
+	const html = highlightJson('{"name":"太郎"}');
+	assert.ok(
+		html.includes(
+			'<span class="text-blue-600 dark:text-blue-400 font-semibold">"name":</span>',
+		),
+		html,
+	);
+});
+
+test('highlightJson: 文字列値をハイライトする', () => {
+	const html = highlightJson('{"name":"太郎"}');
+	assert.ok(
+		html.includes(
+			'<span class="text-amber-600 dark:text-amber-400">"太郎"</span>',
+		),
+		html,
+	);
+});
+
+test('highlightJson: 数値をハイライトする', () => {
+	const html = highlightJson('{"age":30}');
+	assert.ok(
+		html.includes('<span class="text-green-600 dark:text-green-400">30</span>'),
+		html,
+	);
+});
+
+test('highlightJson: 負の数・小数・指数表記もハイライトする', () => {
+	const html = highlightJson('{"a":-1,"b":3.14,"c":1.5e10}');
+	assert.ok(html.includes('>-1<'), html);
+	assert.ok(html.includes('>3.14<'), html);
+	assert.ok(html.includes('>1.5e10<'), html);
+});
+
+test('highlightJson: true/false をハイライトする', () => {
+	const html = highlightJson('{"active":true,"deleted":false}');
+	assert.ok(
+		html.includes(
+			'<span class="text-purple-600 dark:text-purple-400">true</span>',
+		),
+		html,
+	);
+	assert.ok(
+		html.includes(
+			'<span class="text-purple-600 dark:text-purple-400">false</span>',
+		),
+		html,
+	);
+});
+
+test('highlightJson: null をハイライトする', () => {
+	const html = highlightJson('{"value":null}');
+	assert.ok(
+		html.includes('<span class="text-gray-500 dark:text-gray-400">null</span>'),
+		html,
+	);
+});
+
+test('highlightJson: & < > をHTMLエスケープする', () => {
+	const html = highlightJson('{"expr":"a < b && b > c"}');
+	assert.ok(!html.includes('< b'), html);
+	assert.ok(!html.includes('b >'), html);
+	assert.ok(html.includes('&lt;'), html);
+	assert.ok(html.includes('&gt;'), html);
+	assert.ok(html.includes('&amp;&amp;'), html);
+});
+
+test('highlightJson: エスケープはハイライト用span挿入より前に行われる（タグ注入防止）', () => {
+	const html = highlightJson('{"a":"<script>"}');
+	assert.ok(!/<script>/.test(html));
+	assert.ok(html.includes('&lt;script&gt;'));
 });

--- a/tests/unit/sql-formatter.test.ts
+++ b/tests/unit/sql-formatter.test.ts
@@ -1,0 +1,30 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { SQL_KEYWORDS } from '../../src/lib/tools/sql-formatter.ts';
+
+// ============================================================
+// SQL_KEYWORDS: 出力SQLのシンタックスハイライトで使うキーワード一覧
+// ============================================================
+
+test('SQL_KEYWORDS: 空でない配列である', () => {
+	assert.ok(Array.isArray(SQL_KEYWORDS));
+	assert.ok(SQL_KEYWORDS.length > 0);
+});
+
+test('SQL_KEYWORDS: 主要な句を含む', () => {
+	for (const kw of [
+		'SELECT',
+		'FROM',
+		'WHERE',
+		'JOIN',
+		'GROUP BY',
+		'ORDER BY',
+	]) {
+		assert.ok(SQL_KEYWORDS.includes(kw), `${kw} が含まれていません`);
+	}
+});
+
+test('SQL_KEYWORDS: すべて重複なく一意である', () => {
+	const unique = new Set(SQL_KEYWORDS);
+	assert.equal(unique.size, SQL_KEYWORDS.length);
+});


### PR DESCRIPTION
## 概要

「純粋ロジックは `src/lib/tools/`、UIは `src/components/tools/`」という規約への違反のうち、以下を解消する既存UI挙動維持のリファクタリングです。

- 8ツールで重複していた手書きのダウンロード処理（`Blob` + `<a>` + `createObjectURL` + `click()`）を、既存の `downloadBlob()`（`src/lib/download.ts`）に統一
- `JsonFormatter.tsx` にインライン定義されていた純粋関数 `highlightJson()` を `src/lib/tools/json-formatter.ts` へ移動
- `SqlFormatter.tsx` にコンポーネントスコープで定義されていた `SQL_KEYWORDS` 配列を `src/lib/tools/sql-formatter.ts` へ移動
- clipboard 直呼び出し違反の再調査（結果: 既に解消済み。詳細は下記）

ファイル名・MIMEタイプ・コピー/ダウンロード対象・表示内容は一切変更していません（純粋なリファクタリング）。

## 変更内容（対象ファイルごと）

### download統一（`downloadBlob()` へ置き換え）

| ファイル | 対象箇所 | ダウンロードファイル名（変更なし） |
|---|---|---|
| `src/components/tools/Base64Converter.tsx` | `downloadDecodedText` | `decoded.txt` |
| `src/components/tools/JsonFormatter.tsx` | `handleDownload` | `formatted.json` |
| `src/components/tools/Masking.tsx` | `handleDownload` | `masked-text.txt` |
| `src/components/tools/CsvFixer.tsx` | 手動ダウンロード / 即時ダウンロード（2箇所） | 検出エンコーディングに応じた出力ファイル名（変更なし） |
| `src/components/tools/DummyDataGenerator.tsx` | `handleDownload` | `dummy-data.${format}` |
| `src/components/tools/SqlFormatter.tsx` | `handleDownload` | `query.sql` |
| `src/components/tools/BgRemove.tsx` | `handleDownload` | `${baseName}${suffix}.png` |
| `src/components/tools/CsvEditor.tsx` | `handleDownload` / `handleDownloadJson`（2箇所） | `edited.csv`(or `.tsv`) / `exported.json` |

`BgRemove.tsx` のみ、従来は表示用の object URL（`compositeUrl`/`resultUrl`）だけを state で保持し、Blob 実体は保持していませんでした。`downloadBlob(blob, filename)` に Blob を渡せるようにするため、表示用の `compositeUrl` とは独立に `compositeBlob` state を追加し、ダウンロード時は `compositeBlob ?? resultBlob` を渡すようにしています（表示用URLの生成・revoke タイミングは変更していません）。

### highlightJson の移動

- `src/lib/tools/json-formatter.ts`: `highlightJson(json: string): string` を新規 export（JSON文字列のHTMLエスケープ + キー/文字列/数値/真偽値/nullのシンタックスハイライトspan生成。ロジックは無変更でコピー移動のみ）
- `src/components/tools/JsonFormatter.tsx`: インライン定義を削除し、`@/lib/tools/json-formatter` から import
- `tests/unit/json-formatter.test.ts`: `highlightJson` の単体テストを追加（空文字列、キー/文字列/数値/真偽値/nullのハイライト、`&`/`<`/`>` のHTMLエスケープ、タグ注入防止）

### SQL_KEYWORDS の移動

- `src/lib/tools/sql-formatter.ts`: `SQL_KEYWORDS` 配列（約40キーワード）を export
- `src/components/tools/SqlFormatter.tsx`: コンポーネントスコープの配列定義を削除し import。JSXノードを組み立てるハイライト処理自体（`highlightedNodes` useMemo）は React 依存のためコンポーネント側に残置（スコープ外の拡張はしていません）
- `tests/unit/sql-formatter.test.ts`: `SQL_KEYWORDS` の内容（空でない・主要句を含む・重複なし）を検証する単体テストを新規追加

## clipboardの再調査結果

**既に対応済みでした。** 今回の作業では clipboard 関連の追加修正は行っていません。

再調査の証跡（`main` ブランチ相当のこのブランチ上で実行）:

```
$ grep -rn "navigator.clipboard\|\.clipboard\.writeText\|clipboard\s*=\s*navigator" src/ | grep -v "src/lib/clipboard.ts"
(該当なし)

$ grep -rn "execCommand" src/ | grep -v "src/lib/clipboard.ts"
(該当なし)

$ grep -rn "writeText" src/
src/lib/clipboard.ts:10:	if (clipboard?.writeText) {
src/lib/clipboard.ts:12:			await clipboard.writeText(text);
(src/lib/clipboard.ts 自身のみ)
```

`src/components/tools/` 配下は全て `CopyButton`（`useCopyFeedback` 経由）または `useCopyFeedback` を直接使用しており、`copyText()`（Clipboard API → `execCommand('copy')` フォールバック）を経由しています。Notion タスクページ背景に記載の「`navigator.clipboard.writeText()` 直呼び出しが10箇所以上」は、PR #272/#275/#276/#277 で既に解消済みと判断します。

## 検証結果

実行した検証（すべて worktree 上、`node_modules` は worktree 内で `npm install` 済み）:

- ✅ `npm run lint` — exit 0。既存の `tests/e2e/webmcp.spec.ts` の non-null assertion 警告16件は本PRと無関係（本PRで一切変更していないファイル。AGENTS.mdの既知の検証メモにも記載あり）
- ✅ `npm run check`（Astro型チェック + Biome） — exit 0（Astro側 hintのみ、Biomeエラーなし）
- ✅ `npm run test:unit` — 1002 tests / 1002 pass（新規追加: `highlightJson` 9件、`SQL_KEYWORDS` 3件を含む）
- ✅ `npm run build` — exit 0（99ページ生成、OGP画像・SW生成まで完走）
- ✅ `npm run build && npm run preview` 後、対象8ツールの既存E2E仕様を実行:
  - `base64.spec.ts` / `json-formatter.spec.ts` / `masking.spec.ts` / `csv-fixer.spec.ts` / `dummy-data.spec.ts` / `sql-formatter.spec.ts` / `bg-remove.spec.ts` / `csv-editor.spec.ts`
  - chromium プロジェクト: 54/54 pass
  - mobile-chrome プロジェクト: 54/54 pass
- ✅ `npm test`（Playwright全件、chromium + mobile-chrome）実行済み: **1061 passed / 4 failed / 33 skipped**
  - 失敗4件はすべて本PRで一切触れていないファイル（`tests/e2e/upscale.spec.ts`・`tests/e2e/image-mosaic.spec.ts`、対象は `Upscale.tsx`/`ImageMosaic.tsx`）で、AIアップスケール推論のタイムアウトおよびcanvasピクセル比較のタイミング起因と見られる、本変更と無関係な既存の不安定テストです（差分に無関係なことを `git diff origin/main..HEAD --stat` で対象ファイルが含まれないことを確認済み）

※ 実行環境の制約についての付記: このサンドボックス環境ではPlaywrightの公式ブラウザダウンロードCDN（`cdn.playwright.dev`）が組織ポリシーで遮断されていたため、環境に事前キャッシュされていた旧リビジョンのChromiumバイナリを、Playwrightが要求するリビジョンのディレクトリ構造にシンボリックリンクして代用しました（ネットワーク越しの新規ダウンロードは一切行っていません）。テスト内容・アサーション自体への影響はありません。

## UI変更時のスクリーンショット確認結果

本PRはUI表示・レイアウトの変更を伴わない純粋リファクタリングです。目視でのスクリーンショット比較の代わりに、以下の自動化された確認を実施しました:

1. 対象8ツールの既存E2E仕様（chromium/mobile-chrome 各54件、計108件）が全てpassし、ページ表示・フォーマット結果・レイアウトに回帰がないことを確認
2. **ダウンロード導線の実地確認**: `npm run preview` 起動中のアプリに対し、Playwright(`playwright-core`)で以下8件を実際にブラウザ操作し、`page.waitForEvent('download')` でダウンロードイベントの発火とファイル名一致を確認（既存E2E仕様がダウンロードのファイル名アサーションを持たない6ツール分を含む、手動追加検証）:
   - base64: decode実行 → `decoded.txt` ダウンロード確認
   - json-formatter: 整形実行 → シンタックスハイライトspan（`span.text-blue-600` 等）の描画確認 → `formatted.json` ダウンロード確認
   - masking: マスク実行 → `masked-text.txt` ダウンロード確認
   - sql-formatter: 整形実行 → キーワードハイライト（`.text-purple-600`）の描画確認 → `query.sql` ダウンロード確認
   - dummy-data: 生成 → `dummy-data.json` ダウンロード確認
   - csv-editor: パース→編集 → `edited.csv` / `exported.json` の両ダウンロード確認
   - csv-fixer: ファイルアップロード→変換 → `*.csv` ダウンロード確認
   - 全8件 PASS
3. `BgRemove.tsx` のみ、実際の背景削除（ONNXモデル推論）を伴うダウンロード導線の実地確認は行っていません（モデルダウンロード・推論が重く本セッションの時間内では非現実的なため）。既存E2E仕様3件（ページ表示・モード切替・SafetyBadge表示）は pass しており、`compositeBlob`/`resultBlob` の状態遷移はコードレビューで `compositeUrl`/`resultUrl` と完全に同期させていることを確認済みです（設定・クリアタイミングを全箇所で対にして追加）。

いずれもスクリーンショット画像そのものは添付していませんが、上記の通り「ダウンロードイベントが正しいファイル名で発火すること」を実地確認したログが検証エビデンスです。

## 意図的に含めなかった未ステージ変更

- `package-lock.json`: `npm install` 実行時、ローカルのnpmバージョン差により一部パッケージエントリの `libc` フィールドが削除される差分が発生しましたが、本PRの変更とは無関係のため `git checkout -- package-lock.json` で除外し、コミットに含めていません。


---
_Generated by [Claude Code](https://claude.ai/code/session_01UCQ2RmYtJRC8zFacKNjk8b)_