### PR TITLE
refactor(tools): ファイルサイズ定数・マジックナンバーの一元化

### DIFF
--- a/src/components/tools/CsvEditor.tsx
+++ b/src/components/tools/CsvEditor.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
+import { CSV_EDITOR_ROWS_PER_PAGE } from '@/lib/constants';
 import { downloadBlob } from '@/lib/download';
 import { useToolAnalytics } from '@/lib/hooks/useToolAnalytics';
 import { useToolSettings } from '@/lib/hooks/useToolSettings';
@@ -54,7 +55,7 @@ import {
 } from '@/lib/tools/xlsx-reader';
 import { useCopyFeedback } from '@/lib/useCopyFeedback';
 
-const ROWS_PER_PAGE = 50;
+const ROWS_PER_PAGE = CSV_EDITOR_ROWS_PER_PAGE;
 
 export default function CsvEditor() {
 	const { trackRun, trackSharedUrlOpen } = useToolAnalytics('csv-editor');

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,79 @@
+// constants.ts — ツール間で重複しがちな「ファイルサイズ上限」「ObjectURL解放遅延」
+// 「UX表示件数」等のマジックナンバーを一元管理する。
+// 各ツール側では、ここから値を import してそのまま再エクスポート/使用し、
+// 既存の定数名・挙動は変更しない（一括変更時の修正漏れ防止が目的）。
+// 値の違いは意図的なもの（処理コスト・入力形式・UXバランス等）であり、
+// 根拠はキー名およびコメントで明記する。
+
+/** バイト換算の基準値（1MB = 1024 * 1024 bytes） */
+export const BYTES_PER_MB = 1024 * 1024;
+
+/**
+ * 単一ファイルのサイズ上限（MB単位）。
+ * ツールごとの処理コスト・入力形式に応じて意図的に異なる値を設定している。
+ */
+export const FILE_SIZE_LIMITS_MB = {
+	/** 画像共通ユーティリティ（image-mosaic / image-text 共用, image-common.ts） */
+	IMAGE_COMMON: 20,
+	/** 画像圧縮（image-compress.ts） */
+	IMAGE_COMPRESS: 50,
+	/** 画像形式変換（image-convert.ts） */
+	IMAGE_CONVERT: 50,
+	/** 画像結合（image-merge.ts） */
+	IMAGE_MERGE: 50,
+	/** 画像編集：クロップ・回転・反転（image-edit.ts） */
+	IMAGE_EDIT: 50,
+	/** EXIF表示・削除（exif.ts） */
+	EXIF: 50,
+	/** 画像→Base64変換。テキスト化でサイズが約1.37倍に膨張するため他の画像ツールより低め（image-base64.ts） */
+	IMAGE_BASE64: 10,
+	/** メタデータ一括表示・削除（image-metadata.ts） */
+	IMAGE_METADATA: 25,
+	/** 画像アップスケール。推論処理の負荷が高いため厳しめ（upscale-core.ts） */
+	UPSCALE: 20,
+	/** ファビコン生成（favicon.ts） */
+	FAVICON: 20,
+	/** ハッシュ計算。チャンク読み込みのため大容量ファイルを許容（hash.ts） */
+	HASH: 256,
+	/** PDF結合・分割（pdf.ts） */
+	PDF: 100,
+} as const;
+
+/**
+ * 複数ファイル一括処理時の合計サイズ上限（バイト）。
+ * ブラウザのメモリ制約を踏まえ、対象ツール（image-convert / image-merge / image-edit / exif / pdf）
+ * 間で共通の300MBとしている。
+ */
+export const BATCH_TOTAL_SIZE_LIMIT_BYTES = 300 * BYTES_PER_MB;
+
+/**
+ * 複数ファイル一括処理時の最大ファイル数。
+ * 画像圧縮・結合・編集で共通の30枚としている。
+ */
+export const BATCH_MAX_FILE_COUNT = 30;
+
+/**
+ * メタデータ一括削除（image-metadata.ts）の最大ファイル数。
+ * サムネイル一覧表示のレンダリングコストを踏まえ、他の一括処理ツールより少なめ。
+ */
+export const IMAGE_METADATA_MAX_FILE_COUNT = 20;
+
+/**
+ * hash.ts のファイルサイズ警告しきい値（バイト）。
+ * 大容量ファイルのハッシュ計算時にUI上の警告表示を切り替えるための境界値。
+ */
+export const HASH_LARGE_FILE_THRESHOLD_BYTES = 100 * BYTES_PER_MB;
+export const HASH_HUGE_FILE_THRESHOLD_BYTES = 200 * BYTES_PER_MB;
+
+/**
+ * Blob ダウンロード後、生成した ObjectURL を revoke するまでの遅延（ミリ秒）。
+ * click 直後に revoke するとダウンロードが失敗するブラウザがあるため遅延させる
+ * （src/lib/download.ts と src/lib/tools/image-common.ts の downloadBlob で共用）。
+ */
+export const OBJECT_URL_REVOKE_DELAY_MS = 1000;
+
+/**
+ * CSV編集ツール（CsvEditor.tsx）の1ページあたり表示行数。
+ * 大量行のレンダリングコストとページング操作性のバランスを取った値。
+ */
+export const CSV_EDITOR_ROWS_PER_PAGE = 50;

--- a/src/lib/download.ts
+++ b/src/lib/download.ts
@@ -1,3 +1,5 @@
+import { OBJECT_URL_REVOKE_DELAY_MS } from './constants.ts';
+
 /**
  * Blob をファイルとしてダウンロードする共通 helper。
  * click 後に object URL を必ず revoke してメモリを解放する。
@@ -10,5 +12,5 @@ export function downloadBlob(blob: Blob, filename: string): void {
 	document.body.appendChild(a);
 	a.click();
 	document.body.removeChild(a);
-	setTimeout(() => URL.revokeObjectURL(url), 1000);
+	setTimeout(() => URL.revokeObjectURL(url), OBJECT_URL_REVOKE_DELAY_MS);
 }

--- a/src/lib/tools/exif.ts
+++ b/src/lib/tools/exif.ts
@@ -5,6 +5,13 @@
 // メタデータ除去は JPEG セグメント除去（ピクセル非改変）を基本とし、
 // WebP/TIFF は Canvas 再エンコードにフォールバックする。
 
+import {
+	BATCH_MAX_FILE_COUNT,
+	BATCH_TOTAL_SIZE_LIMIT_BYTES,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
+
 // ---------------------------------------------------------------------------
 // 型定義
 // ---------------------------------------------------------------------------
@@ -53,9 +60,9 @@ export type StripResult = { data: Uint8Array; warnings: string[] };
 // 上限値
 // ---------------------------------------------------------------------------
 
-export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024;
-export const MAX_BATCH_FILES = 30;
-export const MAX_TOTAL_INPUT_BYTES = 300 * 1024 * 1024;
+export const MAX_FILE_SIZE_BYTES = FILE_SIZE_LIMITS_MB.EXIF * BYTES_PER_MB;
+export const MAX_BATCH_FILES = BATCH_MAX_FILE_COUNT;
+export const MAX_TOTAL_INPUT_BYTES = BATCH_TOTAL_SIZE_LIMIT_BYTES;
 
 // ---------------------------------------------------------------------------
 // TIFF 型サイズ

--- a/src/lib/tools/favicon.ts
+++ b/src/lib/tools/favicon.ts
@@ -10,6 +10,8 @@
 // ICOは複数PNGをラップする単純なコンテナ形式（ICONDIR + ICONDIRENTRY×N + PNGペイロード）。
 // scripts/_gen-favicons.mts（Node Buffer版）のエンコードを Uint8Array/DataView へ移植している。
 
+import { BYTES_PER_MB, FILE_SIZE_LIMITS_MB } from '../constants.ts';
+
 // ---------------------------------------------------------------------------
 // 型定義
 // ---------------------------------------------------------------------------
@@ -82,7 +84,7 @@ export type GeneratedFavicons = {
 // ---------------------------------------------------------------------------
 
 /** 入力ファイルの上限: 20MB */
-export const MAX_FAVICON_FILE_SIZE = 20 * 1024 * 1024;
+export const MAX_FAVICON_FILE_SIZE = FILE_SIZE_LIMITS_MB.FAVICON * BYTES_PER_MB;
 
 /** マスターキャンバスの一辺（SVGはここでラスタライズしてから各サイズへ縮小） */
 export const MASTER_SIZE = 512;

--- a/src/lib/tools/hash.ts
+++ b/src/lib/tools/hash.ts
@@ -1,3 +1,10 @@
+import {
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+	HASH_HUGE_FILE_THRESHOLD_BYTES,
+	HASH_LARGE_FILE_THRESHOLD_BYTES,
+} from '../constants.ts';
+
 export type HashAlgorithm = 'md5' | 'sha1' | 'sha256' | 'sha512' | 'crc32';
 
 export type HashResults = Partial<Record<HashAlgorithm, string>>;
@@ -6,9 +13,9 @@ export type HashInputValidation =
 	| { ok: true; warnLevel: 'none' | 'large' | 'huge' }
 	| { ok: false; reason: 'too-large-file' };
 
-export const MAX_FILE_SIZE = 256 * 1024 * 1024;
-export const LARGE_FILE_THRESHOLD = 100 * 1024 * 1024;
-export const HUGE_FILE_THRESHOLD = 200 * 1024 * 1024;
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.HASH * BYTES_PER_MB;
+export const LARGE_FILE_THRESHOLD = HASH_LARGE_FILE_THRESHOLD_BYTES;
+export const HUGE_FILE_THRESHOLD = HASH_HUGE_FILE_THRESHOLD_BYTES;
 const CHUNK_SIZE = 8 * 1024 * 1024;
 
 export const HASH_ALGORITHMS: readonly HashAlgorithm[] = [

--- a/src/lib/tools/image-base64.ts
+++ b/src/lib/tools/image-base64.ts
@@ -1,3 +1,5 @@
+import { BYTES_PER_MB, FILE_SIZE_LIMITS_MB } from '../constants.ts';
+
 export type SnippetKind = 'img' | 'css-bg' | 'raw-base64' | 'data-uri';
 
 export type ImageInputValidation =
@@ -22,7 +24,7 @@ const SUPPORTED_MIMES = new Set([
 	'image/svg+xml',
 ]);
 
-const MAX_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.IMAGE_BASE64 * BYTES_PER_MB;
 
 const MIME_TO_EXT: Record<string, string> = {
 	'image/png': 'png',

--- a/src/lib/tools/image-common.ts
+++ b/src/lib/tools/image-common.ts
@@ -2,6 +2,12 @@
 // 読み込み・バリデーション・縮小・エクスポート・座標変換を提供する純粋関数群
 // （image-mosaic / image-text で共用）
 
+import {
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+	OBJECT_URL_REVOKE_DELAY_MS,
+} from '../constants.ts';
+
 export const SUPPORTED_IMAGE_TYPES = [
 	'image/png',
 	'image/jpeg',
@@ -9,7 +15,7 @@ export const SUPPORTED_IMAGE_TYPES = [
 ] as const;
 
 /** 最大ファイルサイズ: 20MB */
-export const MAX_FILE_SIZE = 20 * 1024 * 1024;
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.IMAGE_COMMON * BYTES_PER_MB;
 
 /** 読み込み可能な最大辺長（これを超える画像は拒否） */
 export const MAX_DIMENSION = 8192;
@@ -201,7 +207,7 @@ export function downloadBlob(blob: Blob, filename: string): void {
 	link.click();
 	document.body.removeChild(link);
 	// click 直後の revoke はダウンロード失敗の原因になるため遅延させる
-	setTimeout(() => URL.revokeObjectURL(url), 1000);
+	setTimeout(() => URL.revokeObjectURL(url), OBJECT_URL_REVOKE_DELAY_MS);
 }
 
 /**

--- a/src/lib/tools/image-compress.ts
+++ b/src/lib/tools/image-compress.ts
@@ -5,6 +5,12 @@
 // canvas 依存の関数（compressImage / compressToTargetSize）はブラウザ専用。
 // 寸法計算・品質二分探索・形式解決などの純粋ロジックは個別にエクスポートし unit test 対象とする。
 
+import {
+	BATCH_MAX_FILE_COUNT,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
+
 export type ResizeMode =
 	| { type: 'none' }
 	| { type: 'max-width'; value: number }
@@ -49,8 +55,8 @@ export const SUPPORTED_INPUT_TYPES = [
 	'image/webp',
 ] as const;
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB/枚
-export const MAX_FILE_COUNT = 30; // 30枚/回
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.IMAGE_COMPRESS * BYTES_PER_MB; // 50MB/枚
+export const MAX_FILE_COUNT = BATCH_MAX_FILE_COUNT; // 30枚/回
 export const DEFAULT_QUALITY = 0.8;
 export const DEFAULT_BACKGROUND = '#ffffff';
 export const TARGET_MIN_QUALITY = 0.3;

--- a/src/lib/tools/image-convert.ts
+++ b/src/lib/tools/image-convert.ts
@@ -8,6 +8,13 @@
 // 形式判定・EXIF 抽出/再注入・バリデーション等の純粋ロジックは個別にエクスポートし
 // unit test 対象とする。canvas/WASM 依存（decodeToBitmap / encode / convertOne）は E2E で検証する。
 
+import {
+	BATCH_MAX_FILE_COUNT,
+	BATCH_TOTAL_SIZE_LIMIT_BYTES,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
+
 export type SourceFormat = 'png' | 'jpeg' | 'webp' | 'avif' | 'heic';
 export type TargetFormat = 'jpeg' | 'png' | 'webp' | 'avif';
 export type ExifMode = 'keep' | 'strip';
@@ -49,9 +56,10 @@ export type BatchValidation =
 // 上限値
 // ---------------------------------------------------------------------------
 
-export const MAX_FILE_SIZE_BYTES = 50 * 1024 * 1024; // 50MB/ファイル
-export const MAX_BATCH_FILES = 30; // 30ファイル/回
-export const MAX_TOTAL_INPUT_BYTES = 300 * 1024 * 1024; // 合計300MB
+export const MAX_FILE_SIZE_BYTES =
+	FILE_SIZE_LIMITS_MB.IMAGE_CONVERT * BYTES_PER_MB; // 50MB/ファイル
+export const MAX_BATCH_FILES = BATCH_MAX_FILE_COUNT; // 30ファイル/回
+export const MAX_TOTAL_INPUT_BYTES = BATCH_TOTAL_SIZE_LIMIT_BYTES; // 合計300MB
 
 export const DEFAULT_QUALITY = 85;
 export const DEFAULT_BACKGROUND = '#ffffff';

--- a/src/lib/tools/image-edit.ts
+++ b/src/lib/tools/image-edit.ts
@@ -3,6 +3,12 @@
 // loadBitmap で EXIF Orientation を反映するため、出力には Orientation タグを残さない。
 
 // node --test から直接読み込めるよう、相対パス + 拡張子付きで import する（zip.ts と同じ規約）
+import {
+	BATCH_MAX_FILE_COUNT,
+	BATCH_TOTAL_SIZE_LIMIT_BYTES,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
 import { downloadBlob } from './image-common.ts';
 import { buildZip, dedupeZipNames } from './zip.ts';
 
@@ -59,9 +65,9 @@ const SUPPORTED_TYPES: Record<string, 'png' | 'jpeg' | 'webp'> = {
 	'image/webp': 'webp',
 };
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB/ファイル
-export const MAX_FILE_COUNT = 30;
-export const MAX_TOTAL_SIZE = 300 * 1024 * 1024; // 300MB
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.IMAGE_EDIT * BYTES_PER_MB; // 50MB/ファイル
+export const MAX_FILE_COUNT = BATCH_MAX_FILE_COUNT;
+export const MAX_TOTAL_SIZE = BATCH_TOTAL_SIZE_LIMIT_BYTES; // 300MB
 export const DEFAULT_QUALITY = 85;
 export const DEFAULT_BACKGROUND = '#ffffff';
 

--- a/src/lib/tools/image-merge.ts
+++ b/src/lib/tools/image-merge.ts
@@ -1,6 +1,13 @@
 // image-merge.ts — 複数画像の結合（縦・横・グリッド）コアロジック（純粋関数中心）
 // 処理はすべてブラウザ内（Canvas API）で完結し、サーバーへの送信は行わない。
 
+import {
+	BATCH_MAX_FILE_COUNT,
+	BATCH_TOTAL_SIZE_LIMIT_BYTES,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
+
 // ---------------------------------------------------------------------------
 // 型定義
 // ---------------------------------------------------------------------------
@@ -54,9 +61,9 @@ const SUPPORTED_TYPES: Record<string, 'png' | 'jpeg' | 'webp' | 'gif'> = {
 	'image/gif': 'gif',
 };
 
-export const MAX_FILE_SIZE = 50 * 1024 * 1024;
-export const MAX_FILE_COUNT = 30;
-export const MAX_TOTAL_SIZE = 300 * 1024 * 1024;
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.IMAGE_MERGE * BYTES_PER_MB;
+export const MAX_FILE_COUNT = BATCH_MAX_FILE_COUNT;
+export const MAX_TOTAL_SIZE = BATCH_TOTAL_SIZE_LIMIT_BYTES;
 export const MAX_CANVAS_DIMENSION = 16384;
 export const DEFAULT_QUALITY = 85;
 

--- a/src/lib/tools/image-metadata.ts
+++ b/src/lib/tools/image-metadata.ts
@@ -1,11 +1,18 @@
+import {
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+	IMAGE_METADATA_MAX_FILE_COUNT,
+} from '../constants.ts';
+
 export const SUPPORTED_METADATA_IMAGE_TYPES = [
 	'image/jpeg',
 	'image/png',
 	'image/webp',
 ] as const;
 
-export const MAX_METADATA_FILE_COUNT = 20;
-export const MAX_METADATA_FILE_SIZE = 25 * 1024 * 1024;
+export const MAX_METADATA_FILE_COUNT = IMAGE_METADATA_MAX_FILE_COUNT;
+export const MAX_METADATA_FILE_SIZE =
+	FILE_SIZE_LIMITS_MB.IMAGE_METADATA * BYTES_PER_MB;
 
 export type MetadataImageType = (typeof SUPPORTED_METADATA_IMAGE_TYPES)[number];
 

--- a/src/lib/tools/pdf.ts
+++ b/src/lib/tools/pdf.ts
@@ -4,6 +4,12 @@
 // 用途は merge / split / image embed / page count detection に限定する
 // （署名保持・暗号化処理・フォーム完全保持などの高度なPDF処理は対象外）。
 
+import {
+	BATCH_TOTAL_SIZE_LIMIT_BYTES,
+	BYTES_PER_MB,
+	FILE_SIZE_LIMITS_MB,
+} from '../constants.ts';
+
 export type MergeInput =
 	| { kind: 'pdf'; name: string; bytes: Uint8Array }
 	| {
@@ -50,9 +56,9 @@ export type SplitResult = {
 	pageNumbers: number[];
 };
 
-export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024; // 100MB/ファイル
+export const MAX_FILE_SIZE_BYTES = FILE_SIZE_LIMITS_MB.PDF * BYTES_PER_MB; // 100MB/ファイル
 export const MAX_MERGE_FILES = 20; // 結合は20ファイル/回
-export const MAX_TOTAL_INPUT_BYTES = 300 * 1024 * 1024; // 合計入力300MB/回
+export const MAX_TOTAL_INPUT_BYTES = BATCH_TOTAL_SIZE_LIMIT_BYTES; // 合計入力300MB/回
 
 export const TOTAL_SIZE_EXCEEDED_MESSAGE =
 	'合計サイズが300MBを超えています。ブラウザのメモリ上限により処理できない可能性があります。ファイル数またはサイズを減らしてください。';

--- a/src/lib/tools/upscale-core.ts
+++ b/src/lib/tools/upscale-core.ts
@@ -2,6 +2,8 @@
 // メインスレッド（UI）と Web Worker の双方から import される。
 // 検証・寸法・タイル分割・ファイル名・モデル定義など、推論を伴わない処理を集約する。
 
+import { BYTES_PER_MB, FILE_SIZE_LIMITS_MB } from '../constants.ts';
+
 // --- 定数 ---
 export const SUPPORTED_INPUT_TYPES = [
 	'image/png',
@@ -10,7 +12,7 @@ export const SUPPORTED_INPUT_TYPES = [
 ] as const;
 
 /** 入力ファイルサイズ上限: 20MB */
-export const MAX_FILE_SIZE = 20 * 1024 * 1024;
+export const MAX_FILE_SIZE = FILE_SIZE_LIMITS_MB.UPSCALE * BYTES_PER_MB;
 
 /** 入力解像度の長辺上限。これを超えると出力が巨大化・処理が非現実的になるため拒否する。 */
 export const MAX_INPUT_EDGE = 2000;


### PR DESCRIPTION
## 概要

Notionタスク: https://www.notion.so/391dfd36033681bb937fcbd8b7fd6a9c

各ツールに散在していたファイルサイズ上限・一括処理の合計サイズ/件数上限・ObjectURL解放遅延・CSV編集のページ表示行数のマジックナンバーを `src/lib/constants.ts` に一元化しました。

## 問題

- ファイルサイズ上限の定数名・値がツールごとにバラバラで、一括変更時の修正漏れリスクがあった（`image-common.ts` 20MB / `image-compress.ts` `image-convert.ts` `image-merge.ts` `image-edit.ts` `exif.ts` 50MB / `image-base64.ts` 10MB / `upscale-core.ts` 20MB / `hash.ts` 256MB / `pdf.ts` 100MB / `image-metadata.ts` 25MB / `favicon.ts` 20MB）
- `src/lib/download.ts` と `src/lib/tools/image-common.ts` に `setTimeout(..., 1000)`（ObjectURL解放遅延）がハードコード重複していた
- `CsvEditor.tsx` の `ROWS_PER_PAGE = 50` などUX直結パラメータがコンポーネント内に埋没していた

## 対応内容

- `src/lib/constants.ts` を新設し、以下を集約
  - `FILE_SIZE_LIMITS_MB`: ツール別のファイルサイズ上限（MB単位、キー名とコメントで値の違いの根拠を明記）
  - `BATCH_TOTAL_SIZE_LIMIT_BYTES` / `BATCH_MAX_FILE_COUNT`: 複数ファイル一括処理の合計サイズ・件数上限
  - `IMAGE_METADATA_MAX_FILE_COUNT`: `image-metadata.ts` 固有の件数上限
  - `HASH_LARGE_FILE_THRESHOLD_BYTES` / `HASH_HUGE_FILE_THRESHOLD_BYTES`: hash.ts の警告しきい値
  - `OBJECT_URL_REVOKE_DELAY_MS`: ObjectURL revoke までの遅延（ミリ秒）
  - `CSV_EDITOR_ROWS_PER_PAGE`: CSV編集ツールの1ページ表示行数
- 各ツールファイルは既存のエクスポート名・値を保ったまま、上記の値を `constants.ts` から参照する形に変更（呼び出し側・テストへの影響なし）
- 既存の上限値・挙動は一切変更していません（同一の数値をそのまま定数化しただけ）

## スコープ外

- `BgRemove.tsx` / `qr-reader/ImageUploader.tsx` のコンポーネントローカルなサイズ定数、`transcribe/audio-browser.ts`、`phone-formatter/validation.ts`、`validation/fileValidator.ts`（動的計算のため性質が異なる）は今回のNotionタスクで名指しされた対象外のため変更していません
- `phone-formatter/ResultTable.tsx` の `PAGE_SIZE` も対象外（値・用途が異なり、今回の指摘に含まれていないため）

## 検証結果

- `npm run test:unit`: 1002 tests / 0 failed
- `npm run lint`: エラーなし（`tests/e2e/webmcp.spec.ts` の non-null assertion 警告等、既存の無関係な警告のみ。AGENTS.mdに記載の既知事項）
- `npx astro sync && npx tsc --noEmit --pretty false --ignoreDeprecations 6.0`: エラーなし
- `npm run build`: 成功（99ページ生成）

---
Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0173c4R6CX83snwiD9HQko2D

---
_Generated by [Claude Code](https://claude.ai/code/session_0173c4R6CX83snwiD9HQko2D)_