### PR TITLE
test(unit): 単体テスト欠落9ツールへのテスト追加

### DIFF
--- a/src/lib/phone-formatter/bulk.ts
+++ b/src/lib/phone-formatter/bulk.ts
@@ -3,9 +3,9 @@
  * 複数の電話番号をCSV形式で入力・変換・出力する
  */
 import Papa from 'papaparse';
-import { getNumberTypeLabel } from './classify';
-import { parsePhoneNumber } from './parse';
-import type { BulkResult, ParseResult } from './types';
+import { getNumberTypeLabel } from './classify.ts';
+import { parsePhoneNumber } from './parse.ts';
+import type { BulkResult, ParseResult } from './types.ts';
 
 const MAX_BULK_ITEMS = 10000;
 

--- a/src/lib/phone-formatter/parse.ts
+++ b/src/lib/phone-formatter/parse.ts
@@ -2,10 +2,10 @@
  * 電話番号パーサー & バリデーター
  */
 import { parsePhoneNumber as awpParse } from 'awesome-phonenumber';
-import { classifyNumber } from './classify';
-import { preprocessInput } from './preprocess';
-import { getRegionName } from './regions';
-import type { ParseResult } from './types';
+import { classifyNumber } from './classify.ts';
+import { preprocessInput } from './preprocess.ts';
+import { getRegionName } from './regions.ts';
+import type { ParseResult } from './types.ts';
 
 /**
  * 電話番号文字列をパースしてフォーマット変換・種別判定・地域名取得を行う

--- a/src/lib/tools/image-text.ts
+++ b/src/lib/tools/image-text.ts
@@ -32,7 +32,7 @@ export const LINE_HEIGHT = 1.4;
 /** 背景ボックスのパディング(px) */
 export const BG_PADDING = 4;
 
