### PR TITLE
docs: docsと実装の乖離修正

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,15 +15,15 @@
 
 プロジェクトの全体設計やルールについては、以下の詳細設計書を必ず参照してください。
 
-- **[architecture.md](file:///d:/tools-codelife-cafe/docs/architecture.md) (システムアーキテクチャ設計書)**
+- **[architecture.md](docs/architecture.md) (システムアーキテクチャ設計書)**
   - 全体技術スタック、ディレクトリ構造、およびビルドプロセスと連携した PWA (Service Worker) の構成。
-- **[development-guide.md](file:///d:/tools-codelife-cafe/docs/development-guide.md) (開発ガイドライン / ツール作成手順)**
-  - 命名規約、UI・ロジックの分離（3ファイル構成）、デザインシステム（Tailwind v4）、Biomeの設定、E2Eテスト。
-- **[data-management.md](file:///d:/tools-codelife-cafe/docs/data-management.md) (データ管理とモデル配信設計書)**
+- **[development-guide.md](docs/development-guide.md) (開発ガイドライン / ツール作成手順)**
+  - 命名規約、UI・ロジックの分離（4ファイル構成）、デザインシステム（Tailwind v4）、Biomeの設定、E2Eテスト。
+- **[data-management.md](docs/data-management.md) (データ管理とモデル配信設計書)**
   - 郵便番号データのチャンク化および更新方法、AIモデルの Cloudflare R2 配信と Web Worker 推論。
-- **[analytics.md](file:///d:/tools-codelife-cafe/docs/analytics.md) (計測基盤設計)**
+- **[analytics.md](docs/analytics.md) (計測基盤設計)**
   - Cloudflare Analytics Engine による完全匿名イベント計測方針とAllowlistプロパティ。
-- **[seo.md](file:///d:/tools-codelife-cafe/docs/seo.md) (SEO & 構造化データガイドライン)**
+- **[seo.md](docs/seo.md) (SEO & 構造化データガイドライン)**
   - Schema.org 準拠の JSON-LD 構造化データ付与規約と検証手順。
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,11 @@
 
 > [!NOTE]
 > 詳細な設計方針、コーディング規約、データ管理については以下の設計書および **AGENTS.md** を参照してください。
-> - [architecture.md](file:///d:/tools-codelife-cafe/docs/architecture.md) (全体設計、PWA)
-> - [development-guide.md](file:///d:/tools-codelife-cafe/docs/development-guide.md) (ツール追加手順、命名規約、UI・ロジック分離、テスト)
-> - [data-management.md](file:///d:/tools-codelife-cafe/docs/data-management.md) (郵便番号チャンク、モデルのR2配信)
-> - [analytics.md](file:///d:/tools-codelife-cafe/docs/analytics.md) (計測基盤設計)
-> - [seo.md](file:///d:/tools-codelife-cafe/docs/seo.md) (SEO & 構造化データガイドライン)
+> - [architecture.md](docs/architecture.md) (全体設計、PWA)
+> - [development-guide.md](docs/development-guide.md) (ツール追加手順、命名規約、UI・ロジック分離、テスト)
+> - [data-management.md](docs/data-management.md) (郵便番号チャンク、モデルのR2配信)
+> - [analytics.md](docs/analytics.md) (計測基盤設計)
+> - [seo.md](docs/seo.md) (SEO & 構造化データガイドライン)
 
 ---
 
@@ -36,11 +36,12 @@ npx playwright test --headed                              # ブラウザを表�
 
 ## 2. ツール開発アーキテクチャ (要約)
 
-### 2.1 3ファイル（+1）構成
+### 2.1 4ファイル（+1）構成
 新しいツールを追加する際は、以下の構成でファイルを配置します。
 - **純粋ロジック:** `src/lib/tools/[name].ts`
 - **React UI Island:** `src/components/tools/[Name].tsx` （UIとローカル状態管理）
-- **Astro ページシェル:** `src/pages/[name].astro`
+- **LPコンテンツ:** `src/content/tools/[name].md` （title/description/useCases/howto/faq等のフロントマター）
+- **Astro ページシェル:** `src/pages/[name].astro` （content collection を取得し `ToolLayout` に渡す）
 - **Web Worker (オプション):** `src/workers/[name].worker.ts` （AI推論などの重量処理）
 
 ### 2.2 E2Eテストの注意点

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,11 +49,12 @@ src/
 ├── components/          # UIコンポーネント
 │   ├── ui/              # shadcn/ui コンポーネント（Biome自動生成、手動編集不可）
 │   ├── layout/          # 共通レイアウト部品（Header, Footer, Navigation, SafetyBadge等）
+│   ├── tool/            # ツール共通レイアウト（ToolLayout, RelatedTools, ToolHero等）
 │   ├── tools/           # 汎用的な各ツール固有React UI（テキスト/データ/開発系など）
 │   ├── image-* / pdf-*  # 画像・PDF系など機能単位のReact UIコンポーネント群
 │   ├── zipcode/         # 郵便番号変換ツールのUIとチャンク取得補助
-│   └── common/          # 汎用部品（CopyButton, FileDropzone, ToolLayout, ToolCard等）
-├── content/             # ツールLP用コンテンツコレクション (Markdown/MDXデータ)
+│   └── common/          # 汎用部品（CopyButton, FileDropzone, ToolCard, JsonLd等）
+├── content/tools/       # 各ツールのLPコンテンツ（title/description/useCases/howto/faq等、Markdownフロントマター）
 ├── layouts/
 │   └── BaseLayout.astro # 全ページ共通HTMLレイアウト（SEO, SW登録, 計測タグ）
 ├── pages/
@@ -136,7 +137,7 @@ flowchart TD
 | --- | --- | --- | --- |
 | ページ・UIアセット取得 | Cloudflare Pages から配信される HTML、`/_astro/` 配下の JS/CSS/画像、`dist/sw.js` | アプリ本体の表示、Astro Islands のハイドレーション、PWA のキャッシュ制御 | 許可。静的アセット配信のみ。ユーザー入力データは含めない |
 | ツールカタログ参照 | `src/lib/tools/catalog.ts` | トップページ、検索、カテゴリ、関連ツール、OGP 画像生成の単一情報源 | 許可。ビルド成果物またはブラウザ内コードとして参照するだけで、外部送信はしない |
-| ツール共通レイアウト表示 | `src/components/common/ToolLayout.astro` | `SafetyBadge`、パンくず、関連ツール、構造化データ、ツール本文スロットの表示 | 許可。表示制御のみ。処理対象データの送信はしない |
+| ツール共通レイアウト表示 | `src/components/tool/ToolLayout.astro` | `SafetyBadge`、パンくず、関連ツール、構造化データ、ツール本文スロットの表示 | 許可。表示制御のみ。処理対象データの送信はしない |
 | Service Worker テンプレート・生成物 | `public/sw.js`、`scripts/generate-sw.mjs`、`dist/sw.js` | プリキャッシュ対象の注入、Cache First / Network First、オフラインフォールバック | 許可。同一オリジンの静的ファイル取得・キャッシュに限定 |
 | 郵便番号チャンク取得 | `/data/zipcode/*.json` などの静的JSON | 郵便番号検索・変換に必要な辞書データを必要分だけ取得 | 例外的に許可。静的データのダウンロードのみで、検索語や入力内容は送信しない |
 | AIモデルファイル取得 | Cloudflare R2 等で配信されるモデル・WASM・関連ファイル | AI背景削除などのブラウザ内推論に必要なモデルを取得 | 例外的に許可。モデルファイル取得のみで、画像などの処理対象データは送信しない |
@@ -153,7 +154,7 @@ flowchart TD
 完全クライアントサイド処理をユーザーに明示し、安心してデータを入出力してもらうために、すべてのツールの上部には「完全ローカル処理（外部送信なし）」を示す `SafetyBadge` が自動配置されます。
 
 ### 7.2 ツールカタログと関連ツール回遊
-ツール一覧・検索・個別ページの関連ツールカードは `src/lib/tools/catalog.ts` を単一の情報源として管理します。`ToolLayout.astro` は現在ページの `path` からツールを解決し、`getRelatedTools()` によって `related` 指定を優先しつつ同カテゴリのツールで最大3件まで補完して表示します。これにより、各ページに手書きの関連リンクを分散させず、回遊導線を一元管理します。
+ツール一覧・検索・個別ページの関連ツールカードは `src/lib/tools/catalog.ts` を単一の情報源として管理します。`ToolLayout.astro` が内部で描画する `RelatedTools.astro`（`src/components/tool/`）は、対象ツールの `src/content/tools/[name].md` フロントマターに書かれた `related` を優先しつつ、指定が無い・不足する場合は `getRelatedTools()` により `catalog.ts` の同カテゴリのツールで最大3件まで補完して表示します。これにより、各ページに手書きの関連リンクを分散させず、回遊導線を一元管理します。
 
 ### 7.3 ネットワーク遮断の保証
 本アプリは意図的にバックエンドAPIを持たず、静的ファイル配信のみで構成されているため、ブラウザの開発者ツールの「ネットワーク」タブ等で検証しても、ユーザーデータの外部送信が発生しないことが確認できます。

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -20,15 +20,16 @@
 
 ## 2. 新規ツールのファイル構成
 
-各ツールは、基本的に以下の **3ファイル**（重量処理がある場合は Web Worker を加えた **4ファイル**）で完結するように設計します。画像・PDFなどUIが大きいツールは、`src/components/[feature]/` のように機能別ディレクトリへ分割できます。
+各ツールは、基本的に以下の **4ファイル**（重量処理がある場合は Web Worker を加えた **5ファイル**）で完結するように設計します。画像・PDFなどUIが大きいツールは、`src/components/[feature]/` のように機能別ディレクトリへ分割できます。
 
 ```
 src/
 ├── lib/tools/[name].ts          # 1. 純粋関数のロジック (TypeScript)
 ├── components/tools/[Name].tsx  # 2. React Island (UI & 状態管理)
-└── pages/[name].astro           # 3. Astro ページシェル (レイアウト・メタデータ)
+├── content/tools/[name].md      # 3. LPコンテンツ (title/description/useCases/howto/faq等のフロントマター)
+└── pages/[name].astro           # 4. Astro ページシェル (content collection を取得し ToolLayout に渡すだけ)
 (オプション)
-└── workers/[name].worker.ts     # 4. 重量級処理用の Web Worker
+└── workers/[name].worker.ts     # 5. 重量級処理用の Web Worker
 ```
 
 ### 2.1 命名規約
@@ -72,7 +73,7 @@ import { useState } from 'react';
 import { countCharacters } from '@/lib/tools/char-count';
 import { Textarea } from '@/components/ui/textarea';
 
-export function CharCount() {
+export default function CharCount() {
 	const [text, setText] = useState('');
 	const result = countCharacters(text);
 
@@ -93,29 +94,50 @@ export function CharCount() {
 }
 ```
 
-### 3.3 ページシェル層 (`src/pages/[name].astro`)
-Astroを用いて静的なWebページを宣言します。SEO用のJSON-LDやメタデータ、SafetyBadge（安全表示）、使い方（使い方スロット）などは、`ToolLayout` を使うことで統一的にレイアウトされます。
+### 3.3 コンテンツ層 (`src/content/tools/[name].md`) とページシェル層 (`src/pages/[name].astro`)
+タイトル・説明文・ユースケース・使い方・FAQ・関連ツール等のLP向けコンテンツは、Astro Content Collections（`src/content.config.ts` の `tools` コレクション）のフロントマターとして `src/content/tools/[name].md` に記述します。本文（Markdown本体）は使用せず、フロントマターのみで完結させます。
 
-Reactコンポーネントを配置する際は、ハイドレーションを行うために **`client:load`** ディレクティブを付与します。関連ツールは `src/lib/tools/catalog.ts` の `related` と `getRelatedTools()`、および `ToolLayout.astro` で自動表示するため、各ページの `usage` スロット内に手書きの「関連ツール」リンクを追加しないでください。
+```md
+---
+# 例: src/content/tools/char-count.md
+title: "文字数カウント"
+description: "文字数・バイト数・行数をリアルタイムでカウントします。"
+category: "テキスト解析"
+summary: "テキストの文字数やバイト数をローカル環境で瞬時に計算します。"
+useCases:
+  - "SNSの投稿文字数制限を確認したい"
+howto:
+  - "入力欄にテキストをペーストまたは入力すると、リアルタイムで解析結果が表示されます。"
+faq:
+  - q: "バイト数はどの文字コードで計算されますか？"
+    a: "UTF-8とShift-JISの両方を切り替えて確認できます。"
+related:
+  - "zenkaku-hankaku"
+  - "text-diff"
+updated: 2026-06-28
+---
+```
+
+`src/pages/[name].astro` では、この Content Collection エントリを `getEntry()` で取得し、`ToolLayout` にそのまま渡します。SEO用のJSON-LD、メタデータ、`SafetyBadge`（安全表示）、パンくず、使い方・FAQ・関連ツールの表示は、フロントマターの内容をもとに `ToolLayout` が統一的にレイアウトします（`BaseLayout` も `ToolLayout` が内部でラップするため、ページ側で個別に読み込む必要はありません）。
+
+Reactコンポーネントを配置する際は、ハイドレーションを行うために **`client:load`** ディレクティブを付与します。関連ツールは `src/content/tools/[name].md` の `related`（優先）と `src/lib/tools/catalog.ts` の `getRelatedTools()`（同カテゴリ補完）、および `ToolLayout.astro` で自動表示するため、各ページに手書きの「関連ツール」リンクを追加しないでください。
 
 ```astro
 ---
 // 例: src/pages/char-count.astro
-import BaseLayout from '@/layouts/BaseLayout.astro';
-import ToolLayout from '@/components/common/ToolLayout.astro';
-import { CharCount } from '@/components/tools/CharCount';
+import { getEntry } from 'astro:content';
+import ToolLayout from '../components/tool/ToolLayout.astro';
+import CharCount from '../components/tools/CharCount.tsx';
+
+const toolEntry = await getEntry('tools', 'char-count');
+if (!toolEntry) {
+  throw new Error('Tool entry not found: char-count');
+}
 ---
 
-<BaseLayout title="文字数カウント" description="リアルタイムで文字数・行数・バイト数をカウントします。">
-  <ToolLayout title="文字数カウント" description="テキストの文字数やバイト数をローカル環境で瞬時に計算します。">
-    <CharCount client:load />
-
-    <div slot="usage">
-      <h3>使い方</h3>
-      <p>入力欄にテキストをペーストまたは入力すると、リアルタイムで解析結果が表示されます。</p>
-    </div>
-  </ToolLayout>
-</BaseLayout>
+<ToolLayout tool={toolEntry}>
+  <CharCount client:load />
+</ToolLayout>
 ```
 
 ---
@@ -126,11 +148,12 @@ import { CharCount } from '@/components/tools/CharCount';
 
 - [ ] `src/lib/tools/[name].ts` に、DOM や React に依存しない純粋関数としてロジックを実装する。
 - [ ] `src/components/tools/[Name].tsx`、または UI の規模に応じた機能別ディレクトリに React UI を実装する。
-- [ ] `src/pages/[name].astro` を作成し、共通レイアウトとして `ToolLayout` を利用し、React コンポーネントには `client:load` を付与する。
-- [ ] `src/lib/tools/catalog.ts` に `id`、`title`、`description`、`href`、`category`、`icon`、`related` を登録する。
+- [ ] `src/content/tools/[name].md` に `title`、`description`、`category`、`summary`、`useCases`、`howto`、`faq`、`related`、`updated`（任意で `keywords`）をフロントマターとして登録する（`src/content.config.ts` のスキーマ参照）。
+- [ ] `src/pages/[name].astro` を作成し、`getEntry('tools', '[name]')` で取得したエントリを `<ToolLayout tool={entry}>` に渡す。React コンポーネントには `client:load` を付与する。
+- [ ] `src/lib/tools/catalog.ts` に `id`、`title`、`description`、`href`、`category`、`icon`、`categoryColor`、`keywords`、`related` を登録する。
 - [ ] UI文言、エラーメッセージ、プレースホルダーが日本語であることを確認する。
 - [ ] 外部API、トラッキング、ユーザーデータ送信がないことを確認する。
-- [ ] 関連ツールは各ページに手書きせず、`catalog.ts` の `related` と `ToolLayout.astro` に集約する。
+- [ ] 関連ツールは各ページに手書きせず、コンテンツの `related` と `catalog.ts`・`ToolLayout.astro` に集約する。
 - [ ] `npm run lint` を実行し、必要に応じて `npm run build` と `npm test` も実行する。
 
 ## 4. デザインシステム & スタイリング
@@ -178,12 +201,19 @@ npx shadcn@latest add [component-name]
 
 プロジェクトのコード品質を保つため、**Biome** を採用しています。
 - **インデント:** タブ（Tab）を使用。
-- **型チェック:** TypeScript `strict` モードを有効化。インポート時はエイリアス `@/` を使用（例: `import { cn } from '@/lib/utils'`）。
+- **型チェック:** TypeScript `strict` モードを有効化。`.ts`/`.tsx` からのインポート時はエイリアス `@/` を使用できます（例: `import { cn } from '@/lib/utils'`）。ただし `.astro` ページは慣例としてコンポーネントを相対パスでインポートします（例: `import ToolLayout from '../components/tool/ToolLayout.astro'`）。
 - **Linter & Formatter コマンド:**
   ```bash
   npm run lint       # チェックのみ
   npm run lint:fix   # 自動フォーマットと自動修正の適用
   ```
+
+### 6.1 Biome と astro check の責務分担
+`biome.json` の `files.includes` は `**/*.astro` と `**/*.css` を明示的に除外しています。役割分担は以下の通りです。
+
+- **Biome**（`npm run lint` / `npm run lint:fix`）: `.ts` / `.tsx`（`src/`、`tests/` 配下）の Lint と Formatter を担当します。`.astro` ファイルの構文・テンプレート部分は解析対象外です。
+- **`astro check`**: `.astro` ファイルの型チェック・診断（Props の型不整合、未使用の import、テンプレートバインディングの誤り等）を担当します。`.astro` 内の `<script>` に書かれた TypeScript も含めてチェックします。
+- **`npm run check`** は `astro check && biome check src/ tests/` を実行するため、`.astro` を含む全ファイルの品質を両者で分担して担保します。`npm run lint` 単体では `.astro` の診断は行われない点に注意してください。
 
 ---
 

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -10,7 +10,7 @@
 - **`WebSite`**: サイト全体のメタデータを提供。
 - **`Person`**: 運営者/管理者エンティティ（`@id: "https://tools.codelife.cafe/#org"`）を定義し、GitHub などの `sameAs` リンクを接続。
 
-### 全ツールページ (`src/components/common/ToolLayout.astro`)
+### 全ツールページ (`src/components/tool/ToolLayout.astro`)
 - **`SoftwareApplication`**: ツールごとのアプリケーション情報（名称、説明、料金 `0 JPY`、動作環境 `Any` 等）。`publisher` としてトップページの `@id` (`https://tools.codelife.cafe/#org`) を参照し、エンティティグラフを構成。
 - **`BreadcrumbList`**: ツールページへの階層（ホーム > カテゴリ > ツール名）を絶対 URL で記述。
 
@@ -24,7 +24,7 @@
 - `breadcrumb(path, title, categoryName, categoryHref)`: `BreadcrumbList` オブジェクトを生成
 - `generateJsonLd(tool, categoryHref)`: 上記 2 つを `@graph` 配列にまとめた JSON-LD を生成
 
-各 Astro ページおよびコンポーネント内では、`<JsonLd data={...} />` コンポーネント経由で `<script type="application/ld+json">` として安全にエスケープ出力します。
+トップページ（`src/pages/index.astro`）では `<JsonLd data={...} />`（`src/components/common/JsonLd.astro`）コンポーネント経由で出力します。各ツールページでは `ToolLayout.astro` が `generateJsonLd()` の結果を `<script is:inline type="application/ld+json">` として直接出力します。いずれも `<` 文字をエスケープしてから `set:html` に渡すため、安全に埋め込まれます。
 
 ---
 
@@ -49,7 +49,7 @@ npm run build
 # PowerShell での確認例 (dist ディレクトリ内の SoftwareApplication 件数カウント)
 (Get-ChildItem -Path dist -Recurse -Filter *.html | Select-String -Pattern '"@type":"SoftwareApplication"').Count
 ```
-※全ツールの数（例: 48件）と出力件数が一致することを確認します。
+※各ツールは正規URL（例: `/base64/`）と旧URL（例: `/tools/base64/`、`canonical` は正規URLを指す）の2ページが生成されるため、出力件数は「全ツールの数（`src/lib/tools/catalog.ts` の登録数。本書執筆時点で47件）× 2」と一致することを確認します。
 
 ### 3.3 Schema Markup Validator での検証
 1. [Google Rich Results Test](https://search.google.com/test/rich-results) または [Schema Markup Validator](https://validator.schema.org/) を開きます。


### PR DESCRIPTION
## 概要

`docs/architecture.md` / `docs/development-guide.md` を中心に、記載と実装のズレを洗い出して修正した。監査で指摘された3点（`ToolLayout.astro` のパス、`src/lib/jsonld.ts` の実在確認、Biomeが`.astro`をlint対象外にしている理由の未記載）に加え、`docs/`配下の全ファイルパス参照を実装と照合し、他に見つかった乖離も修正している。

## 対応内容

### 1. `ToolLayout.astro` のパス修正（報告事項）
`docs/architecture.md` / `docs/seo.md` が `src/components/common/ToolLayout.astro` と記載していたが、実際は `src/components/tool/ToolLayout.astro`。ディレクトリツリー・表・本文の該当箇所を修正し、`architecture.md` のディレクトリツリーに存在しなかった `components/tool/` を追加した。

### 2. `src/lib/jsonld.ts` の実在確認（報告事項）
実在を確認済み（`docs/seo.md` の記載は正しい）。修正不要。

### 3. Biome と `astro check` の責務分担を明記（報告事項）
`biome.json` の `files.includes` が `**/*.astro` と `**/*.css` を除外している理由が未記載だったため、`docs/development-guide.md` に §6.1 として、Biomeが `.ts`/`.tsx` のLint/Format、`astro check` が `.astro` の型チェック・診断を担当するという役割分担を追記した。

### 4. 追加で見つかった乖離（`docs/`内の全ファイルパスを実装と照合した結果）
- `docs/development-guide.md` の「3ファイル構成」およびページシェル層のコード例が、実装（`src/content/tools/[name].md` によるContent Collectionを介した `getEntry()` + `<ToolLayout tool={entry}>` パターン）と大きく乖離していた（存在しない `slot="usage"`、存在しない `<ToolLayout title=... description=...>` props、実際は不要な `<BaseLayout>` 個別ラップを例示していた）。実装に合わせて「4ファイル（+1）」構成・コード例・チェックリストを全面的に更新した。
- `docs/seo.md`: JSON-LD出力経路の説明が実装と不一致（`<JsonLd>` コンポーネント経由は実際はトップページのみで、ツールページは `ToolLayout.astro` 内で直接 `<script is:inline>` 出力）だったため修正。また `SoftwareApplication` 件数検証コマンドの説明が「全ツール数と一致」となっていたが、実際は正規URL・旧URL（`/tools/`プレフィックス、`canonical`は正規URLを指す）の2ページ分が出力されるため2倍になる旨を追記。
- `CLAUDE.md` / `AGENTS.md`: 設計書へのリンクが `file:///d:/tools-codelife-cafe/...`（存在しないWindowsローカルパス）になっており、このリポジトリ・この環境では機能しないリンクだった。リポジトリ相対パスに修正し、development-guide.mdの更新に合わせてファイル数表記も統一した。

### 対応しなかった項目（人間確認事項）
- `docs/specs/2026-06-27-tool-related-cards-design.md` にも同様の古いパス・`slot="usage"`記載が残っているが、これは特定時点の設計提案を記録した仕様書（ADR的なドキュメント）であり、現状追従目的で書き換えると設計の経緯記録として不正確になるため、意図的に変更していない。必要であれば別途「このドキュメントは策定当時の設計案であり、現在の実装は development-guide.md を正とする」旨の注記を追加する対応を検討されたい。

## 受け入れ基準チェック

1. docs内の全ファイルパスと実装を照合 → ✅ `docs/*.md` 内のバッククォート付きソースパス参照を全て抽出し、実ファイルの存在を確認（`src/components/common/ToolLayout.astro` のみ不一致で修正）
2. 実在しない参照を修正または削除 → ✅（上記1・4参照）
3. Biomeとastro checkの責務分担を明記 → ✅ `docs/development-guide.md` §6.1
4. ドキュメントリンクとlintが成功する → ✅（下記）

## 検証結果

- `npm run lint` → 成功（既存の無関係な警告のみ、エラー0）
- `npx astro check` → 0 errors / 0 warnings
- `npm run test:unit` → 1002/1002 pass
- `npm run build` → 成功
- ドキュメント内のソースパス参照・markdownリンクを手動で全件突合し、実在確認済み（自動リンクチェッカーは本リポジトリに未導入のため、人手で検証）
- `SoftwareApplication` の件数検証コマンドをビルド後実行し、47ツール×2ページ=94件と記載通りであることを確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01DowkmTmNhx4WgoyFEHiPMD)_