### PR TITLE
fix(theme): ダークモードのカード境界に微細ボーダーを追加

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -90,7 +90,7 @@
     --accent: #2DD4BF;
     --accent-foreground: #0C0A09;
     --destructive: #EF4444;
-    --border: #292524;
+    --border: rgba(255, 255, 255, 0.08);
     --input: #292524;
     --ring: #60A5FA;
     --safety: #34D399;


### PR DESCRIPTION
## 概要
ダークモードでカード（`#1C1917`）と背景（`#0C0A09`）の明度差が小さく、区切りが曖昧だった問題を修正。

## 変更内容
- `src/styles/global.css` のダークモード `--border` トークンを `#292524` から `rgba(255, 255, 255, 0.08)` に変更
- ライトモードの `--border` トークン・シャドウ設計は変更していません（`.dark` ブロック内のみ変更）
- `--border` トークンは `border-border` ユーティリティ経由でカード（`bg-card` + `border`）を含む全ボーダー要素に適用される共通デザイントークンのため、個別コンポーネントへの変更は不要

## 検証結果
- `npm run lint`: エラーなし（`tests/e2e/webmcp.spec.ts` の non-null assertion 警告14件は本変更と無関係の既存警告）
- `npm run test:unit`: 1002 tests passed
- `npm run build`: 成功
- ダーク/ライト両モードでトップページをスクリーンショット確認
  - ダークモード: カード境界が背景から視認できるようになった
  - ライトモード: 既存の見た目に変化なし

## 関連
Notionタスク: https://www.notion.so/1bf2e340049641f1a849765359c28d38


---
_Generated by [Claude Code](https://claude.ai/code/session_01R194NwnfDXn7dwqngnzQ73)_