-import { createId } from './image-common';
+import { createId } from './image-common.ts';
 
 export const FONT_FAMILIES: readonly { value: FontFamily; label: string }[] = [
 	{ value: 'sans-serif', label: 'ゴシック体' },

--- a/tests/unit/csv-fixer.test.ts
+++ b/tests/unit/csv-fixer.test.ts
@@ -1,0 +1,197 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/csv-fixer.test.ts
+//
+// csv-fixer のエンコーディング検出・変換・CSVプレビュー・ファイル検証ロジックを対象とする。
+// ファイル選択UI（FileDropZone等）はブラウザ専用のため E2E で検証する。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { parsePreview } from '../../src/lib/csv/preview.ts';
+import { convertEncoding } from '../../src/lib/encoding/convert.ts';
+import { detectEncoding } from '../../src/lib/encoding/detect.ts';
+import { detectLineEnding } from '../../src/lib/encoding/lineEndings.ts';
+import {
+	getMaxFileSize,
+	validateFile,
+} from '../../src/lib/validation/fileValidator.ts';
+
+function toBuffer(str: string): ArrayBuffer {
+	return new TextEncoder().encode(str).buffer as ArrayBuffer;
+}
+
+function fakeFile(name: string, size: number): File {
+	return { name, size } as unknown as File;
+}
+
+// ============================================================
+// detectEncoding
+// ============================================================
+
+test('detectEncoding: 100バイト未満のファイルは confidence: low', () => {
+	const result = detectEncoding(toBuffer('short utf8 text'));
+	assert.equal(result.confidence, 'low');
+});
+
+test('detectEncoding: ASCIIのみのテキストは confidence: low', () => {
+	const result = detectEncoding(toBuffer('a'.repeat(200)));
+	assert.equal(result.confidence, 'low');
+});
+
+test('detectEncoding: ある程度長い日本語UTF-8テキストは UTF8 として検出される', () => {
+	const text = 'こんにちは、世界。'.repeat(20);
+	const result = detectEncoding(toBuffer(text));
+	assert.equal(result.encoding, 'UTF8');
+});
+
+test('detectEncoding: 空バッファは低信頼度のフォールバックを返す', () => {
+	const result = detectEncoding(new ArrayBuffer(0));
+	assert.equal(result.confidence, 'low');
+	assert.ok(typeof result.encoding === 'string');
+});
+
+// ============================================================
+// detectLineEnding
+// ============================================================
+
+test('detectLineEnding: CRLFのみ -> CRLF', () => {
+	assert.equal(detectLineEnding('a\r\nb\r\nc'), 'CRLF');
+});
+
+test('detectLineEnding: LFのみ -> LF', () => {
+	assert.equal(detectLineEnding('a\nb\nc'), 'LF');
+});
+
+test('detectLineEnding: CRのみ -> CR', () => {
+	assert.equal(detectLineEnding('a\rb\rc'), 'CR');
+});
+
+test('detectLineEnding: 改行なし -> NONE', () => {
+	assert.equal(detectLineEnding('abc'), 'NONE');
+});
+
+test('detectLineEnding: CRLFとLFが混在 -> MIXED', () => {
+	assert.equal(detectLineEnding('a\r\nb\nc'), 'MIXED');
+});
+
+// ============================================================
+// parsePreview
+// ============================================================
+
+test('parsePreview: 非数値の先頭行はヘッダーとして扱われる', () => {
+	const result = parsePreview('name,age\nAlice,30\nBob,25', 10);
+	assert.deepEqual(result.headers, ['name', 'age']);
+	assert.equal(result.rows.length, 2);
+	assert.equal(result.delimiter, ',');
+});
+
+test('parsePreview: 数値のみの先頭行はヘッダーとして扱われない', () => {
+	const result = parsePreview('1,2\n3,4', 10);
+	assert.equal(result.headers, null);
+	assert.equal(result.rows.length, 2);
+});
+
+test('parsePreview: totalRowEstimate は全体の改行数から見積もる', () => {
+	const result = parsePreview('a,b\nc,d\ne,f\ng,h', 2);
+	assert.equal(result.totalRowEstimate, 4);
+	// preview: maxRows=2 のためプレビュー行数はそれ以下
+	assert.ok(result.rows.length <= 2);
+});
+
+test('parsePreview: タブ区切りの delimiter を検出する', () => {
+	const result = parsePreview('a\tb\nc\td', 10);
+	assert.equal(result.delimiter, '\t');
+});
+
+test('parsePreview: 空文字列は1行の見積もりを返す', () => {
+	const result = parsePreview('', 10);
+	assert.equal(result.totalRowEstimate, 1);
+});
+
+// ============================================================
+// convertEncoding
+// ============================================================
+
+test('convertEncoding: UTF-8 BOMを剥がしてから変換する', () => {
+	const withBom = new Uint8Array([
+		0xef,
+		0xbb,
+		0xbf,
+		...new TextEncoder().encode('abc'),
+	]);
+	const result = convertEncoding(
+		withBom.buffer as ArrayBuffer,
+		'UTF8',
+		{ outputEncoding: 'UTF8', lineEnding: 'LF', addBom: false },
+		'sample.csv',
+	);
+	assert.equal(result.blob.type, 'text/csv; charset=utf-8');
+	assert.equal(result.fileName, 'sample_converted.csv');
+	assert.equal(result.outputEncoding, 'UTF8');
+});
+
+test('convertEncoding: addBom: true で UTF-8 BOMが付与される', async () => {
+	const result = convertEncoding(
+		toBuffer('a,b\nc,d'),
+		'UTF8',
+		{ outputEncoding: 'UTF8', lineEnding: 'LF', addBom: true },
+		'data.csv',
+	);
+	const bytes = new Uint8Array(await result.blob.arrayBuffer());
+	assert.equal(bytes[0], 0xef);
+	assert.equal(bytes[1], 0xbb);
+	assert.equal(bytes[2], 0xbf);
+});
+
+test('convertEncoding: 改行コードを CRLF に統一する', async () => {
+	const result = convertEncoding(
+		toBuffer('a\nb\rc\r\nd'),
+		'UTF8',
+		{ outputEncoding: 'UTF8', lineEnding: 'CRLF', addBom: false },
+		'x.csv',
+	);
+	const text = await result.blob.text();
+	assert.equal(text, 'a\r\nb\r\nc\r\nd');
+	assert.equal(result.lineCount, 4);
+});
+
+test('convertEncoding: 出力ファイル名は拡張子を除いた basename + _converted.csv', () => {
+	const result = convertEncoding(
+		toBuffer('a'),
+		'UTF8',
+		{ outputEncoding: 'UTF8', lineEnding: 'LF', addBom: false },
+		'archive.tar.csv',
+	);
+	assert.equal(result.fileName, 'archive.tar_converted.csv');
+});
+
+// ============================================================
+// fileValidator
+// ============================================================
+
+test('validateFile: 空ファイルは EMPTY_FILE', () => {
+	const result = validateFile(fakeFile('data.csv', 0));
+	assert.equal(result.valid, false);
+	assert.equal(result.error, 'EMPTY_FILE');
+});
+
+test('validateFile: 非対応拡張子は INVALID_EXTENSION', () => {
+	const result = validateFile(fakeFile('data.xlsx', 100));
+	assert.equal(result.valid, false);
+	assert.equal(result.error, 'INVALID_EXTENSION');
+});
+
+test('validateFile: 上限を超えるサイズは FILE_TOO_LARGE', () => {
+	const result = validateFile(fakeFile('data.csv', getMaxFileSize() + 1));
+	assert.equal(result.valid, false);
+	assert.equal(result.error, 'FILE_TOO_LARGE');
+});
+
+test('validateFile: 対応拡張子かつサイズ内は valid: true', () => {
+	for (const name of ['data.csv', 'data.tsv', 'data.txt', 'DATA.CSV']) {
+		const result = validateFile(fakeFile(name, 100));
+		assert.equal(result.valid, true, `${name} は valid`);
+	}
+});
+
+test('getMaxFileSize: 正の数を返す', () => {
+	assert.ok(getMaxFileSize() > 0);
+});

--- a/tests/unit/image-mosaic.test.ts
+++ b/tests/unit/image-mosaic.test.ts
@@ -1,0 +1,161 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/image-mosaic.test.ts
+//
+// Canvas 描画（applyMosaic/applyBlur/renderMasked 等、CanvasRenderingContext2D 依存）は
+// ブラウザ専用のため E2E で検証する。ここでは座標計算・判定・ぼかしアルゴリズムなど
+// DOM非依存の純粋ロジックを対象とする。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	BLUR_RADIUS,
+	clampRect,
+	DEFAULT_EMOJI_STAMP,
+	isMaskEffectMode,
+	isMaskEffectRegion,
+	type MaskRegion,
+	MOSAIC_BLOCK,
+	stackBlur,
+	supportsCanvasFilter,
+} from '../../src/lib/tools/image-mosaic.ts';
+
+// ============================================================
+// 定数
+// ============================================================
+
+test('MOSAIC_BLOCK / BLUR_RADIUS: min <= default <= max', () => {
+	assert.ok(MOSAIC_BLOCK.min <= MOSAIC_BLOCK.default);
+	assert.ok(MOSAIC_BLOCK.default <= MOSAIC_BLOCK.max);
+	assert.ok(BLUR_RADIUS.min <= BLUR_RADIUS.default);
+	assert.ok(BLUR_RADIUS.default <= BLUR_RADIUS.max);
+});
+
+test('DEFAULT_EMOJI_STAMP: 空でない文字列', () => {
+	assert.ok(DEFAULT_EMOJI_STAMP.length > 0);
+});
+
+// ============================================================
+// isMaskEffectMode / isMaskEffectRegion
+// ============================================================
+
+test('isMaskEffectMode: mosaic/blur は true、emoji/image は false', () => {
+	assert.equal(isMaskEffectMode('mosaic'), true);
+	assert.equal(isMaskEffectMode('blur'), true);
+	assert.equal(isMaskEffectMode('emoji'), false);
+	assert.equal(isMaskEffectMode('image'), false);
+});
+
+test('isMaskEffectRegion: mode に応じて判定する', () => {
+	const rect = { x: 0, y: 0, width: 10, height: 10 };
+	const mosaicRegion: MaskRegion = {
+		id: '1',
+		rect,
+		mode: 'mosaic',
+		shape: 'rect',
+		strength: 10,
+	};
+	const emojiRegion: MaskRegion = {
+		id: '2',
+		rect,
+		mode: 'emoji',
+		emoji: '🙈',
+	};
+	assert.equal(isMaskEffectRegion(mosaicRegion), true);
+	assert.equal(isMaskEffectRegion(emojiRegion), false);
+});
+
+// ============================================================
+// clampRect
+// ============================================================
+
+test('clampRect: 完全にキャンバス内の矩形はそのまま返る', () => {
+	const result = clampRect({ x: 10, y: 10, width: 20, height: 20 }, 100, 100);
+	assert.deepEqual(result, { x: 10, y: 10, width: 20, height: 20 });
+});
+
+test('clampRect: キャンバス境界からはみ出す矩形はクリップされる', () => {
+	const result = clampRect({ x: 90, y: 90, width: 30, height: 30 }, 100, 100);
+	assert.deepEqual(result, { x: 90, y: 90, width: 10, height: 10 });
+});
+
+test('clampRect: 負の座標は0にクランプされる', () => {
+	const result = clampRect({ x: -10, y: -10, width: 20, height: 20 }, 100, 100);
+	assert.deepEqual(result, { x: 0, y: 0, width: 10, height: 10 });
+});
+
+test('clampRect: キャンバスと交差しない矩形は null を返す', () => {
+	const result = clampRect({ x: 200, y: 200, width: 10, height: 10 }, 100, 100);
+	assert.equal(result, null);
+});
+
+test('clampRect: 小数座標は整数に丸められる', () => {
+	const result = clampRect(
+		{ x: 1.4, y: 1.6, width: 10.2, height: 10.8 },
+		100,
+		100,
+	);
+	assert.equal(result?.x, 1);
+	assert.equal(result?.y, 1);
+});
+
+// ============================================================
+// supportsCanvasFilter（document未定義のNode環境）
+// ============================================================
+
+test('supportsCanvasFilter: document未定義の環境では false を返す', () => {
+	assert.equal(supportsCanvasFilter(), false);
+});
+
+// ============================================================
+// stackBlur
+// ============================================================
+
+function makeImage(
+	width: number,
+	height: number,
+	fill: [number, number, number, number],
+) {
+	const data = new Uint8ClampedArray(width * height * 4);
+	for (let i = 0; i < data.length; i += 4) {
+		data[i] = fill[0];
+		data[i + 1] = fill[1];
+		data[i + 2] = fill[2];
+		data[i + 3] = fill[3];
+	}
+	return { data, width, height };
+}
+
+test('stackBlur: 単色画像はぼかし後も同じ色を保つ', () => {
+	const image = makeImage(10, 10, [100, 150, 200, 255]);
+	// biome-ignore lint/suspicious/noExplicitAny: 純粋なdata/width/heightのみを使うためImageDataの完全な実装は不要
+	stackBlur(image as any, 3);
+	for (let i = 0; i < image.data.length; i += 4) {
+		assert.equal(image.data[i], 100);
+		assert.equal(image.data[i + 1], 150);
+		assert.equal(image.data[i + 2], 200);
+		assert.equal(image.data[i + 3], 255);
+	}
+});
+
+test('stackBlur: 中央の孤立ピクセルが周囲へ拡散する（鋭いピークが弱まる）', () => {
+	const width = 11;
+	const height = 11;
+	const image = makeImage(width, height, [0, 0, 0, 255]);
+	const centerIndex = (5 * width + 5) * 4;
+	image.data[centerIndex] = 255;
+	// biome-ignore lint/suspicious/noExplicitAny: 純粋なdata/width/heightのみを使うためImageDataの完全な実装は不要
+	stackBlur(image as any, 2);
+
+	// ぼかし後、中心ピクセルの値は255未満に減衰する
+	assert.ok(image.data[centerIndex] < 255);
+	// 隣接ピクセルには値がにじみ出る
+	const neighborIndex = (5 * width + 6) * 4;
+	assert.ok(image.data[neighborIndex] > 0);
+});
+
+test('stackBlur: 端のピクセルもクランプされアクセスエラーにならない', () => {
+	const image = makeImage(3, 3, [10, 20, 30, 255]);
+	assert.doesNotThrow(() => {
+		// biome-ignore lint/suspicious/noExplicitAny: 純粋なdata/width/heightのみを使うためImageDataの完全な実装は不要
+		stackBlur(image as any, 5);
+	});
+});

--- a/tests/unit/image-text.test.ts
+++ b/tests/unit/image-text.test.ts
@@ -1,0 +1,88 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/image-text.test.ts
+//
+// Canvas 描画・計測（measureTextLayer/drawTextLayer/renderTextLayers、
+// CanvasRenderingContext2D 依存）はブラウザ専用のため E2E で検証する。
+// ここではレイヤー生成ロジックと定数を対象とする。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	BG_PADDING,
+	createTextLayer,
+	FONT_FAMILIES,
+	FONT_SIZE,
+	LINE_HEIGHT,
+	OPACITY,
+	STROKE_WIDTH,
+} from '../../src/lib/tools/image-text.ts';
+
+// ============================================================
+// 定数
+// ============================================================
+
+test('FONT_SIZE / STROKE_WIDTH / OPACITY: min <= default <= max', () => {
+	assert.ok(FONT_SIZE.min <= FONT_SIZE.default);
+	assert.ok(FONT_SIZE.default <= FONT_SIZE.max);
+	assert.ok(STROKE_WIDTH.min <= STROKE_WIDTH.default);
+	assert.ok(STROKE_WIDTH.default <= STROKE_WIDTH.max);
+	assert.ok(OPACITY.min <= OPACITY.default);
+	assert.ok(OPACITY.default <= OPACITY.max);
+});
+
+test('LINE_HEIGHT / BG_PADDING: 正の数である', () => {
+	assert.ok(LINE_HEIGHT > 0);
+	assert.ok(BG_PADDING >= 0);
+});
+
+test('FONT_FAMILIES: 3種のフォントを持ち value が一意である', () => {
+	assert.equal(FONT_FAMILIES.length, 3);
+	const values = FONT_FAMILIES.map((f) => f.value);
+	assert.deepEqual(new Set(values).size, values.length);
+	for (const f of FONT_FAMILIES) {
+		assert.ok(f.label.length > 0);
+	}
+});
+
+// ============================================================
+// createTextLayer
+// ============================================================
+
+test('createTextLayer: デフォルト値でレイヤーを生成する', () => {
+	const layer = createTextLayer(10, 20);
+	assert.equal(layer.x, 10);
+	assert.equal(layer.y, 20);
+	assert.equal(layer.text, 'テキスト');
+	assert.equal(layer.fontSize, FONT_SIZE.default);
+	assert.equal(layer.fontFamily, 'sans-serif');
+	assert.equal(layer.color, '#ff0000');
+	assert.equal(layer.strokeColor, undefined);
+	assert.equal(layer.strokeWidth, STROKE_WIDTH.default);
+	assert.equal(layer.backgroundColor, undefined);
+	assert.equal(layer.opacity, OPACITY.default);
+	assert.ok(layer.id.length > 0);
+});
+
+test('createTextLayer: overrides で値を上書きできる', () => {
+	const layer = createTextLayer(0, 0, {
+		text: 'カスタム',
+		fontSize: 64,
+		color: '#00ff00',
+		strokeColor: '#000000',
+		strokeWidth: 2,
+		backgroundColor: '#ffffff',
+		opacity: 0.5,
+	});
+	assert.equal(layer.text, 'カスタム');
+	assert.equal(layer.fontSize, 64);
+	assert.equal(layer.color, '#00ff00');
+	assert.equal(layer.strokeColor, '#000000');
+	assert.equal(layer.strokeWidth, 2);
+	assert.equal(layer.backgroundColor, '#ffffff');
+	assert.equal(layer.opacity, 0.5);
+});
+
+test('createTextLayer: 呼び出しごとに一意なidを生成する', () => {
+	const a = createTextLayer(0, 0);
+	const b = createTextLayer(0, 0);
+	assert.notEqual(a.id, b.id);
+});

--- a/tests/unit/phone-formatter.test.ts
+++ b/tests/unit/phone-formatter.test.ts
@@ -1,0 +1,268 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/phone-formatter.test.ts
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { ParsedPhoneNumberFull } from 'awesome-phonenumber';
+import {
+	generateCsvOutput,
+	parseCsvColumn,
+	processBulk,
+} from '../../src/lib/phone-formatter/bulk.ts';
+import {
+	classifyNumber,
+	getNumberTypeLabel,
+} from '../../src/lib/phone-formatter/classify.ts';
+import { parsePhoneNumber } from '../../src/lib/phone-formatter/parse.ts';
+import { preprocessInput } from '../../src/lib/phone-formatter/preprocess.ts';
+import { getRegionName } from '../../src/lib/phone-formatter/regions.ts';
+import type { ParseResult } from '../../src/lib/phone-formatter/types.ts';
+import { validateCsvFile } from '../../src/lib/phone-formatter/validation.ts';
+
+function fakeParsed(
+	overrides: Partial<{ national: string; type: string }>,
+): ParsedPhoneNumberFull {
+	return {
+		number: { national: overrides.national ?? '' },
+		type: overrides.type ?? 'unknown',
+	} as unknown as ParsedPhoneNumberFull;
+}
+
+function fakeFile(name: string, size: number): File {
+	return { name, size } as unknown as File;
+}
+
+// ============================================================
+// preprocessInput
+// ============================================================
+
+test('preprocessInput: 全角数字とハイフンを半角に変換する', () => {
+	assert.equal(preprocessInput('０３−１２３４−５６７８'), '0312345678');
+});
+
+test('preprocessInput: 先頭の + は保持する', () => {
+	assert.equal(preprocessInput('+81 3-1234-5678'), '+81312345678');
+});
+
+test('preprocessInput: 全角括弧を除去する', () => {
+	assert.equal(preprocessInput('（03）1234-5678'), '0312345678');
+});
+
+test('preprocessInput: 空文字はそのまま空文字を返す', () => {
+	assert.equal(preprocessInput(''), '');
+});
+
+// ============================================================
+// classifyNumber / getNumberTypeLabel
+// ============================================================
+
+test('classifyNumber: 050始まりは ip_phone', () => {
+	assert.equal(
+		classifyNumber(fakeParsed({ national: '05012345678' })),
+		'ip_phone',
+	);
+});
+
+test('classifyNumber: 0120/0800始まりは toll_free', () => {
+	assert.equal(
+		classifyNumber(fakeParsed({ national: '0120123456' })),
+		'toll_free',
+	);
+	assert.equal(
+		classifyNumber(fakeParsed({ national: '0800123456' })),
+		'toll_free',
+	);
+});
+
+test('classifyNumber: 070/080/090始まりは mobile', () => {
+	for (const prefix of ['070', '080', '090']) {
+		assert.equal(
+			classifyNumber(fakeParsed({ national: `${prefix}12345678` })),
+			'mobile',
+		);
+	}
+});
+
+test('classifyNumber: 日本ヒューリスティックに該当しない場合はライブラリの type を使う', () => {
+	assert.equal(
+		classifyNumber(fakeParsed({ national: '0312345678', type: 'fixed-line' })),
+		'fixed',
+	);
+	assert.equal(
+		classifyNumber(
+			fakeParsed({ national: '0312345678', type: 'premium-rate' }),
+		),
+		'premium',
+	);
+	assert.equal(
+		classifyNumber(fakeParsed({ national: '0312345678', type: 'pager' })),
+		'pager',
+	);
+	assert.equal(
+		classifyNumber(
+			fakeParsed({ national: '0312345678', type: 'something-else' }),
+		),
+		'unknown',
+	);
+});
+
+test('getNumberTypeLabel: 全種別の日本語ラベルを返す', () => {
+	assert.equal(getNumberTypeLabel('fixed'), '固定電話');
+	assert.equal(getNumberTypeLabel('mobile'), '携帯電話');
+	assert.equal(getNumberTypeLabel('ip_phone'), 'IP電話');
+	assert.equal(getNumberTypeLabel('toll_free'), 'フリーダイヤル');
+	assert.equal(getNumberTypeLabel('premium'), '有料通話');
+	assert.equal(getNumberTypeLabel('pager'), 'ポケベル');
+	assert.equal(getNumberTypeLabel('unknown'), '不明');
+});
+
+// ============================================================
+// getRegionName
+// ============================================================
+
+test('getRegionName: 東京23区(03)を検出する', () => {
+	assert.equal(getRegionName('0312345678'), '東京23区');
+});
+
+test('getRegionName: 携帯電話番号は null を返す', () => {
+	assert.equal(getRegionName('09012345678'), null);
+});
+
+test('getRegionName: フリーダイヤルは null を返す', () => {
+	assert.equal(getRegionName('0120123456'), null);
+});
+
+test('getRegionName: 3桁エリアコード(045=横浜)を最長一致で検出する', () => {
+	assert.equal(getRegionName('0451234567'), '横浜');
+});
+
+test('getRegionName: 未知のエリアコードは null を返す', () => {
+	assert.equal(getRegionName('0211234567'), null);
+});
+
+// ============================================================
+// parsePhoneNumber（awesome-phonenumber 実ライブラリを使用）
+// ============================================================
+
+test('parsePhoneNumber: 空入力は valid: false, error なし', () => {
+	const result = parsePhoneNumber('');
+	assert.equal(result.valid, false);
+	assert.equal(result.formats, null);
+	assert.equal(result.error, undefined);
+});
+
+test('parsePhoneNumber: 有効な固定電話番号をパースできる', () => {
+	const result = parsePhoneNumber('03-1234-5678');
+	assert.equal(result.valid, true);
+	assert.equal(result.numberType, 'fixed');
+	assert.equal(result.regionName, '東京23区');
+	assert.equal(result.formats?.e164, '+81312345678');
+});
+
+test('parsePhoneNumber: 全角入力も正しくパースできる', () => {
+	const result = parsePhoneNumber('０９０−１２３４−５６７８');
+	assert.equal(result.valid, true);
+	assert.equal(result.numberType, 'mobile');
+});
+
+test('parsePhoneNumber: 不正な文字列は valid: false でエラーメッセージを持つ', () => {
+	const result = parsePhoneNumber('abc');
+	assert.equal(result.valid, false);
+	assert.ok(result.error && result.error.length > 0);
+});
+
+test('parsePhoneNumber: 桁数が足りない番号は無効と判定される', () => {
+	const result = parsePhoneNumber('03-12');
+	assert.equal(result.valid, false);
+});
+
+// ============================================================
+// processBulk
+// ============================================================
+
+test('processBulk: 空行は除外され、有効/無効件数を集計する', () => {
+	const result = processBulk(['03-1234-5678', '', '  ', 'invalid']);
+	assert.equal(result.summary.total, 2);
+	assert.equal(result.summary.valid, 1);
+	assert.equal(result.summary.invalid, 1);
+});
+
+test('processBulk: 上限件数を超えると例外を投げる', () => {
+	const many = Array.from({ length: 10001 }, () => '03-1234-5678');
+	assert.throws(() => processBulk(many));
+});
+
+test('processBulk: 上限件数ちょうどはエラーにならない', () => {
+	const exact = Array.from({ length: 10000 }, () => '03-1234-5678');
+	const result = processBulk(exact);
+	assert.equal(result.summary.total, 10000);
+});
+
+// ============================================================
+// parseCsvColumn
+// ============================================================
+
+test('parseCsvColumn: ヘッダーありCSVから指定カラムを抽出する', () => {
+	const csv = 'name,phone\nAlice,03-1234-5678\nBob,090-1111-2222';
+	const result = parseCsvColumn(csv, 1, true);
+	assert.deepEqual(result, ['03-1234-5678', '090-1111-2222']);
+});
+
+test('parseCsvColumn: ヘッダーなしCSVは全行を対象にする', () => {
+	const csv = '03-1234-5678\n090-1111-2222';
+	const result = parseCsvColumn(csv, 0, false);
+	assert.deepEqual(result, ['03-1234-5678', '090-1111-2222']);
+});
+
+test('parseCsvColumn: 空セルは除外される', () => {
+	const csv = 'name,phone\nAlice,\nBob,090-1111-2222';
+	const result = parseCsvColumn(csv, 1, true);
+	assert.deepEqual(result, ['090-1111-2222']);
+});
+
+// ============================================================
+// generateCsvOutput
+// ============================================================
+
+test('generateCsvOutput: UTF-8 BOMを先頭に付与する', () => {
+	const results: ParseResult[] = [
+		{
+			valid: true,
+			input: '03-1234-5678',
+			cleaned: '0312345678',
+			formats: {
+				e164: '+81312345678',
+				international: '+81 3-1234-5678',
+				national: '03-1234-5678',
+				rfc3966: 'tel:+81-3-1234-5678',
+			},
+			numberType: 'fixed',
+			regionName: '東京23区',
+			countryCode: 'JP',
+		},
+	];
+	const csv = generateCsvOutput(results, ['input', 'e164', 'type']);
+	assert.equal(csv[0], '﻿');
+	assert.ok(csv.includes('入力'));
+	assert.ok(csv.includes('E.164'));
+	assert.ok(csv.includes('種別'));
+	assert.ok(csv.includes('固定電話'));
+});
+
+// ============================================================
+// validateCsvFile
+// ============================================================
+
+test('validateCsvFile: 非対応拡張子はエラー', () => {
+	const result = validateCsvFile(fakeFile('data.xlsx', 100));
+	assert.equal(result.valid, false);
+});
+
+test('validateCsvFile: 5MB超はエラー', () => {
+	const result = validateCsvFile(fakeFile('data.csv', 6 * 1024 * 1024));
+	assert.equal(result.valid, false);
+});
+
+test('validateCsvFile: 対応拡張子かつサイズ内は有効', () => {
+	const result = validateCsvFile(fakeFile('data.csv', 100));
+	assert.equal(result.valid, true);
+});

--- a/tests/unit/qr-generator.test.ts
+++ b/tests/unit/qr-generator.test.ts
@@ -1,0 +1,79 @@
+// 実行方法: npm run test:unit（Node 22 の型ストリッピングで .ts を直接実行）
+// 単体実行: node --test tests/unit/qr-generator.test.ts
+//
+// qrcode ライブラリは Node / ブラウザ双方で動作するため、生成ロジックはここで検証する。
+// downloadDataUrl / downloadSvg は document 操作のためブラウザ専用（E2Eで検証）。
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+	defaultOptions,
+	generateQRDataUrl,
+	generateQRSvg,
+	type QROptions,
+} from '../../src/lib/tools/qr-generator.ts';
+
+function opts(overrides: Partial<QROptions> = {}): QROptions {
+	return { ...defaultOptions, ...overrides };
+}
+
+test('defaultOptions: 想定通りの初期値を持つ', () => {
+	assert.equal(defaultOptions.size, 400);
+	assert.equal(defaultOptions.errorCorrection, 'M');
+	assert.equal(defaultOptions.foregroundColor, '#000000');
+	assert.equal(defaultOptions.backgroundColor, '#FFFFFF');
+});
+
+// ============================================================
+// generateQRDataUrl
+// ============================================================
+
+test('generateQRDataUrl: 空文字は空文字を返す', async () => {
+	const result = await generateQRDataUrl('', opts());
+	assert.equal(result, '');
+});
+
+test('generateQRDataUrl: 空白のみの入力は空文字を返す', async () => {
+	const result = await generateQRDataUrl('   ', opts());
+	assert.equal(result, '');
+});
+
+test('generateQRDataUrl: 通常の文字列は PNG data URL を返す', async () => {
+	const result = await generateQRDataUrl('https://tools.codelife.cafe', opts());
+	assert.ok(result.startsWith('data:image/png;base64,'));
+	assert.ok(result.length > 'data:image/png;base64,'.length);
+});
+
+test('generateQRDataUrl: 誤り訂正レベルごとに生成できる', async () => {
+	for (const errorCorrection of ['L', 'M', 'Q', 'H'] as const) {
+		const result = await generateQRDataUrl('test', opts({ errorCorrection }));
+		assert.ok(result.startsWith('data:image/png;base64,'), errorCorrection);
+	}
+});
+
+test('generateQRDataUrl: 日本語テキストも生成できる', async () => {
+	const result = await generateQRDataUrl('こんにちは世界', opts());
+	assert.ok(result.startsWith('data:image/png;base64,'));
+});
+
+// ============================================================
+// generateQRSvg
+// ============================================================
+
+test('generateQRSvg: 空文字は空文字を返す', async () => {
+	const result = await generateQRSvg('', opts());
+	assert.equal(result, '');
+});
+
+test('generateQRSvg: 通常の文字列は <svg> を含む文字列を返す', async () => {
+	const result = await generateQRSvg('https://tools.codelife.cafe', opts());
+	assert.ok(result.includes('<svg'));
+});
+
+test('generateQRSvg: 前景・背景色オプションが出力に反映される', async () => {
+	const result = await generateQRSvg(
+		'color-test',
+		opts({ foregroundColor: '#ff0000', backgroundColor: '#00ff00' }),
+	);
+	assert.ok(result.toLowerCase().includes('#ff0000'));
+	assert.ok(result.toLowerCase().includes('#00ff00'));
+});

--- a/tests/unit/sql-formatter.test.ts
+++ b/tests/unit/sql-formatter.test.ts
@@ -1,6 +1,34 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import { SQL_KEYWORDS } from '../../src/lib/tools/sql-formatter.ts';
+import {
+	formatSql,
+	SQL_KEYWORDS,
+	type SqlFormatOptions,
+	type SqlFormatterSettings,
+	sanitizeSqlFormatterSettings,
+} from '../../src/lib/tools/sql-formatter.ts';
+
+const DEFAULT_SETTINGS: SqlFormatterSettings = {
+	autoFormat: true,
+	dialect: 'sql',
+	indent: '2spaces',
+	uppercase: true,
+	compress: false,
+	isExpanded: false,
+	layout: 'horizontal',
+};
+
+function formatOpts(
+	overrides: Partial<SqlFormatOptions> = {},
+): SqlFormatOptions {
+	return {
+		dialect: 'sql',
+		indent: '2spaces',
+		uppercase: true,
+		compress: false,
+		...overrides,
+	};
+}
 
 // ============================================================
 // SQL_KEYWORDS: 出力SQLのシンタックスハイライトで使うキーワード一覧
@@ -27,4 +55,150 @@ test('SQL_KEYWORDS: 主要な句を含む', () => {
 test('SQL_KEYWORDS: すべて重複なく一意である', () => {
 	const unique = new Set(SQL_KEYWORDS);
 	assert.equal(unique.size, SQL_KEYWORDS.length);
+});
+
+// ============================================================
+// formatSql
+// ============================================================
+
+test('formatSql: 空文字/空白のみは空出力を返す', () => {
+	assert.deepEqual(formatSql('', formatOpts()), { output: '' });
+	assert.deepEqual(formatSql('   ', formatOpts()), { output: '' });
+});
+
+test('formatSql: 基本的なSELECT文を整形する', () => {
+	const result = formatSql(
+		'select id, name from users where id = 1',
+		formatOpts(),
+	);
+	assert.equal(result.error, undefined);
+	assert.ok(result.output.includes('SELECT'));
+	assert.ok(result.output.includes('FROM'));
+	assert.ok(result.output.includes('WHERE'));
+	assert.ok(result.output.includes('\n'));
+});
+
+test('formatSql: uppercase: false はキーワードの大文字小文字を保持する', () => {
+	const result = formatSql(
+		'select id from users',
+		formatOpts({ uppercase: false }),
+	);
+	assert.ok(result.output.includes('select'));
+	assert.ok(!result.output.includes('SELECT'));
+});
+
+test('formatSql: indent が tabs のときタブ文字でインデントする', () => {
+	const result = formatSql(
+		'select id, name from users',
+		formatOpts({ indent: 'tabs' }),
+	);
+	assert.ok(result.output.includes('\t'));
+});
+
+test('formatSql: compress: true は改行を除去した1行に圧縮する', () => {
+	const result = formatSql(
+		'select id,\nname\nfrom users',
+		formatOpts({ compress: true, uppercase: false }),
+	);
+	assert.ok(!result.output.includes('\n'));
+	assert.ok(result.output.includes('select'));
+});
+
+test('formatSql: compress + uppercase はキーワードを大文字化した1行を返す', () => {
+	const result = formatSql(
+		'select id from users',
+		formatOpts({ compress: true, uppercase: true }),
+	);
+	assert.ok(!result.output.includes('\n'));
+	assert.ok(result.output.includes('SELECT'));
+	assert.ok(result.output.includes('FROM'));
+});
+
+test('formatSql: compress はコメントを除去する', () => {
+	const result = formatSql(
+		'select id -- comment\nfrom users /* block */',
+		formatOpts({ compress: true, uppercase: false }),
+	);
+	assert.ok(!result.output.includes('comment'));
+	assert.ok(!result.output.includes('block'));
+});
+
+test('formatSql: 構文エラー時は元のSQLとエラーメッセージを返す', () => {
+	const result = formatSql('select * from (', formatOpts());
+	assert.equal(result.output, 'select * from (');
+	assert.ok(result.error?.includes('SQLの構文エラー'));
+});
+
+test('formatSql: dialect違いでも整形できる', () => {
+	for (const dialect of [
+		'sql',
+		'mysql',
+		'postgresql',
+		'tsql',
+		'plsql',
+	] as const) {
+		const result = formatSql('select 1', formatOpts({ dialect }));
+		assert.equal(result.error, undefined, dialect);
+	}
+});
+
+// ============================================================
+// sanitizeSqlFormatterSettings
+// ============================================================
+
+test('sanitizeSqlFormatterSettings: null/非object はデフォルトを返す', () => {
+	assert.deepEqual(
+		sanitizeSqlFormatterSettings(null, DEFAULT_SETTINGS),
+		DEFAULT_SETTINGS,
+	);
+	assert.deepEqual(
+		sanitizeSqlFormatterSettings('not an object', DEFAULT_SETTINGS),
+		DEFAULT_SETTINGS,
+	);
+	assert.deepEqual(
+		sanitizeSqlFormatterSettings([1, 2], DEFAULT_SETTINGS),
+		DEFAULT_SETTINGS,
+	);
+});
+
+test('sanitizeSqlFormatterSettings: 妥当な値はそのまま採用される', () => {
+	const value = {
+		autoFormat: false,
+		dialect: 'mysql',
+		indent: '4spaces',
+		uppercase: false,
+		compress: true,
+		isExpanded: true,
+		layout: 'vertical',
+	};
+	assert.deepEqual(
+		sanitizeSqlFormatterSettings(value, DEFAULT_SETTINGS),
+		value,
+	);
+});
+
+test('sanitizeSqlFormatterSettings: 不正な値はデフォルトへフォールバックする', () => {
+	const result = sanitizeSqlFormatterSettings(
+		{
+			dialect: 'not-a-real-dialect',
+			indent: 'invalid',
+			layout: 'diagonal',
+			autoFormat: 'yes',
+		},
+		DEFAULT_SETTINGS,
+	);
+	assert.equal(result.dialect, DEFAULT_SETTINGS.dialect);
+	assert.equal(result.indent, DEFAULT_SETTINGS.indent);
+	assert.equal(result.layout, DEFAULT_SETTINGS.layout);
+	assert.equal(result.autoFormat, DEFAULT_SETTINGS.autoFormat);
+});
+
+test('sanitizeSqlFormatterSettings: 一部のキーのみ指定した場合は残りにデフォルトを使う', () => {
+	const result = sanitizeSqlFormatterSettings(
+		{ compress: true },
+		DEFAULT_SETTINGS,
+	);
+	assert.equal(result.compress, true);
+	assert.equal(result.dialect, DEFAULT_SETTINGS.dialect);
+	assert.equal(result.uppercase, DEFAULT_SETTINGS.uppercase);
 });


### PR DESCRIPTION
## 概要

Notionタスク「単体テスト欠落9ツールへのテスト追加」への対応。

対象9ツールのうち、`bg-remove` と `pdf-merge` / `pdf-split` は `main` に既にテストが存在していたため（監査時点から状況が変化）、実際にテストを追加したのは以下6ツールです。

- **csv-fixer**: `src/lib/encoding/{detect,convert,lineEndings}.ts`, `src/lib/csv/preview.ts`, `src/lib/validation/fileValidator.ts` — エンコーディング検出・変換・改行コード検出・CSVプレビュー・ファイルバリデーション
- **phone-formatter**: `src/lib/phone-formatter/{parse,classify,preprocess,regions,bulk,validation}.ts` — パース・種別分類・前処理・地域名検索・一括処理・CSVバリデーション
- **qr-generator**: `src/lib/tools/qr-generator.ts` — PNG/SVG生成（正常系・空入力・誤り訂正レベル・色オプション）
- **sql-formatter**: `src/lib/tools/sql-formatter.ts` — 既存の `SQL_KEYWORDS` テストに `formatSql`（整形/圧縮/構文エラー/dialect違い）と `sanitizeSqlFormatterSettings` を追加
- **image-mosaic**: `src/lib/tools/image-mosaic.ts` — `clampRect` / `isMaskEffectMode` / `isMaskEffectRegion` / `stackBlur` 等、Canvas非依存の純粋ロジック
- **image-text**: `src/lib/tools/image-text.ts` — `createTextLayer` と定数

Canvas / CanvasRenderingContext2D に依存する描画・計測部分（`applyMosaic`, `renderMasked`, `measureTextLayer`, `drawTextLayer` 等）はブラウザ専用のため対象外とし、既存のE2Eテストでカバーされている前提です。

### 副次的な変更

`phone-formatter/{parse,bulk}.ts` と `image-text.ts` はローカルimportが拡張子なし（`./classify` 等）だったため、Node `--test` の型ストリッピング実行でモジュール解決に失敗していました。`src/lib/transcribe/*` や `src/lib/cipher/*` など既にテスト対象になっているファイル群と同じ慣習（`.ts` 拡張子を明記）に合わせて修正しています（挙動に変更はありません）。

## 検証結果

- `npm run test:unit`: 1095 pass / 0 fail
- `npm run lint`: 0 errors（既存の14件の警告は本PRとは無関係。`tests/e2e/webmcp.spec.ts` の non-null assertion と `src/components/tools/ZenkakuHankaku.tsx` の useEffect依存配列で、変更対象ファイル外）
- `npm run build`: 成功

## 制約への対応

- 1タスク=1PR
- マージ・デプロイは行っていません


---
_Generated by [Claude Code](https://claude.ai/code/session_01GG7dF2nHs6NAdrBTheniXp)_